### PR TITLE
Preserve Legacy Evaluator Metadata Parsing with Authority-Level Contracts (Vibe Kanban)

### DIFF
--- a/packages/contracts/src/ethics-core/types.ts
+++ b/packages/contracts/src/ethics-core/types.ts
@@ -190,7 +190,11 @@ export type SafetyDecision =
  * out incrementally.
  */
 export type EvaluatorOutcome = {
-    authorityLevel: EvaluatorAuthorityLevel;
+    /**
+     * Optional for legacy trace compatibility at ingestion boundaries.
+     * New runtime writes should always include this field.
+     */
+    authorityLevel?: EvaluatorAuthorityLevel;
     /**
      * @deprecated Use authorityLevel instead.
      * Kept as a transitional mirror for legacy consumers.

--- a/packages/contracts/src/web/schemas.ts
+++ b/packages/contracts/src/web/schemas.ts
@@ -195,12 +195,16 @@ const EvaluatorAuthorityLevelSchema = z.enum([
 const EvaluatorDecisionModeSchema = z.enum(['observe_only', 'enforced']);
 const EvaluatorOutcomeSchema = z
     .object({
-        authorityLevel: EvaluatorAuthorityLevelSchema,
+        authorityLevel: EvaluatorAuthorityLevelSchema.optional(),
         mode: EvaluatorDecisionModeSchema,
         provenance: ProvenanceSchema,
         safetyDecision: SafetyDecisionSchema,
     })
     .superRefine((value, context) => {
+        if (value.authorityLevel === undefined) {
+            return;
+        }
+
         if (value.mode === 'enforced' && value.authorityLevel !== 'enforce') {
             context.addIssue({
                 code: z.ZodIssueCode.custom,

--- a/packages/contracts/test/webSchemas.test.ts
+++ b/packages/contracts/test/webSchemas.test.ts
@@ -556,6 +556,38 @@ test('ResponseMetadataSchema rejects invalid execution timeline event kind/statu
     });
     assert.equal(invalidEvaluatorMode.success, false);
 
+    const legacyEvaluatorWithoutAuthority = ResponseMetadataSchema.safeParse({
+        ...baseMetadata,
+        evaluator: {
+            mode: 'observe_only',
+            provenance: 'Inferred',
+            safetyDecision: {
+                action: 'block',
+                safetyTier: 'High',
+                ruleId: 'safety.weaponization_request.v1',
+                reasonCode: 'weaponization_request',
+                reason: 'Deterministic weaponization-request rule matched.',
+            },
+        },
+    });
+    assert.equal(legacyEvaluatorWithoutAuthority.success, true);
+
+    const legacyEnforcedWithoutAuthority = ResponseMetadataSchema.safeParse({
+        ...baseMetadata,
+        evaluator: {
+            mode: 'enforced',
+            provenance: 'Inferred',
+            safetyDecision: {
+                action: 'block',
+                safetyTier: 'High',
+                ruleId: 'safety.weaponization_request.v1',
+                reasonCode: 'weaponization_request',
+                reason: 'Deterministic weaponization-request rule matched.',
+            },
+        },
+    });
+    assert.equal(legacyEnforcedWithoutAuthority.success, true);
+
     const invalidNonAllowBreaker = ResponseMetadataSchema.safeParse({
         ...baseMetadata,
         evaluator: {


### PR DESCRIPTION
## Summary
This PR preserves backward compatibility for evaluator metadata while keeping the new evaluator authority model intact.

## What Changed
- Made `EvaluatorOutcome.authorityLevel` optional at the contracts type boundary to support legacy trace payloads that only include `mode`.
- Updated `EvaluatorOutcomeSchema` in web schemas so `authorityLevel` is optional during parse.
- Adjusted schema validation logic so mode/authority consistency checks run only when `authorityLevel` is present.
- Added regression coverage in `webSchemas.test.ts` for legacy evaluator payloads without `authorityLevel` (both `observe_only` and `enforced`).

## Why
The evaluator authority epic introduced explicit authority levels (`observe`, `influence`, `enforce`) to make evaluator behavior inspectable and explainable. However, existing historical traces still use the legacy shape (`mode` without `authorityLevel`). Requiring `authorityLevel` at schema parse time would reject those traces and break provenance retrieval paths before fallback normalization can run.

This PR ensures legacy metadata remains readable while the runtime continues migrating toward explicit authority-level writes.

## Important Implementation Details
- Compatibility is handled at the schema/type ingestion boundary, not by weakening runtime semantics.
- New runtime writes are still expected to include `authorityLevel`; optionality exists to unblock historical and mixed-version data.
- Validation still enforces mode/authority alignment whenever `authorityLevel` is provided, preserving consistency guarantees for new payloads.

This PR was written using [Vibe Kanban](https://vibekanban.com)