### PR TITLE
Bound Planner Invocation to Workflow-Owned Context (Vibe Kanban)

### DIFF
--- a/docs/architecture/execution-contract-authority-map.md
+++ b/docs/architecture/execution-contract-authority-map.md
@@ -12,6 +12,7 @@ Target statement:
 
 - `Execution Contract`: the governing backend contract for allowed execution shape, limits, verification expectations, and fail-open semantics.
 - `chatOrchestrator`: the runtime coordinator that carries out one request under the contract.
+- `planner`: a bounded workflow step owned by workflow logic; it can propose action details but cannot mutate hard execution authority.
 - `workflow profile`: a named workflow shape selected under the contract.
 - `trace/provenance`: evidence of what happened relative to contract-governed execution.
 
@@ -25,6 +26,7 @@ That module is the Execution Contract authority surface.
 | --------------------------------- | ------------------------------------------------------------------------- | ------------------------------------------------------ | --------------------------------------------------------------------------------- |
 | Execution rules and legal shape   | Execution Contract (`packages/backend/src/services/executionContract.ts`) | `chatOrchestrator` + workflow runtime                  | Runtime must satisfy contract fields; runtime does not redefine ontology.         |
 | Request execution coordination    | Execution Contract (policy bounds)                                        | `packages/backend/src/services/chatOrchestrator.ts`    | Orchestrator selects/coordinates steps inside contract limits.                    |
+| Planner step invocation           | Workflow-owned step policy under Execution Contract bounds                | `chatPlanner` invoked from workflow context only       | Planner is a bounded `plan` step with named purpose; planner output is advisory.  |
 | Workflow/profile semantics        | Execution Contract response/limit constraints + workflow profile contract | `workflowProfileRegistry` + `workflowEngine`           | Profiles are named execution shapes, not competing policy authorities.            |
 | Model/provider/tool selection     | Execution Contract routing intent and limits                              | orchestrator + resolver/services + runtime adapters    | Selection details are execution assembly under contract constraints.              |
 | Trace and provenance recording    | Execution Contract requirement to track provenance                        | `chatService`, trace store, response metadata emitters | Provenance records what happened; it does not set policy.                         |
@@ -42,6 +44,8 @@ That module is the Execution Contract authority surface.
 
 - The Execution Contract is the single governing contract for execution shape.
 - The orchestrator is the request-time execution coordinator.
+- Planner is a bounded workflow step, not a second orchestrator.
+- Planner outputs are advisory and cannot directly override Execution Contract authority.
 - Workflow profiles remain named shapes selected under the contract.
 - External evidence systems (including TrustGraph) never become routing or terminal authorities.
 - Provenance explains decisions after execution; it does not become a second decision engine.

--- a/packages/backend/src/services/chatOrchestrator.ts
+++ b/packages/backend/src/services/chatOrchestrator.ts
@@ -16,7 +16,11 @@ import {
     createChatService,
     type CreateChatServiceOptions,
 } from './chatService.js';
