### PR TITLE
Backend: Thread Resolved EPC Through Runtime Boundaries (Vibe Kanban)

### DIFF
--- a/packages/backend/src/services/chatOrchestrator.ts
+++ b/packages/backend/src/services/chatOrchestrator.ts
@@ -33,6 +33,7 @@ import {
 import { createChatPlanner, type ChatPlan } from './chatPlanner.js';
 import { createOpenAiChatPlannerStructuredExecutor } from './chatPlannerStructuredOpenAi.js';
 import type { ChatGenerationPlan } from './chatGenerationTypes.js';
+import type { ExecutionResponseMode } from './executionPolicyContract.js';
 import { normalizeDiscordConversation } from './chatConversationNormalization.js';
 import {
     resolveActiveProfileOverlayPrompt,
@@ -54,6 +55,7 @@ import {
     resolveSearchFallbackPolicy,
     searchFallbackRankingPolicy,
 } from './searchFallbackPolicy.js';
+import { resolveExecutionPolicyContract } from './executionPolicyResolver.js';
 import type { WeatherForecastTool } from './weatherGovForecastTool.js';
 import { applySingleToolPolicy } from './tools/toolPolicy.js';
 import {
@@ -89,6 +91,11 @@ const SEARCH_REROUTE_FALLBACK_POLICY = 'search_reroute_profile_fallback_v1';
 const plannerFallbackTelemetryRollup = createPlannerFallbackTelemetryRollup({
     logger,
 });
+
+const resolveExecutionPolicyPresetId = (
+    responseMode: ExecutionResponseMode | undefined
+): 'fast-direct' | 'quality-grounded' =>
+    responseMode === 'quality_grounded' ? 'quality-grounded' : 'fast-direct';
 
 /**
  * Packs the normalized planner decision into one structured system payload.
@@ -735,6 +742,11 @@ export const createChatOrchestrator = ({
             selectedCapabilityProfile:
                 selectedCapabilityDecision.selectedCapabilityProfile,
         };
+        const resolvedExecutionPolicy = resolveExecutionPolicyContract({
+            presetId: resolveExecutionPolicyPresetId(
+                executionPlan.generation.responseIntentHint?.responseMode
+            ),
+        }).policyContract;
 
         // Non-message actions return early and skip model generation.
         if (executionPlan.action === 'ignore') {
@@ -910,6 +922,10 @@ export const createChatOrchestrator = ({
                     toolRequest: toolRequestContext,
                     ...(surfacePolicy && { surfacePolicy }),
                 },
+                executionPolicy: {
+                    policyId: resolvedExecutionPolicy.policyId,
+                    policyVersion: resolvedExecutionPolicy.policyVersion,
+                },
             }),
             orchestrationStartedAtMs: orchestrationStartedAt,
             plannerTemperament: executionPlan.generation.temperament,
@@ -919,6 +935,7 @@ export const createChatOrchestrator = ({
             capabilities: selectedResponseProfile.capabilities,
             generation: executionPlan.generation,
             toolRequest: toolRequestContext,
+            executionPolicyContract: resolvedExecutionPolicy,
             ...(executionContractScopeTuple !== undefined && {
                 executionContractTrustGraphContext: {
                     queryIntent: normalizedRequest.latestUserInput,
@@ -1008,6 +1025,8 @@ export const createChatOrchestrator = ({
                 plannerExecution.status === 'failed' ||
                 fallbackReasons.length > 0,
             fallbackReasons,
+            executionPolicyId: resolvedExecutionPolicy.policyId,
+            executionPolicyVersion: resolvedExecutionPolicy.policyVersion,
             responseId: response.metadata.responseId,
             responseAction: 'message',
             responseModality: executionPlan.modality,

--- a/packages/backend/src/services/chatService.ts
+++ b/packages/backend/src/services/chatService.ts
@@ -38,6 +38,7 @@ import {
 } from './llmCostRecorder.js';
 import { buildRepoExplainerResponseHint } from './chatGenerationHints.js';
 import type { ChatGenerationPlan } from './chatGenerationTypes.js';
+import type { ExecutionPolicyContract } from './executionPolicyContract.js';
 import { renderConversationPromptLayers } from './prompts/conversationPromptLayers.js';
 import { resolveNoGenerationHandlingFromTermination } from './workflowProfileContract.js';
 import { resolveWorkflowRuntimeConfig } from './workflowProfileRegistry.js';
@@ -264,7 +265,11 @@ const extractOwnershipDenialReason = (
 };
 
 const logTrustGraphRuntimeOutcome = (
-    result: TrustGraphEvidenceIngestionResult
+    result: TrustGraphEvidenceIngestionResult,
+    executionPolicy?: Pick<
+        ExecutionPolicyContract,
+        'policyId' | 'policyVersion'
+    >
 ): void => {
     const adapterInvoked =
         result.adapterStatus === 'success' ||
@@ -300,6 +305,10 @@ const logTrustGraphRuntimeOutcome = (
         timeout,
         adapterError,
         provenanceReasonCodes: result.provenanceReasonCodes,
+        ...(executionPolicy !== undefined && {
+            executionPolicyId: executionPolicy.policyId,
+            executionPolicyVersion: executionPolicy.policyVersion,
+        }),
     };
 
     if (scopeDenied || timeout || adapterError || bypassDenied) {
@@ -363,6 +372,7 @@ export type RunChatMessagesInput = {
     executionContext?: ResponseMetadataRuntimeContext['executionContext'];
     toolRequest?: ToolInvocationRequest;
     executionContractTrustGraphContext?: ExecutionContractTrustGraphContext;
+    executionPolicyContract?: ExecutionPolicyContract;
 };
 
 export type FinalToolExecutionTelemetry = {
@@ -482,6 +492,7 @@ export const createChatService = ({
         executionContext,
         toolRequest,
         executionContractTrustGraphContext,
+        executionPolicyContract,
     }: RunChatMessagesInput): Promise<{
         message: string;
         metadata: ResponseMetadata;
@@ -684,7 +695,19 @@ export const createChatService = ({
             }
         }
         if (trustGraphResult !== undefined) {
-            logTrustGraphRuntimeOutcome(trustGraphResult);
+            logTrustGraphRuntimeOutcome(
+                trustGraphResult,
+                executionPolicyContract
+            );
+        }
+
+        if (executionPolicyContract !== undefined) {
+            logger.info({
+                event: 'chat.runtime.execution_policy',
+                policyId: executionPolicyContract.policyId,
+                policyVersion: executionPolicyContract.policyVersion,
+                responseMode: executionPolicyContract.response.responseMode,
+            });
         }
 
         const assistantMetadata = buildAssistantMetadata(


### PR DESCRIPTION
## Summary
This PR threads a resolved Execution Policy Contract (EPC) through the backend runtime path as carriage-only context, without changing policy decision ownership or workflow/routing behavior.

## What Changed
- `packages/backend/src/services/chatOrchestrator.ts`
- Added a small mapper from planner `responseIntentHint.responseMode` to EPC preset id (`fast-direct` / `quality-grounded`).
- Resolved EPC once per message execution path using `resolveExecutionPolicyContract(...)`.
- Passed the resolved EPC into `chatService.runChatMessages(...)` as `executionPolicyContract`.
- Included `executionPolicy.policyId` and `executionPolicy.policyVersion` in the runtime conversation snapshot payload.
- Added `executionPolicyId` and `executionPolicyVersion` to orchestration timing log context.

- `packages/backend/src/services/chatService.ts`
- Extended `RunChatMessagesInput` with optional `executionPolicyContract` carriage field.
- Extended TrustGraph runtime outcome log context to include EPC id/version when provided.
- Added `chat.runtime.execution_policy` diagnostic log entry with `policyId`, `policyVersion`, and `responseMode`.

## Why
Task BE-EPC-03 required EPC to be assembled once and carried end-to-end across orchestrator/service runtime boundaries while keeping decision ownership unchanged. The goal was to improve coordination and diagnostics visibility (including policy id/version) without introducing semantic branching changes in workflow, routing, or TrustGraph behavior.

## Implementation Details
- EPC resolution is intentionally lightweight and deterministic in orchestrator:
- `quality_grounded` => `quality-grounded`
- all other/undefined modes => `fast-direct` (fail-open default)
- Carried EPC is diagnostic/runtime context only in this PR; it does not alter planner selection, model routing, workflow policy, or tool gating logic.
- `openaiService.ts` was not modified because existing boundaries were sufficient for carriage-only threading and diagnostics.

This PR was written using [Vibe Kanban](https://vibekanban.com)