### PR TITLE
Fix: update start:bot script to build prior to start

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "scripts": {
         "start:dev": "concurrently \"pnpm exec ts-node --transpile-only packages/backend/src/server.ts\" \"pnpm --filter @arete/web dev\"",
         "start:backend": "pnpm exec ts-node --transpile-only packages/backend/src/server.ts",
-        "start:bot": "pnpm --filter @arete/discord-bot dev",
+        "start:bot": "pnpm build && pnpm --filter @arete/discord-bot dev",
         "start:prod-test": "pnpm --filter @arete/backend build && cross-env NODE_ENV=production node server.js",
         "dev:prod-test": "concurrently \"pnpm --filter @arete/backend build && cross-env NODE_ENV=production node server.js\" \"pnpm --filter @arete/web dev\"",
         "build": "pnpm -r build",


### PR DESCRIPTION
Start bot script requires that build is performed before run. Prior to fix the script fails to find the required node_modules.