-import { createChatPlanner, type ChatPlan } from './chatPlanner.js';
+import {
+    createChatPlanner,
+    type ChatPlan,
+    type ChatPlannerInvocationContext,
+} from './chatPlanner.js';
 import { createOpenAiChatPlannerStructuredExecutor } from './chatPlannerStructuredOpenAi.js';
 import type { ChatGenerationPlan } from './chatGenerationTypes.js';
 import {
@@ -273,10 +277,19 @@ export const createChatOrchestrator = ({
             normalizedRequest,
             chatOrchestratorLogger
         );
-        // TODO(workflow-planner-step): Move planner dispatch into workflow step
-        // execution so workflow policy owns when/why planning runs and can
-        // support bounded multi-plan passes with purpose-specific outputs.
-        const planned = await chatPlanner.planChat(normalizedRequest);
+        // Planner remains a bounded workflow-owned step. It can recommend
+        // action-selection details but cannot redefine Execution Contract
+        // authority or become a second orchestrator.
+        const plannerInvocationContext: ChatPlannerInvocationContext = {
+            owner: 'workflow',
+            workflowName: 'chat_orchestration',
+            stepKind: 'plan',
+            purpose: 'chat_orchestrator_action_selection',
+        };
+        const planned = await chatPlanner.planChat(
+            normalizedRequest,
+            plannerInvocationContext
+        );
         const plannerExecution = planned.execution;
         const fallbackReasons: PlannerFallbackReason[] = [];
         if (plannerExecution.status === 'failed') {

--- a/packages/backend/src/services/chatPlanner.ts
+++ b/packages/backend/src/services/chatPlanner.ts
@@ -41,6 +41,15 @@ import {
     normalizeRequestedCapabilityProfile,
     type CapabilityProfileId,
 } from './modelCapabilityPolicy.js';
+import {
+    buildPlannerInvocationRejectionLogMeta,
+    isWorkflowOwnedPlannerInvocation,
+} from './chatPlannerInvocation.js';
+import type { ChatPlannerInvocationContext } from './chatPlannerInvocation.js';
+export type {
+    ChatPlannerInvocationContext,
+    ChatPlannerInvocationPurpose,
+} from './chatPlannerInvocation.js';
 import { runtimeConfig } from '../config.js';
 import { logger } from '../utils/logger.js';
 
@@ -128,20 +137,6 @@ type CreateChatPlannerOptions = {
     structuredExecutionTimeoutMs?: number;
     availableCapabilityProfiles?: ChatPlannerCapabilityProfileOption[];
     recordUsage?: (record: BackendLLMCostRecord) => void;
-};
-
-/**
- * Planner is a bounded workflow-owned step.
- * It does not act as a second orchestrator and cannot redefine Execution
- * Contract authority.
- */
-export type ChatPlannerInvocationPurpose = 'chat_orchestrator_action_selection';
-
-export type ChatPlannerInvocationContext = {
-    owner: 'workflow';
-    workflowName: string;
-    stepKind: 'plan';
-    purpose: ChatPlannerInvocationPurpose;
 };
 
 /**
@@ -1191,65 +1186,18 @@ export const createChatPlanner = ({
               )
             : '[]';
 
-    const isWorkflowOwnedInvocation = (
-        value: unknown
-    ): value is ChatPlannerInvocationContext => {
-        if (!value || typeof value !== 'object') {
-            return false;
-        }
-
-        const candidate = value as Partial<ChatPlannerInvocationContext>;
-        return (
-            candidate.owner === 'workflow' &&
-            candidate.stepKind === 'plan' &&
-            candidate.purpose === 'chat_orchestrator_action_selection' &&
-            typeof candidate.workflowName === 'string' &&
-            candidate.workflowName.trim().length > 0
-        );
-    };
-
     const planChat = async (
         request: PostChatRequest,
         invocationContext?: ChatPlannerInvocationContext
     ): Promise<ChatPlannerResult> => {
         const plannerStartedAt = Date.now();
-        if (!isWorkflowOwnedInvocation(invocationContext)) {
+        if (!isWorkflowOwnedPlannerInvocation(invocationContext)) {
             logger.warn(
                 'chat planner invocation rejected because workflow-owned context and purpose were not provided; using safe fallback',
-                {
-                    event: 'chat.planner.invocation_rejected',
-                    fallbackTo: 'safe_default_plan',
-                    reasonCode: 'planner_runtime_error',
-                    surface: request.surface,
-                    triggerKind: request.trigger.kind,
-                    invocationOwner:
-                        invocationContext &&
-                        typeof invocationContext === 'object' &&
-                        'owner' in invocationContext
-                            ? (invocationContext as { owner?: unknown }).owner
-                            : undefined,
-                    invocationWorkflowName:
-                        invocationContext &&
-                        typeof invocationContext === 'object' &&
-                        'workflowName' in invocationContext
-                            ? (invocationContext as { workflowName?: unknown })
-                                  .workflowName
-                            : undefined,
-                    invocationStepKind:
-                        invocationContext &&
-                        typeof invocationContext === 'object' &&
-                        'stepKind' in invocationContext
-                            ? (invocationContext as { stepKind?: unknown })
-                                  .stepKind
-                            : undefined,
-                    invocationPurpose:
-                        invocationContext &&
-                        typeof invocationContext === 'object' &&
-                        'purpose' in invocationContext
-                            ? (invocationContext as { purpose?: unknown })
-                                  .purpose
-                            : undefined,
-                }
+                buildPlannerInvocationRejectionLogMeta({
+                    request,
+                    invocationContext,
+                })
             );
             return {
                 plan: buildFallbackPlan(

--- a/packages/backend/src/services/chatPlanner.ts
+++ b/packages/backend/src/services/chatPlanner.ts
@@ -131,6 +131,20 @@ type CreateChatPlannerOptions = {
 };
 
 /**
+ * Planner is a bounded workflow-owned step.
+ * It does not act as a second orchestrator and cannot redefine Execution
+ * Contract authority.
+ */
+export type ChatPlannerInvocationPurpose = 'chat_orchestrator_action_selection';
+
+export type ChatPlannerInvocationContext = {
+    owner: 'workflow';
+    workflowName: string;
+    stepKind: 'plan';
+    purpose: ChatPlannerInvocationPurpose;
+};
+
+/**
  * Narrow planner-only execution input.
  * This stays backend-local so planner policy can evolve beyond current providers
  * without creating a second shared runtime abstraction.
@@ -1177,10 +1191,79 @@ export const createChatPlanner = ({
               )
             : '[]';
 
+    const isWorkflowOwnedInvocation = (
+        value: unknown
+    ): value is ChatPlannerInvocationContext => {
+        if (!value || typeof value !== 'object') {
+            return false;
+        }
+
+        const candidate = value as Partial<ChatPlannerInvocationContext>;
+        return (
+            candidate.owner === 'workflow' &&
+            candidate.stepKind === 'plan' &&
+            candidate.purpose === 'chat_orchestrator_action_selection' &&
+            typeof candidate.workflowName === 'string' &&
+            candidate.workflowName.trim().length > 0
+        );
+    };
+
     const planChat = async (
-        request: PostChatRequest
+        request: PostChatRequest,
+        invocationContext?: ChatPlannerInvocationContext
     ): Promise<ChatPlannerResult> => {
         const plannerStartedAt = Date.now();
+        if (!isWorkflowOwnedInvocation(invocationContext)) {
+            logger.warn(
+                'chat planner invocation rejected because workflow-owned context and purpose were not provided; using safe fallback',
+                {
+                    event: 'chat.planner.invocation_rejected',
+                    fallbackTo: 'safe_default_plan',
+                    reasonCode: 'planner_runtime_error',
+                    surface: request.surface,
+                    triggerKind: request.trigger.kind,
+                    invocationOwner:
+                        invocationContext &&
+                        typeof invocationContext === 'object' &&
+                        'owner' in invocationContext
+                            ? (invocationContext as { owner?: unknown }).owner
+                            : undefined,
+                    invocationWorkflowName:
+                        invocationContext &&
+                        typeof invocationContext === 'object' &&
+                        'workflowName' in invocationContext
+                            ? (invocationContext as { workflowName?: unknown })
+                                  .workflowName
+                            : undefined,
+                    invocationStepKind:
+                        invocationContext &&
+                        typeof invocationContext === 'object' &&
+                        'stepKind' in invocationContext
+                            ? (invocationContext as { stepKind?: unknown })
+                                  .stepKind
+                            : undefined,
+                    invocationPurpose:
+                        invocationContext &&
+                        typeof invocationContext === 'object' &&
+                        'purpose' in invocationContext
+                            ? (invocationContext as { purpose?: unknown })
+                                  .purpose
+                            : undefined,
+                }
+            );
+            return {
+                plan: buildFallbackPlan(
+                    request,
+                    'Planner invocation was outside workflow-owned boundaries, so the backend used a safe fallback.'
+                ),
+                execution: {
+                    status: 'skipped',
+                    reasonCode: 'planner_runtime_error',
+                    durationMs: Date.now() - plannerStartedAt,
+                },
+            };
+        }
+
         let plannerMode: ChatPlannerExecutionMode = executePlannerStructured
             ? 'structured'
             : 'text_json';

--- a/packages/backend/src/services/chatPlannerInvocation.ts
+++ b/packages/backend/src/services/chatPlannerInvocation.ts
@@ -1,0 +1,72 @@
+/**
+ * @description: Defines planner invocation boundaries and validation helpers for workflow-owned planner execution.
+ * @footnote-scope: core
+ * @footnote-module: ChatPlannerInvocation
+ * @footnote-risk: medium - Incorrect validation can allow planner invocation outside workflow-owned boundaries.
+ * @footnote-ethics: high - Invocation boundaries preserve clear execution authority and prevent hidden control-plane drift.
+ */
+import type { PostChatRequest } from '@footnote/contracts/web';
+
+/**
+ * Planner is a bounded workflow-owned step.
+ * It does not act as a second orchestrator and cannot redefine Execution
+ * Contract authority.
+ */
+export type ChatPlannerInvocationPurpose = 'chat_orchestrator_action_selection';
+
+export type ChatPlannerInvocationContext = {
+    owner: 'workflow';
+    workflowName: string;
+    stepKind: 'plan';
+    purpose: ChatPlannerInvocationPurpose;
+};
+
+export const isWorkflowOwnedPlannerInvocation = (
+    value: unknown
+): value is ChatPlannerInvocationContext => {
+    if (!value || typeof value !== 'object') {
+        return false;
+    }
+
+    const candidate = value as Partial<ChatPlannerInvocationContext>;
+    return (
+        candidate.owner === 'workflow' &&
+        candidate.stepKind === 'plan' &&
+        candidate.purpose === 'chat_orchestrator_action_selection' &&
+        typeof candidate.workflowName === 'string' &&
+        candidate.workflowName.trim().length > 0
+    );
+};
+
+const readInvocationField = (
+    invocationContext: unknown,
+    field: 'owner' | 'workflowName' | 'stepKind' | 'purpose'
+): unknown => {
+    if (!invocationContext || typeof invocationContext !== 'object') {
+        return undefined;
+    }
+
+    const record = invocationContext as Record<string, unknown>;
+    return record[field];
+};
+
+export const buildPlannerInvocationRejectionLogMeta = ({
+    request,
+    invocationContext,
+}: {
+    request: PostChatRequest;
+    invocationContext?: ChatPlannerInvocationContext;
+}): Record<string, unknown> => ({
+    event: 'chat.planner.invocation_rejected',
+    fallbackTo: 'safe_default_plan',
+    reasonCode: 'planner_runtime_error',
+    surface: request.surface,
+    triggerKind: request.trigger.kind,
+    invocationOwner: readInvocationField(invocationContext, 'owner'),
+    invocationWorkflowName: readInvocationField(
+        invocationContext,
+        'workflowName'
+    ),
+    invocationStepKind: readInvocationField(invocationContext, 'stepKind'),
+    invocationPurpose: readInvocationField(invocationContext, 'purpose'),
+});

--- a/packages/backend/test/chatPlanner.test.ts
+++ b/packages/backend/test/chatPlanner.test.ts
@@ -12,6 +12,7 @@ import type { PostChatRequest } from '@footnote/contracts/web';
 import {
     createChatPlanner,
     type ChatPlannerCapabilityProfileOption,
+    type ChatPlannerInvocationContext,
 } from '../src/services/chatPlanner.js';
 import { logger } from '../src/utils/logger.js';
 
@@ -30,23 +31,36 @@ const createChatRequest = (
     ...overrides,
 });
 
+const WORKFLOW_PLANNER_INVOCATION: ChatPlannerInvocationContext = {
+    owner: 'workflow',
+    workflowName: 'chat_orchestration',
+    stepKind: 'plan',
+    purpose: 'chat_orchestrator_action_selection',
+};
+
+const planFromWorkflow = (
+    planner: ReturnType<typeof createChatPlanner>,
+    request: PostChatRequest
+) => planner.planChat(request, WORKFLOW_PLANNER_INVOCATION);
+
 const createPlanner = (
     normalizedText: string,
     availableCapabilityProfiles: ChatPlannerCapabilityProfileOption[] = []
-) =>
-    createChatPlanner({
+) => {
+    return createChatPlanner({
         executePlanner: async () => ({
             text: normalizedText,
             model: 'gpt-5-mini',
         }),
         availableCapabilityProfiles,
     });
+};
 
 const createStructuredPlanner = (
     decision: unknown,
     availableCapabilityProfiles: ChatPlannerCapabilityProfileOption[] = []
-) =>
-    createChatPlanner({
+) => {
+    return createChatPlanner({
         executePlannerStructured: async () => ({
             decision,
             model: 'gpt-5-mini',
@@ -59,6 +73,123 @@ const createStructuredPlanner = (
         }),
         availableCapabilityProfiles,
     });
+};
+
+test('chatPlanner rejects invocation without workflow-owned context and fails open', async () => {
+    let plannerCalled = false;
+    const warnings: Array<{ message: string; meta?: unknown }> = [];
+    const originalWarn = logger.warn;
+    logger.warn = ((message: string, meta?: unknown) => {
+        warnings.push({ message, meta });
+        return logger;
+    }) as typeof logger.warn;
+
+    try {
+        const planner = createChatPlanner({
+            executePlanner: async () => {
+                plannerCalled = true;
+                return {
+                    text: JSON.stringify({
+                        action: 'message',
+                        modality: 'text',
+                        requestedCapabilityProfile: 'balanced-general',
+                        safetyTier: 'Low',
+                        reasoning: 'unused',
+                        generation: {
+                            reasoningEffort: 'low',
+                            verbosity: 'low',
+                            temperament: {
+                                tightness: 4,
+                                rationale: 3,
+                                attribution: 4,
+                                caution: 3,
+                                extent: 4,
+                            },
+                        },
+                    }),
+                    model: 'gpt-5-mini',
+                };
+            },
+        });
+
+        const { plan, execution } = await planner.planChat(createChatRequest());
+
+        assert.equal(plannerCalled, false);
+        assert.equal(execution.status, 'skipped');
+        assert.equal(execution.reasonCode, 'planner_runtime_error');
+        assert.equal(plan.action, 'message');
+        const rejectedWarning = warnings.find(
+            (warning) =>
+                (warning.meta as { event?: string } | undefined)?.event ===
+                'chat.planner.invocation_rejected'
+        );
+        assert.ok(rejectedWarning);
+    } finally {
+        logger.warn = originalWarn;
+    }
+});
+
+test('chatPlanner rejects workflow invocation with invalid purpose and fails open', async () => {
+    let plannerCalled = false;
+    const warnings: Array<{ message: string; meta?: unknown }> = [];
+    const originalWarn = logger.warn;
+    logger.warn = ((message: string, meta?: unknown) => {
+        warnings.push({ message, meta });
+        return logger;
+    }) as typeof logger.warn;
+
+    try {
+        const planner = createChatPlanner({
+            executePlanner: async () => {
+                plannerCalled = true;
+                return {
+                    text: JSON.stringify({
+                        action: 'message',
+                        modality: 'text',
+                        requestedCapabilityProfile: 'balanced-general',
+                        safetyTier: 'Low',
+                        reasoning: 'unused',
+                        generation: {
+                            reasoningEffort: 'low',
+                            verbosity: 'low',
+                            temperament: {
+                                tightness: 4,
+                                rationale: 3,
+                                attribution: 4,
+                                caution: 3,
+                                extent: 4,
+                            },
+                        },
+                    }),
+                    model: 'gpt-5-mini',
+                };
+            },
+        });
+        const invalidInvocation = {
+            owner: 'workflow',
+            workflowName: 'chat_orchestration',
+            stepKind: 'plan',
+            purpose: 'invalid-purpose',
+        } as unknown as ChatPlannerInvocationContext;
+
+        const { execution } = await planner.planChat(
+            createChatRequest(),
+            invalidInvocation
+        );
+
+        assert.equal(plannerCalled, false);
+        assert.equal(execution.status, 'skipped');
+        assert.equal(execution.reasonCode, 'planner_runtime_error');
+        const rejectedWarning = warnings.find(
+            (warning) =>
+                (warning.meta as { event?: string } | undefined)?.event ===
+                'chat.planner.invocation_rejected'
+        );
+        assert.ok(rejectedWarning);
+    } finally {
+        logger.warn = originalWarn;
+    }
+});
 
 test('chatPlanner parses plain JSON output from the backend-native planner prompt', async () => {
     const planner = createPlanner(
@@ -86,7 +217,10 @@ test('chatPlanner parses plain JSON output from the backend-native planner promp
             },
         })
     );
-    const { plan, execution } = await planner.planChat(createChatRequest());
+    const { plan, execution } = await planFromWorkflow(
+        planner,
+        createChatRequest()
+    );
 
     assert.equal(plan.action, 'message');
     assert.equal(plan.requestedCapabilityProfile, 'balanced-general');
@@ -122,7 +256,10 @@ ${JSON.stringify({
 })}
 \`\`\``);
 
-    const { plan, execution } = await planner.planChat(createChatRequest());
+    const { plan, execution } = await planFromWorkflow(
+        planner,
+        createChatRequest()
+    );
 
     assert.equal(plan.action, 'message');
     assert.equal(plan.requestedCapabilityProfile, 'balanced-general');
@@ -149,7 +286,10 @@ test('chatPlanner accepts structured planner decisions without text JSON parsing
         },
     });
 
-    const { plan, execution } = await planner.planChat(createChatRequest());
+    const { plan, execution } = await planFromWorkflow(
+        planner,
+        createChatRequest()
+    );
 
     assert.equal(plan.action, 'message');
     assert.equal(plan.requestedCapabilityProfile, 'structured-cheap');
@@ -168,7 +308,7 @@ test('chatPlanner marks structured policy-invalid decisions as failed with inval
         },
     });
 
