### PR TITLE
BE-EPC-02 Harden EPC Boundaries and Demote Non-Authoritative Hints (Vibe Kanban)

### DIFF
--- a/packages/backend/src/services/chatGenerationTypes.ts
+++ b/packages/backend/src/services/chatGenerationTypes.ts
@@ -47,9 +47,10 @@ export type ChatGenerationWeatherRequest = {
 };
 
 /**
- * Optional EPC-adjacent hint from planner to execution.
+ * Optional non-authoritative EPC hint from planner to execution assembly.
  *
- * This is intent vocabulary only. It does not execute EPC policy by itself.
+ * This is advisory vocabulary only. Canonical policy ownership stays in EPC
+ * contract resolution; this hint cannot define or override EPC ontology.
  */
 export type ChatGenerationResponseIntentHint = {
     responseMode: ExecutionResponseMode;
@@ -61,7 +62,7 @@ export type ChatGenerationResponseIntentHint = {
  * backend-owned because it feeds Footnote metadata rather than runtime execution directly.
  *
  * `reasoningEffort` and `verbosity` are generation controls, not EPC response
- * intent. Use `responseIntentHint` when callers need explicit EPC vocabulary.
+ * intent. `responseIntentHint` is advisory only and non-authoritative.
  */
 export type ChatGenerationPlan = {
     reasoningEffort: NonNullable<GenerationRequest['reasoningEffort']>;

--- a/packages/backend/src/services/executionPolicyContract.ts
+++ b/packages/backend/src/services/executionPolicyContract.ts
@@ -122,7 +122,8 @@ export type ExecutionPolicyFailOpen = {
 /**
  * Lightweight routing intent seam that policy can declare.
  *
- * This is provider-neutral. Model/provider selection logic stays outside EPC.
+ * This is provider-neutral and non-authoritative assembly input only.
+ * Model/provider selection logic stays outside EPC.
  * This is not a full multi-search or evidence-acquisition strategy layer.
  */
 export type ExecutionPolicyRoutingIntent = {
@@ -133,8 +134,9 @@ export type ExecutionPolicyRoutingIntent = {
 /**
  * TrustGraph integration seam metadata.
  *
- * TrustGraph remains evidence/provenance input. It is not a second policy
- * authority and cannot block execution through this field.
+ * TrustGraph remains evidence/provenance input and non-authoritative seam
+ * metadata. It is not a second policy authority and cannot block execution
+ * through this field.
  */
 export type ExecutionPolicyTrustGraphSeam = {
     evidenceMode: 'off' | 'advisory';
@@ -180,7 +182,7 @@ export type ExecutionPolicyPresetId =
     | (string & {});
 
 /**
- * Shared override shape used by EPC presets, builders, and resolver assembly.
+ * Shared override shape used by EPC presets, builders, and resolver assembly glue.
  */
 export type ExecutionPolicyContractOverrides = Partial<
     Omit<ExecutionPolicyContract, 'policyId' | 'policyVersion' | 'displayName'>
@@ -343,6 +345,7 @@ export const EXECUTION_POLICY_PRESETS: Readonly<
 export const EXECUTION_POLICY_OUTSIDE_SCOPE: ReadonlyArray<string> = [
     'Transport-specific behavior (web/discord response shaping).',
     'TrustGraph evidence retrieval and ingestion implementation.',
+    'Workflow profile registry and runtime hook assembly glue.',
     'Operator incident workflows and alerting channels.',
     'Provider-specific model invocation details.',
     'Multi-search/evidence acquisition implementation strategy.',

--- a/packages/backend/src/services/workflowProfileContract.ts
+++ b/packages/backend/src/services/workflowProfileContract.ts
@@ -30,7 +30,9 @@ export type WorkflowProfileId =
 /**
  * EPC-aligned workflow policy preset checked before each workflow transition.
  *
- * This is the canonical workflow-policy shape for backend workflow execution.
+ * This is the canonical workflow-step gating shape for backend workflow execution.
+ * It is outside EPC response/evidence/verification ontology ownership and is
+ * used as execution assembly glue for workflow transitions only.
  * Engine/runtime modules should import this type instead of re-declaring fields.
  *
  * `enableGeneration` stays optional because current callers still rely on the
@@ -172,6 +174,7 @@ export type NoGenerationHandlingResolution =
  *
  * Call this only when the workflow ended before any successful generation. The
  * result tells chat runtime whether to surface that outcome or run fallback.
+ * This resolver is assembly glue for runtime branching, not a policy ontology owner.
  */
 export const resolveNoGenerationHandlingFromTermination = (input: {
     terminationReason: WorkflowTerminationReason;
@@ -271,7 +274,8 @@ export type WorkflowProfileContract = {
  * Internal runtime-only hooks for profile execution.
  *
  * Keep this separate from `WorkflowProfileContract` so public types remain
- * serializable and transport-safe.
+ * serializable and transport-safe. These hooks are assembly glue and remain
+ * outside EPC policy contract ownership.
  */
 type WorkflowProfileRuntimeHooks = {
     requiredHooks: {

--- a/packages/backend/src/services/workflowProfileRegistry.ts
+++ b/packages/backend/src/services/workflowProfileRegistry.ts
@@ -24,8 +24,9 @@ type BuiltinWorkflowProfileId = 'bounded-review' | 'generate-only';
  * - quality-grounded: generate + assess + revise
  * - fast-direct: generate only
  *
- * Keep workflow policy semantics anchored to EPC language. Profiles select one
- * preset and attach limits/hooks; they should not invent a second policy model.
+ * Registry ownership here is assembly glue only: map profile ids to
+ * EPC-aligned workflow-step toggles plus runtime hooks. Profiles select one
+ * preset and attach limits/hooks; they do not own EPC ontology.
  */
 const EPC_QUALITY_GROUNDED_WORKFLOW_POLICY_PRESET: Readonly<
     RuntimeWorkflowProfile['policy']
@@ -195,6 +196,8 @@ export type WorkflowProfileRegistryResolution = {
  * - Unknown/blank ids fail open to `DEFAULT_RUNTIME_WORKFLOW_PROFILE_ID`.
  * - `requestedProfileId` may differ from `runtimeProfile.profileId` when
  *   fallback is applied.
+ *
+ * This function is registry assembly glue and is not a policy ontology owner.
  */
 export const resolveWorkflowProfileRegistry = (
     profileId: string | null | undefined
@@ -239,10 +242,12 @@ export type ResolvedWorkflowRuntimeConfig = {
  * policy.
  *
  * Invariants:
- * - This is the single workflow-execution gating surface for chat runtime.
+ * - This is the single workflow-execution gating assembly surface for chat runtime.
  * - Callers should not branch on workflow profile ids directly.
  * - `forceWorkflowExecution` is the explicit profile-level override for
  *   workflow execution when review-loop gating would otherwise disable it.
+ *
+ * This resolver composes runtime config from contracts; it does not define EPC ontology.
  */
 export const resolveWorkflowRuntimeConfig = (input: {
     profileId: string | null | undefined;


### PR DESCRIPTION
## What changed
- Clarified `ChatGenerationResponseIntentHint` as an advisory, non-authoritative hint in `packages/backend/src/services/chatGenerationTypes.ts`.
- Tightened EPC boundary language in `packages/backend/src/services/executionPolicyContract.ts` by marking routing/trust-graph seam fields as non-authoritative assembly inputs.
- Added explicit outside-EPC scope text for workflow profile registry/hook assembly glue in `executionPolicyContract.ts`.
- Updated workflow profile contract/registry docs in:
  - `packages/backend/src/services/workflowProfileContract.ts`
  - `packages/backend/src/services/workflowProfileRegistry.ts`
  to state these resolvers are assembly glue for runtime composition, not policy ontology owners.

## Why
This PR implements BE-EPC-02 boundary hardening. The goal is to prevent second-source policy interpretation by removing ambiguous ownership cues and making EPC ownership explicit. The changes keep response/evidence/verification policy semantics anchored to EPC while demoting nearby hint surfaces to advisory-only language.

## Important implementation details
- Scope stayed intentionally narrow: doc/comment and contract-boundary wording updates in four backend service files only.
- No broad refactor, behavior rewiring, or new compatibility layers were introduced.
- Resolver language now consistently communicates composition/assembly responsibilities, not ontology ownership.
- Existing fail-open/runtime semantics remain unchanged; this is a boundary-hardening and clarity pass.

This PR was written using [Vibe Kanban](https://vibekanban.com)