### PR TITLE
Backend: Make workflow and routing decisions EPC-driven (Vibe Kanban)

### DIFF
--- a/packages/backend/src/services/chatOrchestrator.ts
+++ b/packages/backend/src/services/chatOrchestrator.ts
@@ -499,6 +499,12 @@ export const createChatOrchestrator = ({
                 }
             );
         }
+        const resolvedExecutionPolicy = resolveExecutionPolicyContract({
+            presetId: resolveExecutionPolicyPresetId(
+                generationForExecution.responseIntentHint?.responseMode
+            ),
+        }).policyContract;
+        const routingStrategy = resolvedExecutionPolicy.routing.strategy;
         let selectedResponseProfile = defaultResponseProfile;
         let profileSelectionSource: PlannerSelectionSource = 'default';
         // Profile domains at this seam:
@@ -508,43 +514,48 @@ export const createChatOrchestrator = ({
         // Planner selects capability intent; orchestrator resolves model profile.
         const requestedModelProfileId = normalizedRequest.profileId?.trim();
         const allowRequestProfileOverride =
-            normalizedRequest.trigger.kind === 'submit';
+            normalizedRequest.trigger.kind === 'submit' &&
+            routingStrategy === 'profile-first';
         const selectedCapabilityDecision = selectModelProfileForWorkflowStep({
             step: 'generation',
             requestedCapabilityProfile: plan.requestedCapabilityProfile,
             profiles: enabledProfiles,
             requiresSearch: generationForExecution.search !== undefined,
+            routingIntent: resolvedExecutionPolicy.routing,
         });
         const plannerSelectedModelProfileId =
             selectedCapabilityDecision.selectedProfile?.id.trim();
         const profileSelectionOrder: Array<{
             source: PlannerSelectionSource;
             profileId?: string;
-        }> = allowRequestProfileOverride
-            ? [
-                  {
-                      source: 'request',
-                      profileId: requestedModelProfileId,
-                  },
-                  {
-                      source: 'planner',
-                      profileId: plannerSelectedModelProfileId,
-                  },
-                  {
-                      source: 'default',
-                      profileId: defaultResponseProfile.id,
-                  },
-              ]
-            : [
-                  {
-                      source: 'planner',
-                      profileId: plannerSelectedModelProfileId,
-                  },
-                  {
-                      source: 'default',
-                      profileId: defaultResponseProfile.id,
-                  },
-              ];
+        }> =
+            routingStrategy === 'profile-first'
+                ? [
+                      {
+                          source: 'request',
+                          profileId: allowRequestProfileOverride
+                              ? requestedModelProfileId
+                              : undefined,
+                      },
+                      {
+                          source: 'default',
+                          profileId: defaultResponseProfile.id,
+                      },
+                      {
+                          source: 'planner',
+                          profileId: plannerSelectedModelProfileId,
+                      },
+                  ]
+                : [
+                      {
+                          source: 'planner',
+                          profileId: plannerSelectedModelProfileId,
+                      },
+                      {
+                          source: 'default',
+                          profileId: defaultResponseProfile.id,
+                      },
+                  ];
 
         for (const candidate of profileSelectionOrder) {
             if (!candidate.profileId) {
@@ -638,6 +649,7 @@ export const createChatOrchestrator = ({
             fallbackRollupSelectionSource = searchPolicySelectionSource;
             const searchFallbackDecision = resolveSearchFallbackPolicy({
                 selectionSource: searchPolicySelectionSource,
+                routingStrategy,
                 selectedProfile: selectedResponseProfile,
                 searchCapableProfiles,
             });
@@ -742,11 +754,6 @@ export const createChatOrchestrator = ({
             selectedCapabilityProfile:
                 selectedCapabilityDecision.selectedCapabilityProfile,
         };
-        const resolvedExecutionPolicy = resolveExecutionPolicyContract({
-            presetId: resolveExecutionPolicyPresetId(
-                executionPlan.generation.responseIntentHint?.responseMode
-            ),
-        }).policyContract;
 
         // Non-message actions return early and skip model generation.
         if (executionPlan.action === 'ignore') {
@@ -1027,6 +1034,7 @@ export const createChatOrchestrator = ({
             fallbackReasons,
             executionPolicyId: resolvedExecutionPolicy.policyId,
             executionPolicyVersion: resolvedExecutionPolicy.policyVersion,
+            routingStrategy: resolvedExecutionPolicy.routing.strategy,
             responseId: response.metadata.responseId,
             responseAction: 'message',
             responseModality: executionPlan.modality,

--- a/packages/backend/src/services/chatService.ts
+++ b/packages/backend/src/services/chatService.ts
@@ -539,14 +539,19 @@ export const createChatService = ({
             reviewLoopEnabled: chatWorkflowConfig.reviewLoopEnabled,
             maxIterations: chatWorkflowConfig.maxIterations,
             maxDurationMs: chatWorkflowConfig.maxDurationMs,
+            executionPolicyContract:
+                executionPolicyContract !== undefined
+                    ? {
+                          response: executionPolicyContract.response,
+                          limits: executionPolicyContract.limits,
+                      }
+                    : undefined,
         });
         const workflowProfile = workflowRuntimeConfig.runtimeProfile;
         const workflowExecutionEnabled =
             workflowRuntimeConfig.workflowExecutionEnabled;
-        const workflowMaxIterations =
-            workflowRuntimeConfig.workflowMaxIterations;
-        const workflowMaxDurationMs =
-            workflowRuntimeConfig.workflowMaxDurationMs;
+        const workflowExecutionLimits =
+            workflowRuntimeConfig.workflowExecutionLimits;
 
         let generationResult: GenerationResult;
         let workflowLineage: WorkflowRecord | undefined;
@@ -560,8 +565,9 @@ export const createChatService = ({
                 generationStartedAtMs: generationStartedAt,
                 workflowConfig: {
                     workflowName: workflowProfile.workflowName,
-                    maxIterations: workflowMaxIterations,
-                    maxDurationMs: workflowMaxDurationMs,
+                    maxIterations: chatWorkflowConfig.maxIterations,
+                    maxDurationMs: chatWorkflowConfig.maxDurationMs,
+                    executionLimits: workflowExecutionLimits,
                 },
                 workflowPolicy,
                 captureUsage: (result, requestedModel) =>
@@ -605,8 +611,14 @@ export const createChatService = ({
                     }
 
                     const handling = noGenerationResolution.handling;
+                    const backendFailOpenAllowed =
+                        executionPolicyContract?.failOpen
+                            .allowFallbackGeneration ?? true;
 
-                    if (handling.runtimeAction === 'run_fallback_generation') {
+                    if (
+                        handling.runtimeAction === 'run_fallback_generation' &&
+                        backendFailOpenAllowed
+                    ) {
                         try {
                             generationResult =
                                 await generationRuntime.generate(
@@ -641,6 +653,24 @@ export const createChatService = ({
                         }
                         fallbackAfterInternalNoGeneration = true;
                         break;
+                    }
+                    if (
+                        handling.runtimeAction === 'run_fallback_generation' &&
+                        !backendFailOpenAllowed
+                    ) {
+                        logger.info(
+                            'Execution policy disabled fallback generation after internal no-generation outcome.',
+                            {
+                                workflowName: workflowProfile.workflowName,
+                                failOpenAuthority:
+                                    executionPolicyContract?.failOpen
+                                        .authority ?? 'backend',
+                                reasonCode: noGenerationResolution.reasonCode,
+                                terminationReason:
+                                    workflowResult.workflowLineage
+                                        .terminationReason,
+                            }
+                        );
                     }
 
                     generationResult = {
@@ -707,6 +737,9 @@ export const createChatService = ({
                 policyId: executionPolicyContract.policyId,
                 policyVersion: executionPolicyContract.policyVersion,
                 responseMode: executionPolicyContract.response.responseMode,
+                failOpenAuthority: executionPolicyContract.failOpen.authority,
+                failOpenFallbackGeneration:
+                    executionPolicyContract.failOpen.allowFallbackGeneration,
             });
         }
 

--- a/packages/backend/src/services/chatService.ts
+++ b/packages/backend/src/services/chatService.ts
@@ -565,8 +565,21 @@ export const createChatService = ({
                 generationStartedAtMs: generationStartedAt,
                 workflowConfig: {
                     workflowName: workflowProfile.workflowName,
-                    maxIterations: chatWorkflowConfig.maxIterations,
-                    maxDurationMs: chatWorkflowConfig.maxDurationMs,
+                    maxIterations: Math.max(
+                        0,
+                        Math.min(
+                            Math.ceil(
+                                workflowExecutionLimits.maxDeliberationCalls / 2
+                            ),
+                            Math.ceil(
+                                Math.max(
+                                    0,
+                                    workflowExecutionLimits.maxWorkflowSteps - 1
+                                ) / 2
+                            )
+                        )
+                    ),
+                    maxDurationMs: workflowExecutionLimits.maxDurationMs,
                     executionLimits: workflowExecutionLimits,
                 },
                 workflowPolicy,

--- a/packages/backend/src/services/modelCapabilityPolicy.ts
+++ b/packages/backend/src/services/modelCapabilityPolicy.ts
@@ -10,6 +10,7 @@ import type {
     ModelLatencyClass,
     ModelProfile,
 } from '@footnote/contracts';
+import type { ExecutionPolicyRoutingIntent } from './executionPolicyContract.js';
 
 export type WorkflowModelStep = 'generation';
 
@@ -29,6 +30,7 @@ export type CapabilityProfileOption = {
 
 export type ModelCapabilityReasonCode =
     | 'planner_requested_capability_profile_invalid'
+    | 'planner_requested_capability_profile_ignored_by_routing_policy'
     | 'planner_requested_capability_profile_no_compatible_model'
     | 'planner_requested_capability_profile_no_floor_match';
 
@@ -204,6 +206,10 @@ export const selectModelProfileForWorkflowStep = (input: {
     requestedCapabilityProfile?: unknown;
     profiles: readonly ModelProfile[];
     requiresSearch: boolean;
+    routingIntent?: Pick<
+        ExecutionPolicyRoutingIntent,
+        'strategy' | 'capabilityTags'
+    >;
 }): {
     selectedProfile?: ModelProfile;
     selectedCapabilityProfile: CapabilityProfileId;
@@ -211,13 +217,31 @@ export const selectModelProfileForWorkflowStep = (input: {
 } => {
     const defaultCapabilityProfile =
         STEP_DEFAULT_CAPABILITY_PROFILE[input.step];
+    const routingStrategy = input.routingIntent?.strategy ?? 'capability-first';
+    const routingCapabilityTags = input.routingIntent?.capabilityTags ?? [];
+    const routedCapabilityProfile = routingCapabilityTags.includes(
+        'verification'
+    )
+        ? 'expressive-generation'
+        : routingCapabilityTags.includes('grounding')
+          ? 'balanced-general'
+          : defaultCapabilityProfile;
+    const effectiveDefaultCapabilityProfile = isCapabilityAllowedForStep(
+        input.step,
+        routedCapabilityProfile
+    )
+        ? routedCapabilityProfile
+        : defaultCapabilityProfile;
     const normalizedRequestedCapabilityProfile =
-        normalizeRequestedCapabilityProfile(
-            input.step,
-            input.requestedCapabilityProfile
-        );
+        routingStrategy === 'profile-first'
+            ? undefined
+            : normalizeRequestedCapabilityProfile(
+                  input.step,
+                  input.requestedCapabilityProfile
+              );
     const selectedCapabilityProfile =
-        normalizedRequestedCapabilityProfile ?? defaultCapabilityProfile;
+        normalizedRequestedCapabilityProfile ??
+        effectiveDefaultCapabilityProfile;
     const rankedEnabledProfiles = rankModelProfiles(input.profiles);
     const floorCandidates = filterCapabilityFloor(
         rankedEnabledProfiles,
@@ -236,32 +260,55 @@ export const selectModelProfileForWorkflowStep = (input: {
         matchesCapabilityProfile(input.step, profile, selectedCapabilityProfile)
     );
     if (compatibleCandidates.length > 0) {
+        const ignoredByRoutingPolicy =
+            routingStrategy === 'profile-first' &&
+            input.requestedCapabilityProfile !== undefined;
         return {
             selectedProfile: compatibleCandidates[0],
             selectedCapabilityProfile,
-            ...(normalizedRequestedCapabilityProfile === undefined &&
-                input.requestedCapabilityProfile !== undefined && {
-                    reasonCode:
-                        'planner_requested_capability_profile_invalid' as const,
-                }),
+            ...(ignoredByRoutingPolicy
+                ? {
+                      reasonCode:
+                          'planner_requested_capability_profile_ignored_by_routing_policy' as const,
+                  }
+                : normalizedRequestedCapabilityProfile === undefined &&
+                    input.requestedCapabilityProfile !== undefined
+                  ? {
+                        reasonCode:
+                            'planner_requested_capability_profile_invalid' as const,
+                    }
+                  : {}),
         };
     }
 
     const defaultCompatibleCandidates = floorCandidates.filter((profile) =>
-        matchesCapabilityProfile(input.step, profile, defaultCapabilityProfile)
+        matchesCapabilityProfile(
+            input.step,
+            profile,
+            effectiveDefaultCapabilityProfile
+        )
     );
     if (defaultCompatibleCandidates.length > 0) {
+        const ignoredByRoutingPolicy =
+            routingStrategy === 'profile-first' &&
+            input.requestedCapabilityProfile !== undefined;
         return {
             selectedProfile: defaultCompatibleCandidates[0],
-            selectedCapabilityProfile: defaultCapabilityProfile,
-            reasonCode:
-                'planner_requested_capability_profile_no_compatible_model',
+            selectedCapabilityProfile: effectiveDefaultCapabilityProfile,
+            reasonCode: ignoredByRoutingPolicy
+                ? 'planner_requested_capability_profile_ignored_by_routing_policy'
+                : 'planner_requested_capability_profile_no_compatible_model',
         };
     }
 
+    const ignoredByRoutingPolicy =
+        routingStrategy === 'profile-first' &&
+        input.requestedCapabilityProfile !== undefined;
     return {
         selectedProfile: floorCandidates[0],
-        selectedCapabilityProfile: defaultCapabilityProfile,
-        reasonCode: 'planner_requested_capability_profile_no_compatible_model',
+        selectedCapabilityProfile: effectiveDefaultCapabilityProfile,
+        reasonCode: ignoredByRoutingPolicy
+            ? 'planner_requested_capability_profile_ignored_by_routing_policy'
+            : 'planner_requested_capability_profile_no_compatible_model',
     };
 };

--- a/packages/backend/src/services/searchFallbackPolicy.ts
+++ b/packages/backend/src/services/searchFallbackPolicy.ts
@@ -11,6 +11,7 @@ import type {
     ModelProfile,
 } from '@footnote/contracts';
 import type { ToolInvocationReasonCode } from '@footnote/contracts/ethics-core';
+import type { ExecutionPolicyRoutingIntent } from './executionPolicyContract.js';
 import type { PlannerSelectionSource } from './plannerFallbackTelemetryRollup.js';
 
 type SearchFallbackPolicy = {
@@ -29,21 +30,16 @@ export const searchFallbackRankingPolicy = {
     ] as const,
 };
 
-const searchFallbackPolicyBySelectionSource: Record<
-    PlannerSelectionSource,
+const searchFallbackPolicyByRoutingStrategy: Record<
+    ExecutionPolicyRoutingIntent['strategy'],
     SearchFallbackPolicy
 > = {
-    planner: {
+    'capability-first': {
         allowReroute: true,
         rerouteReasonCode: 'search_rerouted_to_fallback_profile',
         skipReasonCode: 'search_reroute_no_tool_capable_fallback_available',
     },
-    request: {
-        allowReroute: false,
-        rerouteReasonCode: 'search_rerouted_to_fallback_profile',
-        skipReasonCode: 'search_reroute_not_permitted_by_selection_source',
-    },
-    default: {
+    'profile-first': {
         allowReroute: false,
         rerouteReasonCode: 'search_rerouted_to_fallback_profile',
         skipReasonCode: 'search_reroute_not_permitted_by_selection_source',
@@ -122,6 +118,7 @@ const rankSearchFallbackProfiles = (
 
 type ResolveSearchFallbackPolicyInput = {
     selectionSource: PlannerSelectionSource;
+    routingStrategy: ExecutionPolicyRoutingIntent['strategy'];
     selectedProfile: ModelProfile;
     searchCapableProfiles: ModelProfile[];
 };
@@ -137,7 +134,7 @@ export const resolveSearchFallbackPolicy = (
     input: ResolveSearchFallbackPolicyInput
 ): ResolveSearchFallbackPolicyResult => {
     const fallbackPolicy =
-        searchFallbackPolicyBySelectionSource[input.selectionSource];
+        searchFallbackPolicyByRoutingStrategy[input.routingStrategy];
     const rankedFallbackCandidates = rankSearchFallbackProfiles(
         input.selectedProfile,
         input.searchCapableProfiles.filter(

--- a/packages/backend/src/services/workflowEngine.ts
+++ b/packages/backend/src/services/workflowEngine.ts
@@ -119,6 +119,7 @@ export type ReviewWorkflowRuntimeConfig = {
     workflowName: string;
     maxIterations: number;
     maxDurationMs: number;
+    executionLimits?: ExecutionLimits;
 };
 
 export type ReviewWorkflowUsageSummary = {
@@ -404,11 +405,29 @@ export const runBoundedReviewWorkflow = async ({
         parseReviewDecision ?? profileStrategy.parseReviewDecision;
 
     const executionLimits: ExecutionLimits = {
-        maxWorkflowSteps: Math.max(1, normalizedMaxIterations * 2),
-        maxToolCalls: UNBOUNDED_LIMIT,
-        maxDeliberationCalls: Math.max(1, normalizedMaxIterations * 2),
-        maxTokensTotal: UNBOUNDED_LIMIT,
-        maxDurationMs: normalizedMaxDurationMs,
+        maxWorkflowSteps: sanitizePositiveInteger(
+            workflowConfig.executionLimits?.maxWorkflowSteps ??
+                Math.max(1, normalizedMaxIterations * 2),
+            Math.max(1, normalizedMaxIterations * 2)
+        ),
+        maxToolCalls: sanitizeNonNegativeInteger(
+            workflowConfig.executionLimits?.maxToolCalls ?? UNBOUNDED_LIMIT,
+            UNBOUNDED_LIMIT
+        ),
+        maxDeliberationCalls: sanitizeNonNegativeInteger(
+            workflowConfig.executionLimits?.maxDeliberationCalls ??
+                Math.max(1, normalizedMaxIterations * 2),
+            Math.max(1, normalizedMaxIterations * 2)
+        ),
+        maxTokensTotal: sanitizeNonNegativeInteger(
+            workflowConfig.executionLimits?.maxTokensTotal ?? UNBOUNDED_LIMIT,
+            UNBOUNDED_LIMIT
+        ),
+        maxDurationMs: sanitizePositiveInteger(
+            workflowConfig.executionLimits?.maxDurationMs ??
+                normalizedMaxDurationMs,
+            normalizedMaxDurationMs
+        ),
     };
     let workflowState = createInitialWorkflowState({
         workflowId,

--- a/packages/backend/src/services/workflowEngine.ts
+++ b/packages/backend/src/services/workflowEngine.ts
@@ -271,7 +271,8 @@ export const applyStepExecutionToState = (
 export const isWithinExecutionLimits = (
     state: WorkflowState,
     limits: ExecutionLimits,
-    nowMs: number
+    nowMs: number,
+    nextStepKind?: WorkflowStepKind
 ): {
     withinLimits: boolean;
     exhaustedBy?: ExhaustedLimit;
@@ -283,14 +284,22 @@ export const isWithinExecutionLimits = (
         };
     }
 
-    if (state.toolCallCount >= limits.maxToolCalls) {
+    const isNextStepTool = nextStepKind === 'tool';
+    if (isNextStepTool && state.toolCallCount >= limits.maxToolCalls) {
         return {
             withinLimits: false,
             exhaustedBy: 'maxToolCalls',
         };
     }
 
-    if (state.deliberationCallCount >= limits.maxDeliberationCalls) {
+    const isNextStepDeliberative =
+        nextStepKind === 'plan' ||
+        nextStepKind === 'assess' ||
+        nextStepKind === 'revise';
+    if (
+        isNextStepDeliberative &&
+        state.deliberationCallCount >= limits.maxDeliberationCalls
+    ) {
         return {
             withinLimits: false,
             exhaustedBy: 'maxDeliberationCalls',
@@ -429,6 +438,18 @@ export const runBoundedReviewWorkflow = async ({
             normalizedMaxDurationMs
         ),
     };
+    const effectiveMaxIterations =
+        workflowConfig.executionLimits !== undefined
+            ? Math.max(
+                  0,
+                  Math.min(
+                      Math.ceil(executionLimits.maxDeliberationCalls / 2),
+                      Math.ceil(
+                          Math.max(0, executionLimits.maxWorkflowSteps - 1) / 2
+                      )
+                  )
+              )
+            : normalizedMaxIterations;
     let workflowState = createInitialWorkflowState({
         workflowId,
         workflowName: workflowConfig.workflowName,
@@ -494,11 +515,12 @@ export const runBoundedReviewWorkflow = async ({
         return stepId;
     };
 
-    const stopIfOverLimits = (): boolean => {
+    const stopIfOverLimits = (nextStepKind?: WorkflowStepKind): boolean => {
         const limitsCheck = isWithinExecutionLimits(
             workflowState,
             executionLimits,
-            Date.now()
+            Date.now(),
+            nextStepKind
         );
         if (limitsCheck.withinLimits) {
             return false;
@@ -523,7 +545,7 @@ export const runBoundedReviewWorkflow = async ({
         terminationReason = 'transition_blocked_by_policy';
         shouldStop = true;
     } else {
-        if (!stopIfOverLimits()) {
+        if (!stopIfOverLimits('generate')) {
             const initialDraftStartedAt = generationStartedAtMs;
             try {
                 draftResult =
@@ -592,14 +614,14 @@ export const runBoundedReviewWorkflow = async ({
             }
         }
     }
-    if (!shouldStop && normalizedMaxIterations === 0) {
+    if (!shouldStop && effectiveMaxIterations === 0) {
         terminationReason = 'goal_satisfied';
         workflowStatus = 'completed';
     }
 
     for (
         let iteration = 1;
-        iteration <= normalizedMaxIterations && !shouldStop;
+        iteration <= effectiveMaxIterations && !shouldStop;
         iteration += 1
     ) {
         if (
@@ -614,7 +636,7 @@ export const runBoundedReviewWorkflow = async ({
             break;
         }
 
-        if (stopIfOverLimits()) {
+        if (stopIfOverLimits('assess')) {
             break;
         }
 
@@ -684,7 +706,7 @@ export const runBoundedReviewWorkflow = async ({
                 break;
             }
 
-            if (iteration >= normalizedMaxIterations) {
+            if (iteration >= effectiveMaxIterations) {
                 terminationReason = 'budget_exhausted_steps';
                 workflowStatus = 'degraded';
                 shouldStop = true;
@@ -704,7 +726,7 @@ export const runBoundedReviewWorkflow = async ({
                 break;
             }
 
-            if (stopIfOverLimits()) {
+            if (stopIfOverLimits('revise')) {
                 break;
             }
 

--- a/packages/backend/src/services/workflowProfileRegistry.ts
+++ b/packages/backend/src/services/workflowProfileRegistry.ts
@@ -11,6 +11,7 @@ import {
     DEFAULT_REVISION_PROMPT_PREFIX,
     parseReviewDecisionText,
 } from './workflowEngine.js';
+import type { ExecutionPolicyContract } from './executionPolicyContract.js';
 import type {
     RuntimeWorkflowProfile,
     WorkflowProfileContract,
@@ -233,8 +234,7 @@ export type ResolvedWorkflowRuntimeConfig = {
     runtimeProfile: RuntimeWorkflowProfile;
     profileContract: WorkflowProfileContract;
     workflowExecutionEnabled: boolean;
-    workflowMaxIterations: number;
-    workflowMaxDurationMs: number;
+    workflowExecutionLimits: RuntimeWorkflowProfile['defaultLimits'];
 };
 
 /**
@@ -254,30 +254,62 @@ export const resolveWorkflowRuntimeConfig = (input: {
     reviewLoopEnabled: boolean;
     maxIterations: number;
     maxDurationMs: number;
+    executionPolicyContract?: Pick<
+        ExecutionPolicyContract,
+        'response' | 'limits'
+    >;
 }): ResolvedWorkflowRuntimeConfig => {
     const requestedProfileId =
         input.profileId ?? DEFAULT_RUNTIME_WORKFLOW_PROFILE_ID;
     const profileResolution =
         resolveWorkflowProfileRegistry(requestedProfileId);
     const workflowProfile = profileResolution.runtimeProfile;
+    const executionPolicy = input.executionPolicyContract;
+    const executionEnabledByPolicy =
+        executionPolicy !== undefined
+            ? executionPolicy.response.responseMode === 'quality_grounded'
+            : input.reviewLoopEnabled === true;
     const workflowExecutionEnabled =
         workflowProfile.requiredHooks.forceWorkflowExecution ||
-        input.reviewLoopEnabled === true;
-    const profileDefaultMaxIterations = workflowProfile.policy.enableAssessment
-        ? deriveDefaultMaxIterationsFromWorkflowSteps(
-              workflowProfile.defaultLimits.maxWorkflowSteps
-          )
-        : 0;
-    const workflowMaxIterations = workflowProfile.policy.enableAssessment
-        ? sanitizeNonNegativeInteger(
-              input.maxIterations,
-              profileDefaultMaxIterations
-          )
-        : 0;
-    const workflowMaxDurationMs = sanitizePositiveInteger(
-        input.maxDurationMs,
-        workflowProfile.defaultLimits.maxDurationMs
-    );
+        executionEnabledByPolicy;
+    const profileDefaultMaxIterations =
+        deriveDefaultMaxIterationsFromWorkflowSteps(
+            workflowProfile.defaultLimits.maxWorkflowSteps
+        );
+    const fallbackWorkflowStepLimit =
+        workflowProfile.policy.enableAssessment === false
+            ? 1
+            : Math.max(1, profileDefaultMaxIterations * 2);
+    const workflowExecutionLimits: RuntimeWorkflowProfile['defaultLimits'] = {
+        maxWorkflowSteps: sanitizePositiveInteger(
+            executionPolicy?.limits.maxWorkflowSteps ??
+                (workflowProfile.policy.enableAssessment === false
+                    ? 1
+                    : input.maxIterations * 2),
+            fallbackWorkflowStepLimit
+        ),
+        maxToolCalls: sanitizeNonNegativeInteger(
+            executionPolicy?.limits.maxToolCalls ??
+                workflowProfile.defaultLimits.maxToolCalls,
+            workflowProfile.defaultLimits.maxToolCalls
+        ),
+        maxDeliberationCalls: sanitizeNonNegativeInteger(
+            executionPolicy?.limits.maxDeliberationCalls ??
+                (workflowProfile.policy.enableAssessment === false
+                    ? 0
+                    : input.maxIterations * 2),
+            workflowProfile.defaultLimits.maxDeliberationCalls
+        ),
+        maxTokensTotal: sanitizeNonNegativeInteger(
+            executionPolicy?.limits.maxTokensTotal ??
+                workflowProfile.defaultLimits.maxTokensTotal,
+            workflowProfile.defaultLimits.maxTokensTotal
+        ),
+        maxDurationMs: sanitizePositiveInteger(
+            executionPolicy?.limits.maxDurationMs ?? input.maxDurationMs,
+            workflowProfile.defaultLimits.maxDurationMs
+        ),
+    };
 
     return {
         requestedProfileId,
@@ -285,7 +317,6 @@ export const resolveWorkflowRuntimeConfig = (input: {
         runtimeProfile: workflowProfile,
         profileContract: profileResolution.profileContract,
         workflowExecutionEnabled,
-        workflowMaxIterations,
-        workflowMaxDurationMs,
+        workflowExecutionLimits,
     };
 };

--- a/packages/backend/test/workflowProfileRegistry.test.ts
+++ b/packages/backend/test/workflowProfileRegistry.test.ts
@@ -115,8 +115,18 @@ test('resolveWorkflowRuntimeConfig applies forceWorkflowExecution and review-loo
     });
     assert.equal(generateOnlyRuntimeConfig.profileId, 'generate-only');
     assert.equal(generateOnlyRuntimeConfig.workflowExecutionEnabled, true);
-    assert.equal(generateOnlyRuntimeConfig.workflowMaxIterations, 0);
-    assert.equal(generateOnlyRuntimeConfig.workflowMaxDurationMs, 9000);
+    assert.equal(
+        generateOnlyRuntimeConfig.workflowExecutionLimits.maxWorkflowSteps,
+        1
+    );
+    assert.equal(
+        generateOnlyRuntimeConfig.workflowExecutionLimits.maxDeliberationCalls,
+        0
+    );
+    assert.equal(
+        generateOnlyRuntimeConfig.workflowExecutionLimits.maxDurationMs,
+        9000
+    );
 
     const boundedReviewRuntimeConfig = resolveWorkflowRuntimeConfig({
         profileId: 'bounded-review',
@@ -126,6 +136,16 @@ test('resolveWorkflowRuntimeConfig applies forceWorkflowExecution and review-loo
     });
     assert.equal(boundedReviewRuntimeConfig.profileId, 'bounded-review');
     assert.equal(boundedReviewRuntimeConfig.workflowExecutionEnabled, false);
-    assert.equal(boundedReviewRuntimeConfig.workflowMaxIterations, 5);
-    assert.equal(boundedReviewRuntimeConfig.workflowMaxDurationMs, 9000);
+    assert.equal(
+        boundedReviewRuntimeConfig.workflowExecutionLimits.maxWorkflowSteps,
+        10
+    );
+    assert.equal(
+        boundedReviewRuntimeConfig.workflowExecutionLimits.maxDeliberationCalls,
+        10
+    );
+    assert.equal(
+        boundedReviewRuntimeConfig.workflowExecutionLimits.maxDurationMs,
+        9000
+    );
 });


### PR DESCRIPTION
## Summary
This PR moves backend runtime decision ownership to the Execution Policy Contract (EPC) for workflow execution, execution limits, and routing/model-selection behavior.

## What changed
- Updated workflow runtime resolution to read execution intent and limits from EPC when available.
  - `workflowProfileRegistry` now derives workflow execution enablement from EPC response mode (`quality_grounded`) and returns resolved execution limits as a single object.
  - `chatService` now passes EPC response/limits into workflow config resolution and passes resolved limits into the workflow engine.
  - `workflowEngine` now accepts optional explicit execution limits and enforces those limits when provided.
- Updated routing/model selection to be EPC-driven.
  - `chatOrchestrator` now resolves EPC before model-profile selection and uses EPC routing strategy (`capability-first` vs `profile-first`) to determine selection precedence.
  - `modelCapabilityPolicy` now accepts EPC routing intent and can explicitly ignore planner capability requests under `profile-first` strategy, with explicit reason codes.
  - `searchFallbackPolicy` now uses EPC routing strategy to decide whether search reroute is allowed.
- Kept fail-open authority explicit and backend-centralized.
  - `chatService` now gates internal fallback generation on EPC fail-open policy (`authority` remains backend) and logs the policy decision path.

## Why this was changed
Task context required switching runtime decision points to EPC-owned fields so policy intent is centralized and deterministic.
This addresses three goals:
- Workflow execution and limits must be controlled by EPC.
- Routing and model-selection intent must be controlled by EPC.
- Fail-open behavior must remain explicit and backend-owned.

## Important implementation details
- Scope is limited to backend service orchestration paths in:
  - `chatService.ts`
  - `chatOrchestrator.ts`
  - `workflowProfileRegistry.ts`
  - `workflowEngine.ts`
  - `modelCapabilityPolicy.ts`
  - `searchFallbackPolicy.ts`
- Existing fail-open behavior is preserved by defaulting safely when EPC is absent.
- Logging now includes additional EPC context (including routing strategy and fail-open fields) to improve traceability of runtime decisions.
- The changes are cleanly separable into:
  - Workflow ownership (`BE-EPC-04A`)
  - Routing ownership (`BE-EPC-04B`)

This PR was written using [Vibe Kanban](https://vibekanban.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Improvements**
  * Enhanced execution policy enforcement with strategy-driven model selection and routing
  * More precise workflow execution limits configuration with intelligent normalization
  * Improved fallback generation behavior based on policy directives

<!-- end of auto-generated comment: release notes by coderabbit.ai -->