-    const { execution } = await planner.planChat(createChatRequest());
+    const { execution } = await planFromWorkflow(planner, createChatRequest());
 
     assert.equal(execution.status, 'failed');
     assert.equal(execution.reasonCode, 'planner_invalid_output');
@@ -222,7 +362,10 @@ test('chatPlanner forwards bounded capability options context and rejects blank 
             },
         });
 
-        const { execution } = await planner.planChat(createChatRequest());
+        const { execution } = await planFromWorkflow(
+            planner,
+            createChatRequest()
+        );
 
         assert.equal(execution.status, 'failed');
         assert.equal(execution.reasonCode, 'planner_invalid_output');
@@ -291,7 +434,10 @@ test('chatPlanner marks unknown requested capability profile as invalid planner 
             },
         });
 
-        const { execution } = await planner.planChat(createChatRequest());
+        const { execution } = await planFromWorkflow(
+            planner,
+            createChatRequest()
+        );
 
         assert.equal(execution.status, 'failed');
         assert.equal(execution.reasonCode, 'planner_invalid_output');
@@ -324,7 +470,10 @@ test('chatPlanner fails open to a valid fallback generation config when planner 
 
     try {
         const planner = createPlanner('{not-valid-json');
-        const { plan, execution } = await planner.planChat(createChatRequest());
+        const { plan, execution } = await planFromWorkflow(
+            planner,
+            createChatRequest()
+        );
 
         assert.equal(plan.action, 'message');
         assert.equal(plan.generation.search, undefined);
@@ -382,7 +531,7 @@ test('repo_explainer search plans normalize repo hints and medium context', asyn
             },
         })
     );
