### PR TITLE
Make Core Chat Runtime Provider Defaults Truly Provider-Agnostic (Vibe Kanban)

### DIFF
--- a/packages/agent-runtime/src/voltagentRuntime.ts
+++ b/packages/agent-runtime/src/voltagentRuntime.ts
@@ -1001,9 +1001,14 @@ const createVoltAgentRuntime = ({
                 provider: request.provider,
                 ollama,
             });
+            const hasExplicitRequestModel =
+                typeof request.model === 'string' &&
+                request.model.trim().length > 0;
             const inferredProvider =
                 inferProviderFromModelId(selectedModel) ??
-                inferProviderFromModelId(defaultModel);
+                (!hasExplicitRequestModel
+                    ? inferProviderFromModelId(defaultModel)
+                    : undefined);
             const executedModel = toVoltAgentModel(
                 selectedModel,
                 requestedProvider ?? inferredProvider

--- a/packages/agent-runtime/src/voltagentRuntime.ts
+++ b/packages/agent-runtime/src/voltagentRuntime.ts
@@ -188,6 +188,23 @@ const toVoltAgentModel = (model: string, provider?: string): string => {
         : `openai/${model}`;
 };
 
+const inferProviderFromModelId = (model?: string): string | undefined => {
+    if (!model) {
+        return undefined;
+    }
+
+    const trimmed = model.trim();
+    if (!trimmed.includes('/')) {
+        return undefined;
+    }
+
+    const [providerPart] = trimmed.split('/', 1);
+    const normalizedProvider = providerPart?.trim().toLowerCase();
+    return normalizedProvider && normalizedProvider.length > 0
+        ? normalizedProvider
+        : undefined;
+};
+
 const isLocalOllamaHost = (hostname: string): boolean =>
     hostname === 'localhost' ||
     hostname === '127.0.0.1' ||
@@ -980,12 +997,16 @@ const createVoltAgentRuntime = ({
                 );
             }
 
+            const requestedProvider = resolveVoltAgentProviderOverride({
+                provider: request.provider,
+                ollama,
+            });
+            const inferredProvider =
+                inferProviderFromModelId(selectedModel) ??
+                inferProviderFromModelId(defaultModel);
             const executedModel = toVoltAgentModel(
                 selectedModel,
-                resolveVoltAgentProviderOverride({
-                    provider: request.provider,
-                    ollama,
-                })
+                requestedProvider ?? inferredProvider
             );
             const provider = getVoltAgentProvider(executedModel);
             const executorOllamaConfig = resolveExecutorOllamaConfig(

--- a/packages/agent-runtime/test/voltagentRuntime.test.ts
+++ b/packages/agent-runtime/test/voltagentRuntime.test.ts
@@ -125,7 +125,7 @@ test('voltagent runtime uses default model when request model is blank', async (
     assert.equal(result.model, 'gpt-5-mini');
 });
 
-test('voltagent runtime infers provider from configured default model when request provider is omitted', async () => {
+test('voltagent runtime infers provider from configured default model when request model is blank', async () => {
     let seenModel: string | undefined;
     const runtime = createVoltAgentRuntime({
         defaultModel: 'ollama/gpt-oss:20b-cloud',
@@ -146,10 +146,38 @@ test('voltagent runtime infers provider from configured default model when reque
 
     const result = await runtime.generate({
         messages: [{ role: 'user', content: 'Summarize this.' }],
+        model: '   ',
+    });
+
+    assert.equal(seenModel, 'ollama/gpt-oss:20b-cloud');
+    assert.equal(result.model, 'gpt-oss:20b-cloud');
+});
+
+test('voltagent runtime does not infer provider from default model for explicit unprefixed request models', async () => {
+    let seenModel: string | undefined;
+    const runtime = createVoltAgentRuntime({
+        defaultModel: 'ollama/gpt-oss:20b-cloud',
+        createExecutor: ({ model }) => {
+            seenModel = model;
+            return {
+                async generateText() {
+                    return {
+                        text: 'explicit-model reply',
+                        response: {
+                            modelId: model,
+                        },
+                    };
+                },
+            };
+        },
+    });
+
+    const result = await runtime.generate({
+        messages: [{ role: 'user', content: 'Summarize this.' }],
         model: 'qwen3.5:cloud',
     });
 
-    assert.equal(seenModel, 'ollama/qwen3.5:cloud');
+    assert.equal(seenModel, 'openai/qwen3.5:cloud');
     assert.equal(result.model, 'qwen3.5:cloud');
 });
 

--- a/packages/agent-runtime/test/voltagentRuntime.test.ts
+++ b/packages/agent-runtime/test/voltagentRuntime.test.ts
@@ -125,6 +125,34 @@ test('voltagent runtime uses default model when request model is blank', async (
     assert.equal(result.model, 'gpt-5-mini');
 });
 
+test('voltagent runtime infers provider from configured default model when request provider is omitted', async () => {
+    let seenModel: string | undefined;
+    const runtime = createVoltAgentRuntime({
+        defaultModel: 'ollama/gpt-oss:20b-cloud',
+        createExecutor: ({ model }) => {
+            seenModel = model;
+            return {
+                async generateText() {
+                    return {
+                        text: 'default-provider reply',
+                        response: {
+                            modelId: model,
+                        },
+                    };
+                },
+            };
+        },
+    });
+
+    const result = await runtime.generate({
+        messages: [{ role: 'user', content: 'Summarize this.' }],
+        model: 'qwen3.5:cloud',
+    });
+
+    assert.equal(seenModel, 'ollama/qwen3.5:cloud');
+    assert.equal(result.model, 'qwen3.5:cloud');
+});
+
 test('voltagent runtime normalizes non-search output into GenerationResult', async () => {
     const runtime = createVoltAgentRuntime({
         defaultModel: 'gpt-5-mini',

--- a/packages/backend/src/server.ts
+++ b/packages/backend/src/server.ts
@@ -55,6 +55,7 @@ import { buildRealtimeInstructions } from './services/prompts/realtimePromptComp
 import { createChatProfilesHandler } from './handlers/chatProfiles.js';
 import { createWeatherGovForecastTool } from './services/weatherGovForecastTool.js';
 import { resolveExecutionContractTrustGraphRuntimeOptions } from './services/executionContractTrustGraph/index.js';
+import { createModelProfileResolver } from './services/modelProfileResolver.js';
 
 /**
  * @footnote-logger: openAiRealtimeVoiceRuntime
@@ -208,9 +209,20 @@ const initializeServices = () => {
             'Ollama profiles are present in the model catalog, but Ollama provider is unavailable at boot. Ollama profiles will remain disabled.'
         );
     }
+    const startupModelProfileResolver = createModelProfileResolver({
+        catalog: runtimeConfig.modelProfiles.catalog,
+        defaultProfileId: runtimeConfig.modelProfiles.defaultProfileId,
+        legacyDefaultModel: runtimeConfig.openai.defaultModel,
+        warn: logger,
+    });
+    const startupDefaultProfile = startupModelProfileResolver.defaultProfile;
+    const generationRuntimeDefaultModel = `${startupDefaultProfile.provider}/${startupDefaultProfile.providerModel}`;
+    logger.info(
+        `Core generation runtime default profile: ${startupDefaultProfile.id} (${generationRuntimeDefaultModel}).`
+    );
     if (hasOpenAiProvider || hasOllamaProvider) {
         generationRuntime = createVoltAgentRuntime({
-            defaultModel: runtimeConfig.openai.defaultModel,
+            defaultModel: generationRuntimeDefaultModel,
             logger: voltAgentLogger,
             ollama: {
                 baseUrl: runtimeConfig.ollama.baseUrl ?? undefined,

--- a/packages/backend/src/services/modelProfileResolver.ts
+++ b/packages/backend/src/services/modelProfileResolver.ts
@@ -168,16 +168,16 @@ export const createModelProfileResolver = ({
     );
     // Ordered enabled list powers default fallback behavior.
     const enabledCatalog = catalog.filter((profile) => profile.enabled);
-    const configuredDefaultProvider =
-        catalogById.get(defaultProfileId)?.provider;
+    const configuredDefaultProvider = catalogById.get(defaultProfileId)?.enabled
+        ? catalogById.get(defaultProfileId)?.provider
+        : undefined;
     const legacyDefaultModelParsed = parseRawModel(legacyDefaultModel);
     const normalizedLegacyDefaultModel =
         legacyDefaultModelParsed?.providerModel ?? legacyDefaultModel;
     const legacyDefaultProvider =
         legacyDefaultModelParsed?.provider ??
-        configuredDefaultProvider ??
         enabledCatalog[0]?.provider ??
-        catalog[0]?.provider ??
+        configuredDefaultProvider ??
         'openai';
 
     /**

--- a/packages/backend/src/services/modelProfileResolver.ts
+++ b/packages/backend/src/services/modelProfileResolver.ts
@@ -171,6 +171,8 @@ export const createModelProfileResolver = ({
     const configuredDefaultProvider =
         catalogById.get(defaultProfileId)?.provider;
     const legacyDefaultModelParsed = parseRawModel(legacyDefaultModel);
+    const normalizedLegacyDefaultModel =
+        legacyDefaultModelParsed?.providerModel ?? legacyDefaultModel;
     const legacyDefaultProvider =
         legacyDefaultModelParsed?.provider ??
         configuredDefaultProvider ??
@@ -220,7 +222,7 @@ export const createModelProfileResolver = ({
             },
         });
         return buildLegacyDefaultProfile(
-            legacyDefaultModel,
+            normalizedLegacyDefaultModel,
             legacyDefaultProvider
         );
     };

--- a/packages/backend/src/services/modelProfileResolver.ts
+++ b/packages/backend/src/services/modelProfileResolver.ts
@@ -80,7 +80,7 @@ const normalizeSelector = (value: string | undefined): string | null => {
  * Parses raw model selectors into provider + model pieces.
  *
  * Accepted forms:
- * - `model-name` (defaults provider to OpenAI for compatibility)
+ * - `model-name` (provider stays unset so resolver can apply runtime defaults)
  * - `provider/model-name` (provider must be supported)
  */
 const parseRawModel = (selector: string): ParsedRawModel | null => {
@@ -117,12 +117,13 @@ const parseRawModel = (selector: string): ParsedRawModel | null => {
  * `DEFAULT_MODEL` while catalog migration completes.
  */
 const buildLegacyDefaultProfile = (
-    legacyDefaultModel: string
+    legacyDefaultModel: string,
+    fallbackProvider: SupportedProvider
 ): ModelProfile => ({
     id: 'legacy-default-model',
     description:
         'Compatibility profile synthesized from DEFAULT_MODEL fallback behavior.',
-    provider: 'openai',
+    provider: fallbackProvider,
     providerModel: legacyDefaultModel,
     enabled: true,
     tierBindings: [],
@@ -137,9 +138,10 @@ const buildLegacyDefaultProfile = (
  */
 const buildRawModelProfile = (
     selector: string,
-    parsed: ParsedRawModel
+    parsed: ParsedRawModel,
+    fallbackProvider: SupportedProvider
 ): ModelProfile => {
-    const provider = parsed.provider ?? 'openai';
+    const provider = parsed.provider ?? fallbackProvider;
     return {
         id: `raw-${provider}-${parsed.providerModel.replace(/[^a-zA-Z0-9-]+/g, '-')}`.toLowerCase(),
         description: `Raw model selector passthrough for "${selector}".`,
@@ -166,6 +168,15 @@ export const createModelProfileResolver = ({
     );
     // Ordered enabled list powers default fallback behavior.
     const enabledCatalog = catalog.filter((profile) => profile.enabled);
+    const configuredDefaultProvider =
+        catalogById.get(defaultProfileId)?.provider;
+    const legacyDefaultModelParsed = parseRawModel(legacyDefaultModel);
+    const legacyDefaultProvider =
+        legacyDefaultModelParsed?.provider ??
+        configuredDefaultProvider ??
+        enabledCatalog[0]?.provider ??
+        catalog[0]?.provider ??
+        'openai';
 
     /**
      * Resolves startup default profile with fail-open fallback order:
@@ -208,7 +219,10 @@ export const createModelProfileResolver = ({
                 legacyDefaultModel,
             },
         });
-        return buildLegacyDefaultProfile(legacyDefaultModel);
+        return buildLegacyDefaultProfile(
+            legacyDefaultModel,
+            legacyDefaultProvider
+        );
     };
 
     const defaultProfile = resolveDefaultProfile();
@@ -278,7 +292,8 @@ export const createModelProfileResolver = ({
             return null;
         }
 
-        const resolvedProvider = parsedRawModel.provider ?? 'openai';
+        const resolvedProvider =
+            parsedRawModel.provider ?? defaultProfile.provider;
         const exactMatches = catalog.filter(
             (profile) =>
                 profile.enabled &&
@@ -306,7 +321,7 @@ export const createModelProfileResolver = ({
             });
         }
 
-        return buildRawModelProfile(selector, parsedRawModel);
+        return buildRawModelProfile(selector, parsedRawModel, resolvedProvider);
     };
 
     /**

--- a/packages/backend/test/modelProfileCatalog.test.ts
+++ b/packages/backend/test/modelProfileCatalog.test.ts
@@ -44,6 +44,22 @@ const createCatalog = (): ModelProfile[] => [
     },
 ];
 
+const createOllamaCatalog = (): ModelProfile[] => [
+    {
+        id: 'ollama-text-fast',
+        description: 'Fast local profile.',
+        provider: 'ollama',
+        providerModel: 'llama3.2:3b',
+        enabled: true,
+        tierBindings: ['text-fast'],
+        capabilities: {
+            canUseSearch: false,
+        },
+        costClass: 'low',
+        latencyClass: 'low',
+    },
+];
+
 test('buildModelProfilesSection loads valid catalog YAML with profile defaults', () => {
     const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'model-catalog-'));
     const yamlPath = path.join(tempDir, 'catalog.yaml');
@@ -377,6 +393,48 @@ test('model profile resolver synthesizes raw profile when multiple enabled catal
     assert.match(
         warnings.map((warning) => warning.message).join('\n'),
         /multiple enabled catalog profiles matched raw selector/i
+    );
+});
+
+test('model profile resolver defaults raw model selectors to configured default provider', () => {
+    const warnings: Array<{ message: string; meta?: Record<string, unknown> }> =
+        [];
+    const resolver = createModelProfileResolver({
+        catalog: createOllamaCatalog(),
+        defaultProfileId: 'ollama-text-fast',
+        legacyDefaultModel: 'llama3.2:3b',
+        warn: (warning) => warnings.push(warning),
+    });
+
+    const resolved = resolver.resolve('qwen3.5:cloud');
+    assert.equal(resolved.provider, 'ollama');
+    assert.equal(resolved.providerModel, 'qwen3.5:cloud');
+    assert.equal(resolved.id, 'raw-ollama-qwen3-5-cloud');
+    assert.equal(warnings.length, 0);
+});
+
+test('model profile resolver legacy fallback honors configured default profile provider when catalog is disabled', () => {
+    const warnings: Array<{ message: string; meta?: Record<string, unknown> }> =
+        [];
+    const resolver = createModelProfileResolver({
+        catalog: [
+            {
+                ...createOllamaCatalog()[0],
+                enabled: false,
+            },
+        ],
+        defaultProfileId: 'ollama-text-fast',
+        legacyDefaultModel: 'llama3.2:3b',
+        warn: (warning) => warnings.push(warning),
+    });
+
+    const resolved = resolver.resolve();
+    assert.equal(resolved.id, 'legacy-default-model');
+    assert.equal(resolved.provider, 'ollama');
+    assert.equal(resolved.providerModel, 'llama3.2:3b');
+    assert.match(
+        warnings.map((warning) => warning.message).join('\n'),
+        /legacy DEFAULT_MODEL/i
     );
 });
 

--- a/packages/backend/test/modelProfileCatalog.test.ts
+++ b/packages/backend/test/modelProfileCatalog.test.ts
@@ -413,7 +413,7 @@ test('model profile resolver defaults raw model selectors to configured default 
     assert.equal(warnings.length, 0);
 });
 
-test('model profile resolver legacy fallback honors configured default profile provider when catalog is disabled', () => {
+test('model profile resolver legacy fallback does not force disabled default-profile providers', () => {
     const warnings: Array<{ message: string; meta?: Record<string, unknown> }> =
         [];
     const resolver = createModelProfileResolver({
@@ -430,7 +430,7 @@ test('model profile resolver legacy fallback honors configured default profile p
 
     const resolved = resolver.resolve();
     assert.equal(resolved.id, 'legacy-default-model');
-    assert.equal(resolved.provider, 'ollama');
+    assert.equal(resolved.provider, 'openai');
     assert.equal(resolved.providerModel, 'llama3.2:3b');
     assert.match(
         warnings.map((warning) => warning.message).join('\n'),

--- a/packages/backend/test/modelProfileCatalog.test.ts
+++ b/packages/backend/test/modelProfileCatalog.test.ts
@@ -438,6 +438,20 @@ test('model profile resolver legacy fallback honors configured default profile p
     );
 });
 
+test('model profile resolver normalizes provider-prefixed legacy default models', () => {
+    const resolver = createModelProfileResolver({
+        catalog: [],
+        defaultProfileId: 'missing-default',
+        legacyDefaultModel: 'ollama/qwen3.5:cloud',
+        warn: () => undefined,
+    });
+
+    const resolved = resolver.resolve();
+    assert.equal(resolved.id, 'legacy-default-model');
+    assert.equal(resolved.provider, 'ollama');
+    assert.equal(resolved.providerModel, 'qwen3.5:cloud');
+});
+
 test('bundled active model profiles are fully covered by pricing or explicit policy classifications', () => {
     const section = buildModelProfilesSection(
         {


### PR DESCRIPTION
## Summary
This PR removes remaining OpenAI-default assumptions from the core chat runtime path so backend/web chat routing is provider-flexible by default.

## What Changed
- Updated backend model profile resolution to avoid defaulting raw model selectors to OpenAI when no provider prefix is supplied.
- Updated legacy default-profile synthesis to derive provider and model consistently, including normalization of provider-prefixed `DEFAULT_MODEL` values.
- Updated backend startup wiring to resolve the runtime default model from the active model profile catalog (`provider/providerModel`) instead of the OpenAI default model setting.
- Updated VoltAgent runtime model mapping to infer provider from configured model context when request-level provider is omitted.
- Added regression tests for:
  - Ollama-default raw selector resolution
  - Legacy fallback provider behavior when catalog defaults are disabled
  - Provider-prefixed legacy default normalization
  - VoltAgent provider inference from non-OpenAI default model configuration

## Why
The epic goal is to make provider abstraction real in the core runtime path. Prior behavior still had OpenAI-specific defaults in profile fallback, runtime model prefixing, and startup launch defaults. That made non-OpenAI operation work in many cases but not consistently by default.

These changes align runtime behavior with the provider-agnostic architecture claims and reduce lock-in in core backend/web chat flows.

## Important Implementation Details
- Fail-open behavior is preserved:
  - Resolver fallback order remains deterministic.
  - OpenAI is still used as a final fallback only when no provider can be inferred from catalog/default context.
- Core startup now resolves runtime defaults through `createModelProfileResolver`, making launch behavior match catalog truth.
- Optional OpenAI-only surfaces (image/voice/realtime) are intentionally unchanged in this PR and continue to degrade gracefully when unavailable.

## Validation
- `pnpm exec tsx --test packages/backend/test/modelProfileCatalog.test.ts packages/agent-runtime/test/voltagentRuntime.test.ts`
- `pnpm lint:fix`
- `pnpm lint`

This PR was written using [Vibe Kanban](https://vibekanban.com)
