### PR TITLE
Harden steerability control observability envelopes across runtime paths (Vibe Kanban)

### DIFF
--- a/docs/architecture/2026-04-steerability-foundation.md
+++ b/docs/architecture/2026-04-steerability-foundation.md
@@ -126,11 +126,11 @@ authority.
 
 ## Control Observability Envelope
 
-Control decisions also emit one required observability envelope event:
+Every control decision also writes one structured event:
 `chat.steerability.control_observability`.
 
-The envelope is backend-owned and versioned (`v1`). It keeps control
-observability legible in both message and non-message runtime paths.
+Think of this as a compact audit note for each run. It is backend-owned,
+versioned (`v1`), and used in both message and non-message paths.
 
 Required `input` fields:
 
@@ -156,9 +156,12 @@ Required `outcome` fields:
 - `plannerStatus`
 - `mattered`
 
-If required fields are missing, the envelope is invalid. Tests must fail for
-that path. Runtime emission remains fail-open: invalid envelope emission logs
-an error signal and does not block response execution.
+Why this is strict:
+
+- If any required field is missing, that envelope is invalid.
+- Tests should fail for that path.
+- Runtime still fails open. If emission is invalid, we log it and continue
+  response execution.
 
 Canonical planner event:
 

--- a/docs/architecture/2026-04-steerability-foundation.md
+++ b/docs/architecture/2026-04-steerability-foundation.md
@@ -124,6 +124,42 @@ If workflows later support multiple planner invocations or retries, add
 explicit correlation. Do not let planner metadata turn into orchestration
 authority.
 