-    const { plan } = await planner.planChat(createChatRequest());
+    const { plan } = await planFromWorkflow(planner, createChatRequest());
 
     assert.ok(plan.generation.search);
     assert.equal(plan.generation.search?.intent, 'repo_explainer');
@@ -434,7 +583,7 @@ test('search topicHints are bounded, deduped, and normalized fail-open', async (
             },
         })
     );
-    const { plan } = await planner.planChat(createChatRequest());
+    const { plan } = await planFromWorkflow(planner, createChatRequest());
 
     assert.deepEqual(plan.generation.search?.topicHints, [
         'incident lifecycle',
@@ -472,7 +621,7 @@ test('invalid web_search query downgrades safely to none', async () => {
             },
         })
     );
-    const { plan } = await planner.planChat(createChatRequest());
+    const { plan } = await planFromWorkflow(planner, createChatRequest());
 
     assert.equal(plan.generation.search, undefined);
     assert.match(plan.reasoning, /search was disabled safely/i);
@@ -507,7 +656,7 @@ test('planner weather request is normalized when location contract is valid', as
         })
     );
 
-    const { plan } = await planner.planChat(createChatRequest());
+    const { plan } = await planFromWorkflow(planner, createChatRequest());
 
     assert.deepEqual(plan.generation.weather, {
         location: {
@@ -546,7 +695,7 @@ test('invalid weather request is disabled safely', async () => {
         })
     );
 
-    const { plan } = await planner.planChat(createChatRequest());
+    const { plan } = await planFromWorkflow(planner, createChatRequest());
 
     assert.equal(plan.generation.weather, undefined);
     assert.match(plan.reasoning, /weather tool request was disabled safely/i);
@@ -580,7 +729,7 @@ test('out-of-range lat/lon weather request is disabled safely', async () => {
         })
     );
 
-    const { plan } = await planner.planChat(createChatRequest());
+    const { plan } = await planFromWorkflow(planner, createChatRequest());
 
     assert.equal(plan.generation.weather, undefined);
     assert.match(plan.reasoning, /weather tool request was disabled safely/i);
@@ -615,7 +764,7 @@ test('non-positive gridpoint weather request is disabled safely', async () => {
         })
     );
 
