### PR TITLE
Configure Dependabot for pnpm monorepo

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,21 +13,6 @@ updates:
       - dependency-name: "typescript"
         update-types: ["version-update:semver-major"]
 
-  - package-ecosystem: "npm"
-    directory: "/packages/ethics-core"
-    schedule:
-      interval: "weekly"
-
-  - package-ecosystem: "npm"
-    directory: "/packages/discord-bot"
-    schedule:
-      interval: "weekly"
-
-  - package-ecosystem: "npm"
-    directory: "/packages/web"
-    schedule:
-      interval: "weekly"
-
   # ─── Fly.io Deployment Stack ──────────────────────────────────────────────────
   - package-ecosystem: "docker"
     directory: "/"


### PR DESCRIPTION
Limit Dependabot npm updates to the workspace root so pnpm lockfile updates stay consistent. This avoids subdirectory updates that change `package.json` without updating the root `pnpm-lock.yaml`, which breaks `pnpm install --frozen-lockfile`