+## Control Observability Envelope
+
+Control decisions also emit one required observability envelope event:
+`chat.steerability.control_observability`.
+
+The envelope is backend-owned and versioned (`v1`). It keeps control
+observability legible in both message and non-message runtime paths.
+
+Required `input` fields:
+
+- `surface`
+- `workflowModeId`
+- `executionContractResponseMode`
+- `selectedProfileId`
+- `personaOverlaySource`
+- `toolRequest.toolName`
+- `toolRequest.requested`
+- `toolRequest.eligible`
+
+Required `decision` fields:
+
+- `plannerApplyOutcome`
+- `plannerMatteredControlIds`
+- `controls`
+
+Required `outcome` fields:
+
+- `responseAction`
+- `responseModality`
+- `plannerStatus`
+- `mattered`
+
+If required fields are missing, the envelope is invalid. Tests must fail for
+that path. Runtime emission remains fail-open: invalid envelope emission logs
+an error signal and does not block response execution.
+
 Canonical planner event:
 
 ```json

--- a/packages/backend/src/services/chatOrchestrator.ts
+++ b/packages/backend/src/services/chatOrchestrator.ts
@@ -64,6 +64,10 @@ import {
     type PlannerGenerationForPrompt,
     type PlannerPayloadChatPlan,
 } from './chatOrchestrator/plannerPayload.js';
+import {
+    buildControlObservabilityEnvelope,
+    emitControlObservabilityEnvelope,
+} from './steerabilityControlObservability.js';
 
 type CreateChatOrchestratorOptions = CreateChatServiceOptions & {
     weatherForecastTool?: WeatherForecastTool;
@@ -463,6 +467,52 @@ export const createChatOrchestrator = ({
                     toolPolicyDecision.logEvent !== undefined
                   ? 'adjusted_by_policy'
                   : 'applied';
+        const emitControlObservability = (input: {
+            responseAction: 'message' | 'ignore' | 'react' | 'image';
+            responseModality: ChatPlan['modality'];
+        }): void => {
+            try {
+                const observabilityEnvelope = buildControlObservabilityEnvelope(
+                    {
+                        surface: normalizedRequest.surface,
+                        workflowModeId:
+                            workflowModeResolution.modeDecision.modeId,
+                        executionContractResponseMode:
+                            resolvedExecutionContract.response.responseMode,
+                        requestedProfileId: normalizedRequest.profileId,
+                        plannerSelectedProfileId: plan.profileId,
+                        selectedProfileId: selectedResponseProfile.id,
+                        personaOverlaySource:
+                            personaProfile.promptOverlay.source,
+                        toolRequest: toolRequestContext,
+                        plannerApplyOutcome,
+                        plannerMatteredControlIds,
+                        plannerStatus: plannerExecution.status,
+                        plannerReasonCode: plannerExecution.reasonCode,
+                        responseAction: input.responseAction,
+                        responseModality: input.responseModality,
+                        steerabilityControls,
+                    }
+                );
+                emitControlObservabilityEnvelope(
+                    chatOrchestratorLogger,
+                    observabilityEnvelope
+                );
+            } catch (error) {
+                chatOrchestratorLogger.warn(
+                    'chat.steerability.control_observability_failed_open',
+                    {
+                        event: 'chat.steerability.control_observability_failed_open',
+                        reason:
+                            error instanceof Error
+                                ? error.message
+                                : String(error),
+                        surface: normalizedRequest.surface,
+                        plannerStatus: plannerExecution.status,
+                    }
+                );
+            }
+        };
         // TODO(planner-correlation-id): If chat orchestration ever runs
         // multiple planner passes/retries per response, add explicit correlation
         // fields while preserving workflow-owned planner boundaries.
@@ -492,6 +542,10 @@ export const createChatOrchestrator = ({
             }
         );
         if (nonMessageResponse) {
+            emitControlObservability({
+                responseAction: nonMessageResponse.action,
+                responseModality: executionPlan.modality,
+            });
             return nonMessageResponse;
         }
         const promptLayers = renderConversationPromptLayers(
@@ -676,6 +730,10 @@ export const createChatOrchestrator = ({
         emitFallbackRollup(fallbackRollupSelectionSource);
         notifyBreakerEvent({
             responseId: response.metadata.responseId,
+            responseAction: 'message',
+            responseModality: executionPlan.modality,
+        });
+        emitControlObservability({
             responseAction: 'message',
             responseModality: executionPlan.modality,
         });

--- a/packages/backend/src/services/steerabilityControlObservability.ts
+++ b/packages/backend/src/services/steerabilityControlObservability.ts
@@ -1,0 +1,189 @@
+/**
+ * @description: Defines one shared observability envelope for steerability
+ * control input, decision, and outcome records across orchestration paths.
+ * @footnote-scope: core
+ * @footnote-module: SteerabilityControlObservability
+ * @footnote-risk: medium - Inconsistent envelope fields can reduce auditability and hide control drift.
+ * @footnote-ethics: high - Missing control lineage can mislead operators about what shaped an answer.
+ */
+import type {
+    ExecutionReasonCode,
+    ExecutionStatus,
+    PlannerExecutionApplyOutcome,
+    SteerabilityControlId,
+    SteerabilityControls,
+    ToolInvocationRequest,
+    WorkflowModeDecision,
+} from '@footnote/contracts/ethics-core';
+import type { PostChatRequest } from '@footnote/contracts/web';
+
+type ControlObservabilityLogger = {
+    info: (entry: Record<string, unknown>) => void;
+};
+
+export type ControlObservabilityEnvelope = {
+    version: 'v1';
+    input: {
+        surface: PostChatRequest['surface'];
+        workflowModeId: WorkflowModeDecision['modeId'];
+        executionContractResponseMode: 'fast_direct' | 'quality_grounded';
+        requestedProfileId: string | null;
+        plannerSelectedProfileId: string | null;
+        selectedProfileId: string;
+        personaOverlaySource: 'none' | 'inline' | 'file';
+        toolRequest: {
+            toolName: ToolInvocationRequest['toolName'];
+            requested: boolean;
+            eligible: boolean;
+            reasonCode: ToolInvocationRequest['reasonCode'] | null;
+        };
+    };
+    decision: {
+        plannerApplyOutcome: PlannerExecutionApplyOutcome;
+        plannerMatteredControlIds: SteerabilityControlId[];
+        controls: SteerabilityControls['controls'];
+    };
+    outcome: {
+        responseAction: 'message' | 'ignore' | 'react' | 'image';
+        responseModality: 'text' | 'voice';
+        plannerStatus: ExecutionStatus;
+        plannerReasonCode: ExecutionReasonCode | null;
+        mattered: boolean;
+    };
+};
+
+const REQUIRED_CONTROL_OBSERVABILITY_FIELDS: readonly string[] = [
+    'version',
+    'input.surface',
+    'input.workflowModeId',
+    'input.executionContractResponseMode',
+    'input.selectedProfileId',
+    'input.personaOverlaySource',
+    'input.toolRequest.toolName',
+    'input.toolRequest.requested',
+    'input.toolRequest.eligible',
+    'decision.plannerApplyOutcome',
+    'decision.plannerMatteredControlIds',
+    'decision.controls',
+    'outcome.responseAction',
+    'outcome.responseModality',
+    'outcome.plannerStatus',
+    'outcome.mattered',
+];
+
+const getValueByPath = (
+    source: Record<string, unknown>,
+    path: string
+): unknown =>
+    path.split('.').reduce<unknown>((current, segment) => {
+        if (!current || typeof current !== 'object') {
+            return undefined;
+        }
+
+        return (current as Record<string, unknown>)[segment];
+    }, source);
+
+const hasRequiredValue = (value: unknown): boolean => {
+    if (value === undefined || value === null) {
+        return false;
+    }
+
+    if (typeof value === 'string') {
+        return value.trim().length > 0;
+    }
+
+    if (Array.isArray(value)) {
+        return true;
+    }
+
+    return true;
+};
+
+export const listMissingControlObservabilityFields = (
+    envelope: ControlObservabilityEnvelope
+): string[] => {
+    const envelopeRecord = envelope as unknown as Record<string, unknown>;
+    const missing: string[] = [];
+    for (const requiredField of REQUIRED_CONTROL_OBSERVABILITY_FIELDS) {
+        const value = getValueByPath(envelopeRecord, requiredField);
+        if (!hasRequiredValue(value)) {
+            missing.push(requiredField);
+        }
+    }
+
+    return missing;
+};
+
+export const buildControlObservabilityEnvelope = (input: {
+    surface: PostChatRequest['surface'];
+    workflowModeId: WorkflowModeDecision['modeId'];
+    executionContractResponseMode: 'fast_direct' | 'quality_grounded';
+    requestedProfileId?: string;
+    plannerSelectedProfileId?: string;
+    selectedProfileId: string;
+    personaOverlaySource: 'none' | 'inline' | 'file';
+    toolRequest: ToolInvocationRequest;
+    plannerApplyOutcome: PlannerExecutionApplyOutcome;
+    plannerMatteredControlIds: SteerabilityControlId[];
+    plannerStatus: ExecutionStatus;
+    plannerReasonCode?: ExecutionReasonCode;
+    responseAction: 'message' | 'ignore' | 'react' | 'image';
+    responseModality: 'text' | 'voice';
+    steerabilityControls: SteerabilityControls;
+}): ControlObservabilityEnvelope => {
+    const trimToNull = (value: string | undefined): string | null => {
+        const trimmed = value?.trim();
+        return trimmed && trimmed.length > 0 ? trimmed : null;
+    };
+    const envelope: ControlObservabilityEnvelope = {
+        version: 'v1',
+        input: {
+            surface: input.surface,
+            workflowModeId: input.workflowModeId,
+            executionContractResponseMode: input.executionContractResponseMode,
+            requestedProfileId: trimToNull(input.requestedProfileId),
+            plannerSelectedProfileId: trimToNull(
+                input.plannerSelectedProfileId
+            ),
+            selectedProfileId: input.selectedProfileId,
+            personaOverlaySource: input.personaOverlaySource,
+            toolRequest: {
+                toolName: input.toolRequest.toolName,
+                requested: input.toolRequest.requested,
+                eligible: input.toolRequest.eligible,
+                reasonCode: input.toolRequest.reasonCode ?? null,
+            },
+        },
+        decision: {
+            plannerApplyOutcome: input.plannerApplyOutcome,
+            plannerMatteredControlIds: input.plannerMatteredControlIds,
+            controls: input.steerabilityControls.controls,
+        },
+        outcome: {
+            responseAction: input.responseAction,
+            responseModality: input.responseModality,
+            plannerStatus: input.plannerStatus,
+            plannerReasonCode: input.plannerReasonCode ?? null,
+            mattered: input.plannerMatteredControlIds.length > 0,
+        },
+    };
+
+    const missingFields = listMissingControlObservabilityFields(envelope);
+    if (missingFields.length > 0) {
+        throw new Error(
+            `Control observability envelope missing required fields: ${missingFields.join(', ')}`
+        );
+    }
+
+    return envelope;
+};
+
+export const emitControlObservabilityEnvelope = (
+    targetLogger: ControlObservabilityLogger,
+    envelope: ControlObservabilityEnvelope
+): void => {
+    targetLogger.info({
+        event: 'chat.steerability.control_observability',
+        controlObservability: envelope,
+    });
+};

--- a/packages/backend/src/services/steerabilityControlObservability.ts
+++ b/packages/backend/src/services/steerabilityControlObservability.ts
@@ -45,7 +45,7 @@ export type ControlObservabilityEnvelope = {
     };
     outcome: {
         responseAction: 'message' | 'ignore' | 'react' | 'image';
-        responseModality: 'text' | 'voice';
+        responseModality: 'text' | 'tts';
         plannerStatus: ExecutionStatus;
         plannerReasonCode: ExecutionReasonCode | null;
         mattered: boolean;
@@ -128,7 +128,7 @@ export const buildControlObservabilityEnvelope = (input: {
     plannerStatus: ExecutionStatus;
     plannerReasonCode?: ExecutionReasonCode;
     responseAction: 'message' | 'ignore' | 'react' | 'image';
-    responseModality: 'text' | 'voice';
+    responseModality: 'text' | 'tts';
     steerabilityControls: SteerabilityControls;
 }): ControlObservabilityEnvelope => {
     const trimToNull = (value: string | undefined): string | null => {

--- a/packages/backend/src/services/steerabilityControlObservability.ts
+++ b/packages/backend/src/services/steerabilityControlObservability.ts
@@ -57,6 +57,8 @@ const REQUIRED_CONTROL_OBSERVABILITY_FIELDS: readonly string[] = [
     'input.surface',
     'input.workflowModeId',
     'input.executionContractResponseMode',
+    'input.requestedProfileId',
+    'input.plannerSelectedProfileId',
     'input.selectedProfileId',
     'input.personaOverlaySource',
     'input.toolRequest.toolName',
@@ -70,6 +72,32 @@ const REQUIRED_CONTROL_OBSERVABILITY_FIELDS: readonly string[] = [
     'outcome.plannerStatus',
     'outcome.mattered',
 ];
+
+const REQUIRED_CONTROL_OBSERVABILITY_INPUT_FIELDS: readonly string[] = [
+    'surface',
+    'workflowModeId',
+    'executionContractResponseMode',
+    'requestedProfileId',
+    'plannerSelectedProfileId',
+    'selectedProfileId',
+    'personaOverlaySource',
+    'toolRequest.toolName',
+    'toolRequest.requested',
+    'toolRequest.eligible',
+    'plannerApplyOutcome',
+    'plannerMatteredControlIds',
+    'plannerStatus',
+    'responseAction',
+    'responseModality',
+    'steerabilityControls.controls',
+];
+
+const NULLABLE_REQUIRED_CONTROL_OBSERVABILITY_FIELDS = new Set<string>([
+    'input.requestedProfileId',
+    'input.plannerSelectedProfileId',
+    'requestedProfileId',
+    'plannerSelectedProfileId',
+]);
 
 const getValueByPath = (
     source: Record<string, unknown>,
@@ -99,6 +127,17 @@ const hasRequiredValue = (value: unknown): boolean => {
     return true;
 };
 
+const hasRequiredValueAtPath = (path: string, value: unknown): boolean => {
+    if (
+        value === null &&
+        NULLABLE_REQUIRED_CONTROL_OBSERVABILITY_FIELDS.has(path)
+    ) {
+        return true;
+    }
+
+    return hasRequiredValue(value);
+};
+
 export const listMissingControlObservabilityFields = (
     envelope: ControlObservabilityEnvelope
 ): string[] => {
@@ -106,7 +145,21 @@ export const listMissingControlObservabilityFields = (
     const missing: string[] = [];
     for (const requiredField of REQUIRED_CONTROL_OBSERVABILITY_FIELDS) {
         const value = getValueByPath(envelopeRecord, requiredField);
-        if (!hasRequiredValue(value)) {
+        if (!hasRequiredValueAtPath(requiredField, value)) {
+            missing.push(requiredField);
+        }
+    }
+
+    return missing;
+};
+
+const listMissingControlObservabilityInputFields = (
+    input: Record<string, unknown>
+): string[] => {
+    const missing: string[] = [];
+    for (const requiredField of REQUIRED_CONTROL_OBSERVABILITY_INPUT_FIELDS) {
+        const value = getValueByPath(input, requiredField);
+        if (!hasRequiredValueAtPath(requiredField, value)) {
             missing.push(requiredField);
         }
     }
@@ -135,16 +188,29 @@ export const buildControlObservabilityEnvelope = (input: {
         const trimmed = value?.trim();
         return trimmed && trimmed.length > 0 ? trimmed : null;
     };
+    const normalizedInput = {
+        ...input,
+        requestedProfileId: trimToNull(input.requestedProfileId),
+        plannerSelectedProfileId: trimToNull(input.plannerSelectedProfileId),
+    } as Record<string, unknown>;
+    const missingInputFields =
+        listMissingControlObservabilityInputFields(normalizedInput);
+    if (missingInputFields.length > 0) {
+        throw new Error(
+            `Control observability input missing required fields: ${missingInputFields.join(', ')}`
+        );
+    }
     const envelope: ControlObservabilityEnvelope = {
         version: 'v1',
         input: {
             surface: input.surface,
             workflowModeId: input.workflowModeId,
             executionContractResponseMode: input.executionContractResponseMode,
-            requestedProfileId: trimToNull(input.requestedProfileId),
-            plannerSelectedProfileId: trimToNull(
-                input.plannerSelectedProfileId
-            ),
+            requestedProfileId: normalizedInput.requestedProfileId as
+                | string
+                | null,
+            plannerSelectedProfileId:
+                normalizedInput.plannerSelectedProfileId as string | null,
             selectedProfileId: input.selectedProfileId,
             personaOverlaySource: input.personaOverlaySource,
             toolRequest: {

--- a/packages/backend/test/steerabilityControlObservability.test.ts
+++ b/packages/backend/test/steerabilityControlObservability.test.ts
@@ -87,6 +87,39 @@ test('buildControlObservabilityEnvelope emits required input/decision/outcome gr
     assert.equal(listMissingControlObservabilityFields(envelope).length, 0);
 });
 
+test('profile lineage keys are required keys but allow explicit null lineage values', () => {
+    const envelope = buildControlObservabilityEnvelope({
+        ...createEnvelopeInput(),
+        requestedProfileId: undefined,
+        plannerSelectedProfileId: undefined,
+    });
+
+    assert.equal(envelope.input.requestedProfileId, null);
+    assert.equal(envelope.input.plannerSelectedProfileId, null);
+    assert.equal(listMissingControlObservabilityFields(envelope).length, 0);
+});
+
+test('listMissingControlObservabilityFields reports missing profile lineage keys', () => {
+    const envelope = buildControlObservabilityEnvelope(
+        createEnvelopeInput()
+    ) as unknown as {
+        input: {
+            requestedProfileId?: string | null;
+            plannerSelectedProfileId?: string | null;
+        };
+    };
+    delete envelope.input.requestedProfileId;
+    delete envelope.input.plannerSelectedProfileId;
+
+    const missing = listMissingControlObservabilityFields(
+        envelope as unknown as Parameters<
+            typeof listMissingControlObservabilityFields
+        >[0]
+    );
+    assert.ok(missing.includes('input.requestedProfileId'));
+    assert.ok(missing.includes('input.plannerSelectedProfileId'));
+});
+
 test('buildControlObservabilityEnvelope throws when required fields are missing', () => {
     const input = createEnvelopeInput();
     const trimmedInput = {

--- a/packages/backend/test/steerabilityControlObservability.test.ts
+++ b/packages/backend/test/steerabilityControlObservability.test.ts
@@ -1,0 +1,101 @@
+/**
+ * @description: Verifies the shared control observability envelope keeps required
+ * input, decision, and outcome fields explicit and auditable.
+ * @footnote-scope: test
+ * @footnote-module: SteerabilityControlObservabilityTests
+ * @footnote-risk: medium - Missing checks here can allow silent drift in control observability payloads.
+ * @footnote-ethics: high - Incomplete control lineage can mislead operators about runtime decisions.
+ */
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import {
+    buildControlObservabilityEnvelope,
+    listMissingControlObservabilityFields,
+} from '../src/services/steerabilityControlObservability.js';
+import { buildSteerabilityControls } from '../src/services/steerabilityControls.js';
+
+const createEnvelopeInput = (): Parameters<
+    typeof buildControlObservabilityEnvelope
+>[0] => {
+    const steerabilityControls = buildSteerabilityControls({
+        workflowMode: {
+            modeId: 'grounded',
+            selectedBy: 'requested_mode',
+            selectionReason: 'Configured mode selected.',
+            behavior: {
+                executionContractPresetId: 'quality-grounded',
+                workflowProfileClass: 'reviewed',
+                workflowProfileId: 'bounded-review',
+                workflowExecution: 'policy_gated',
+                reviewPass: 'included',
+                reviseStep: 'allowed',
+                evidencePosture: 'strict',
+                maxWorkflowSteps: 8,
+                maxDeliberationCalls: 4,
+            },
+        },
+        executionContractResponseMode: 'quality_grounded',
+        requestedProfileId: 'openai-text-fast',
+        plannerSelectedProfileId: 'openai-text-fast',
+        selectedProfile: {
+            profileId: 'openai-text-fast',
+            provider: 'openai',
+            model: 'gpt-5-mini',
+        },
+        persona: {
+            personaId: 'myuri',
+            overlaySource: 'file',
+        },
+        toolRequest: {
+            toolName: 'web_search',
+            requested: true,
+            eligible: true,
+        },
+    });
+
+    return {
+        surface: 'discord',
+        workflowModeId: 'grounded',
+        executionContractResponseMode: 'quality_grounded',
+        requestedProfileId: 'openai-text-fast',
+        plannerSelectedProfileId: 'openai-text-fast',
+        selectedProfileId: 'openai-text-fast',
+        personaOverlaySource: 'file',
+        toolRequest: {
+            toolName: 'web_search',
+            requested: true,
+            eligible: true,
+        },
+        plannerApplyOutcome: 'applied',
+        plannerMatteredControlIds: ['tool_allowance'],
+        plannerStatus: 'executed',
+        plannerReasonCode: undefined,
+        responseAction: 'message',
+        responseModality: 'text',
+        steerabilityControls,
+    };
+};
+
+test('buildControlObservabilityEnvelope emits required input/decision/outcome groups', () => {
+    const envelope = buildControlObservabilityEnvelope(createEnvelopeInput());
+
+    assert.equal(envelope.version, 'v1');
+    assert.equal(envelope.input.surface, 'discord');
+    assert.equal(envelope.decision.plannerApplyOutcome, 'applied');
+    assert.equal(envelope.outcome.responseAction, 'message');
+    assert.equal(envelope.outcome.mattered, true);
+    assert.equal(listMissingControlObservabilityFields(envelope).length, 0);
+});
+
+test('buildControlObservabilityEnvelope throws when required fields are missing', () => {
+    const input = createEnvelopeInput();
+    const trimmedInput = {
+        ...input,
+        selectedProfileId: '   ',
+    };
+
+    assert.throws(
+        () => buildControlObservabilityEnvelope(trimmedInput),
+        /missing required fields/i
+    );
+});


### PR DESCRIPTION
## Summary
This PR hardens steerability control observability so control decisions are represented consistently and remain auditable across runtime paths.

## What Changed
- Added a shared backend helper for a required control observability envelope:
  - `packages/backend/src/services/steerabilityControlObservability.ts`
  - Defines a versioned `v1` envelope with explicit `input`, `decision`, and `outcome` groups.
  - Validates required fields and exposes missing-field detection.
  - Emits a single structured event: `chat.steerability.control_observability`.
- Wired shared envelope emission into orchestrator runtime paths:
  - `packages/backend/src/services/chatOrchestrator.ts`
  - Emits for both message and non-message outcomes.
  - Preserves fail-open behavior by logging a failure signal and continuing execution if envelope emission is invalid.
- Added test coverage that fails when required fields are missing:
  - `packages/backend/test/steerabilityControlObservability.test.ts`
  - Verifies valid envelope shape and missing-field failure behavior.
- Updated architecture documentation:
  - `docs/architecture/2026-04-steerability-foundation.md`
  - Documents required envelope fields and behavior in clearer contributor-friendly language.

## Why
Control metadata is already live in runtime paths. This change prevents observability drift as new adaptive seams land, and avoids inconsistent or misleading records about which controls materially influenced decisions.

## Important Implementation Details
- Required fields are enforced by group:
  - `input`: surface, workflow mode, execution contract mode, selected profile, persona overlay source, and tool request fields.
  - `decision`: planner apply outcome, mattered control ids, and control records.
  - `outcome`: response action/modality, planner status/reason, and whether controls mattered.
- Envelope validation is strict in tests but runtime emission remains fail-open.
- Modality typing is aligned to orchestrator runtime values (`text | tts`) to keep review/build checks green.

This PR was written using [Vibe Kanban](https://vibekanban.com)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Emit a standardized control-observability event for control decisions across message and non-message execution paths; additional telemetry improves visibility and is resilient (invalid emissions are logged and do not block responses).

* **Documentation**
  * Added architecture docs describing the control observability framework and event schema.

* **Tests**
  * Added tests validating envelope construction, required-field checks, and handling of explicit null/whitespace inputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->