-    const { plan } = await planner.planChat(createChatRequest());
+    const { plan } = await planFromWorkflow(planner, createChatRequest());
 
     assert.equal(plan.generation.weather, undefined);
     assert.match(plan.reasoning, /weather tool request was disabled safely/i);
@@ -652,7 +801,7 @@ test('mixed lat/lon and gridpoint weather location is disabled safely', async ()
         })
     );
 
-    const { plan } = await planner.planChat(createChatRequest());
+    const { plan } = await planFromWorkflow(planner, createChatRequest());
 
     assert.equal(plan.generation.weather, undefined);
     assert.match(plan.reasoning, /weather tool request was disabled safely/i);
@@ -690,7 +839,7 @@ test('invalid weather request does not suppress valid search normalization', asy
         })
     );
 
-    const { plan } = await planner.planChat(createChatRequest());
+    const { plan } = await planFromWorkflow(planner, createChatRequest());
 
     assert.equal(plan.generation.weather, undefined);
     assert.equal(
@@ -721,7 +870,7 @@ test('planner temperament is accepted when all TRACE axes are integer 1..5', asy
             },
         })
     );
-    const { plan } = await planner.planChat(createChatRequest());
+    const { plan } = await planFromWorkflow(planner, createChatRequest());
 
     assert.deepEqual(plan.generation.temperament, {
         tightness: 5,
@@ -758,7 +907,10 @@ test('message plans with missing or invalid TRACE axes fall back safely', async 
             },
         })
     );
-    const { plan, execution } = await planner.planChat(createChatRequest());
+    const { plan, execution } = await planFromWorkflow(
+        planner,
+        createChatRequest()
+    );
 
     assert.equal(plan.action, 'message');
     assert.equal(plan.generation.search, undefined);
@@ -772,7 +924,10 @@ test('message plans with missing or invalid TRACE axes fall back safely', async 
 
 test('non-object planner payload falls back safely without runtime errors', async () => {
     const planner = createPlanner(JSON.stringify('not-an-object'));
-    const { plan, execution } = await planner.planChat(createChatRequest());
+    const { plan, execution } = await planFromWorkflow(
+        planner,
+        createChatRequest()
+    );
 
     assert.equal(plan.action, 'message');
     assert.equal(plan.generation.search, undefined);
@@ -794,7 +949,7 @@ test('react plans with non-emoji payload fall back safely', async () => {
             },
         })
     );
-    const { plan } = await planner.planChat(createChatRequest());
+    const { plan } = await planFromWorkflow(planner, createChatRequest());
 
     assert.equal(plan.action, 'message');
     assert.equal(plan.reaction, undefined);
@@ -867,7 +1022,8 @@ test('expanded_with_summary digest summarizes dropped older context, not recent 
         },
     });
 
-    await planner.planChat(
+    await planFromWorkflow(
+        planner,
         createChatRequest({
             conversation: Array.from({ length: 24 }, (_value, index) => ({
                 role: index % 2 === 0 ? 'user' : 'assistant',
@@ -939,7 +1095,8 @@ test('chatPlanner treats expanded safety and TRACE temperament changes as materi
         },
     });
 
-    const response = await planner.planChat(
+    const response = await planFromWorkflow(
+        planner,
         createChatRequest({
             conversation: Array.from({ length: 10 }, (_value, index) => ({
                 role: index % 2 === 0 ? 'user' : 'assistant',
@@ -1026,7 +1183,8 @@ test('chatPlanner adopts expanded attempt when initial marks context as insuffic
         },
     });
 
-    const response = await planner.planChat(
+    const response = await planFromWorkflow(
+        planner,
         createChatRequest({
             conversation: Array.from({ length: 10 }, (_value, index) => ({
                 role: index % 2 === 0 ? 'user' : 'assistant',
@@ -1085,7 +1243,8 @@ test('chatPlanner keeps initial plan when expanded attempt is invalid', async ()
         },
     });
 
-    const response = await planner.planChat(
+    const response = await planFromWorkflow(
+        planner,
         createChatRequest({
             conversation: Array.from({ length: 8 }, (_value, index) => ({
                 role: index % 2 === 0 ? 'user' : 'assistant',
@@ -1135,7 +1294,8 @@ test('chatPlanner marks budget exhausted when expansion is requested with no ext
         },
     });
 
-    const response = await planner.planChat(
+    const response = await planFromWorkflow(
+        planner,
         createChatRequest({
             conversation: [{ role: 'user', content: 'single message only' }],
         })


### PR DESCRIPTION
## Summary
This PR defines planner as a bounded workflow step owned by workflow logic. It prevents planner from becoming a second orchestrator and keeps Execution Contract as the hard authority boundary.

## What Changed
- Added canonical planner authority language to architecture docs:
  - docs/architecture/execution-contract-authority-map.md
- Updated orchestrator planner call path to pass explicit workflow-owned invocation context and named purpose:
  - packages/backend/src/services/chatOrchestrator.ts
- Added planner invocation gate and fail-open rejection behavior:
  - packages/backend/src/services/chatPlanner.ts
- Extracted invocation contract/validation/log metadata into a focused module to keep planner logic easier to audit:
  - packages/backend/src/services/chatPlannerInvocation.ts
- Expanded planner tests to cover disallowed invocation paths and preserved behavior:
  - packages/backend/test/chatPlanner.test.ts

## Why
This branch addresses a high-risk semantic boundary: if planner invocation is not explicitly bounded, planner behavior can drift into hidden execution-policy control. The changes ensure planner is only invoked from workflow-owned context with a named purpose, while preserving fail-open response behavior.

## Important Implementation Details
- planChat now requires a valid workflow invocation contract at runtime (owner: workflow, stepKind: plan, explicit purpose).
- Invalid/non-workflow invocation is rejected with structured warning telemetry (chat.planner.invocation_rejected) and safe fallback plan output.
- Planner outputs remain advisory and cannot directly mutate hard execution authority.
- chatPlannerInvocation.ts centralizes invocation types + gate logic, and chatPlanner.ts re-exports types for compatibility.
- Tests validate:
  - rejection on missing workflow context,
  - rejection on invalid purpose,
  - preservation of existing planner normalization/fail-open behavior.

## Validation
- pnpm lint:fix
- pnpm lint
- pnpm exec tsx --test packages/backend/test/chatPlanner.test.ts
- pnpm review
- docker compose -f deploy/compose.yml build

This PR was written using [Vibe Kanban](https://vibekanban.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Formalized planner role within workflow execution, clarifying it as an advisory planning stage with defined constraints and invariants.

* **Bug Fixes**
  * Added validation for workflow-owned planning invocations with safe fallback behavior when validation fails.

* **Tests**
  * Added test coverage for planning invocation validation and rejection scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->