### PR TITLE
Harden internal steerability precedence and semantic boundaries (Vibe Kanban)

### DIFF
--- a/docs/architecture/2026-04-steerability-foundation.md
+++ b/docs/architecture/2026-04-steerability-foundation.md
@@ -39,6 +39,32 @@ Preference signal:
 This is advisory by default. Runtime may honor it, override it, or replace it
 through fallback. Do not treat it as execution authority unless policy says so.
 
+## Internal Precedence Matrix (Current Controls Only)
+
+Steerability control conflicts for current internal controls are resolved by one
+shared resolver in backend runtime code:
+`steerabilityControlPrecedence`.
+
+Current precedence:
+
+- `execution_policy` > `preference_signal`
+- `execution_policy` > `presentation_only`
+- `preference_signal` > `presentation_only`
+
+Current class mapping:
+
+- `execution_policy`: `workflow_mode`, `evidence_strictness`,
+  `review_intensity`, `tool_allowance`
+- `preference_signal`: `provider_preference`
+- `presentation_only`: `persona_tone_overlay`
+
+Guardrails:
+
+- `provider_preference` cannot escalate into execution-policy authority.
+- `persona_tone_overlay` cannot escalate into execution-policy authority.
+- Tone/presentation and preference requests are represented as outcomes, not
+  authority commands.
+
 `mattered = true` means the control had an observed material effect on the run
 or the delivered answer.
 
@@ -76,6 +102,12 @@ For `provider_preference`, the trace should preserve the visible state:
 - `advisory_honored`
 - `advisory_overridden`
 - `fallback_resolved`
+
+For `persona_tone_overlay`, the trace should preserve explicit presentation
+state:
+
+- `presentation_applied`
+- `presentation_not_applied`
 
 ## Planner Events
 

--- a/docs/architecture/workflow-mode-routing.md
+++ b/docs/architecture/workflow-mode-routing.md
@@ -44,6 +44,9 @@ workflow profile (`bounded-review`) but differ in posture and limits.
 
 This keeps the system available while preferring the more careful default
 posture.
+Initial mode selection is not revisable later in current runtime behavior.
+Future escalation should attach to the centralized mode resolver path instead
+of introducing parallel routing logic.
 
 ## Metadata Contract
 

--- a/packages/backend/src/services/chatOrchestrator.ts
+++ b/packages/backend/src/services/chatOrchestrator.ts
@@ -68,6 +68,7 @@ import {
     buildControlObservabilityEnvelope,
     emitControlObservabilityEnvelope,
 } from './steerabilityControlObservability.js';
+import { resolveInternalSteerabilityControlConflicts } from './steerabilityControlPrecedence.js';
 
 type CreateChatOrchestratorOptions = CreateChatServiceOptions & {
     weatherForecastTool?: WeatherForecastTool;
@@ -430,6 +431,13 @@ export const createChatOrchestrator = ({
             },
             toolRequest: toolRequestContext,
         });
+        const steerabilityConflictResolution =
+            resolveInternalSteerabilityControlConflicts({
+                requestedProfileId: normalizedRequest.profileId,
+                plannerSelectedProfileId: plan.profileId,
+                selectedProfileId: selectedResponseProfile.id,
+                personaOverlaySource: personaProfile.promptOverlay.source,
+            });
         const plannerMatteredControlIds =
             plannerExecution.status === 'executed'
                 ? steerabilityControls.controls
@@ -442,15 +450,9 @@ export const createChatOrchestrator = ({
                       )
                       .map((control) => control.controlId)
                 : [];
-        const providerPreferenceControl = steerabilityControls.controls.find(
-            (control) => control.controlId === 'provider_preference'
-        );
-        const trimmedRequestedProfileId = normalizedRequest.profileId?.trim();
         const providerPreferencePolicyAdjusted =
-            providerPreferenceControl?.mattered === true &&
-            trimmedRequestedProfileId !== undefined &&
-            trimmedRequestedProfileId.length > 0 &&
-            trimmedRequestedProfileId !== selectedResponseProfile.id;
+            steerabilityConflictResolution.providerPreference
+                .wasOverriddenByExecutionPolicy;
         // `mattered` is an observed-material-effect signal derived from
         // concrete control records in this run. It is not full causal proof.
         const plannerMattered = plannerMatteredControlIds.length > 0;

--- a/packages/backend/src/services/chatOrchestrator.ts
+++ b/packages/backend/src/services/chatOrchestrator.ts
@@ -285,6 +285,9 @@ export const createChatOrchestrator = ({
         // Planner remains a bounded workflow-owned step. It can recommend
         // action-selection details but cannot redefine Execution Contract
         // authority or become a second orchestrator.
+        // TODO(workflow-planner-lineage): Planner is orchestrator-frontloaded
+        // today. When planner becomes workflow-native, persist it as a
+        // first-class workflow step in workflow lineage.
         const plannerInvocationContext: ChatPlannerInvocationContext = {
             owner: 'workflow',
             workflowName: 'chat_orchestration',
@@ -600,7 +603,7 @@ export const createChatOrchestrator = ({
         };
 
         // Planner output is injected as a final system message so generation
-        // can follow one backend-owned decision payload.
+        // follows one bounded planner payload selected by backend policy.
         const conversationMessages: Array<
             Pick<ChatConversationMessage, 'role' | 'content'>
         > = [
@@ -626,7 +629,8 @@ export const createChatOrchestrator = ({
                 content: [
                     '// ==========',
                     '// BEGIN Planner Output',
-                    '// This planner decision was made by the backend and should be treated as authoritative for this response.',
+                    '// This bounded planner output was selected by backend policy for this response.',
+                    '// It is execution input for this run, not execution-contract authority.',
                     '// ==========',
                     buildPlannerPayload(executionPlanForPrompt, surfacePolicy),
                     '// ==========',
@@ -689,6 +693,9 @@ export const createChatOrchestrator = ({
             executionContext: {
                 // Planner execution metadata is sourced from ChatPlannerResult
                 // so traces can distinguish successful planning from fallback.
+                // TODO(workflow-planner-lineage): Keep this metadata bridge
+                // until planner execution is represented directly as workflow
+                // lineage instead of orchestrator-frontloaded context.
                 planner: {
                     status: plannerExecution.status,
                     ...(plannerExecution.reasonCode !== undefined && {

--- a/packages/backend/src/services/chatService.ts
+++ b/packages/backend/src/services/chatService.ts
@@ -799,9 +799,10 @@ export const createChatService = ({
             trustGraphResult?.provenanceJoin?.consumedByConsumers.includes(
                 'P_EVID'
             ) === true;
-        // TODO(workflow-mode-escalation): If runtime introduces mode transitions,
-        // capture transition records here (planned mode -> effective mode) once
-        // retrieval/sufficiency checks can revise an initial mode choice.
+        // TODO(workflow-mode-escalation): Initial mode selection is not
+        // revisable in current runtime behavior. If mode transitions are added,
+        // capture transition records here (planned mode -> effective mode)
+        // instead of inferring revisions from downstream effects.
         const hasSearchIntent = normalizedGeneration?.search !== undefined;
         const upstreamToolExecution = executionContext?.tool;
         const effectiveToolExecutionContext:

--- a/packages/backend/src/services/openaiService.ts
+++ b/packages/backend/src/services/openaiService.ts
@@ -848,6 +848,9 @@ const buildResponseMetadata = (
             runtimeContext.trustGraphEvidenceAvailable ?? false,
         trustGraphEvidenceUsed: runtimeContext.trustGraphEvidenceUsed ?? false,
     });
+    // TODO(provenance-structural-first): Reduce heuristic dependence here by
+    // preferring explicit runtime retrieval/tool evidence signals wherever they
+    // are available and contract-stable.
     const provenance = provenanceClassification.provenance;
     const provenanceAssessment = provenanceClassification.assessment;
     const tradeoffCount = resolveTradeoffCount(
@@ -901,10 +904,10 @@ const buildResponseMetadata = (
     const execution: ExecutionEvent[] = [];
     const plannerExecution = runtimeContext.executionContext?.planner;
     if (plannerExecution) {
-        // TODO(workflow-planner-step-metadata): If workflows support multiple
-        // planner invocations per response, add explicit attempt/correlation
-        // metadata without allowing planner events to redefine orchestration
-        // authority or step ownership boundaries.
+        // TODO(workflow-planner-step-metadata): Planner is not workflow-native
+        // in lineage yet. If workflows support multiple planner invocations,
+        // add explicit attempt/correlation metadata without letting planner
+        // events redefine orchestration authority or step ownership.
         const normalizedPlannerReasonCode = normalizePlannerReasonCode(
             plannerExecution.status,
             plannerExecution.reasonCode
@@ -1088,8 +1091,8 @@ const buildResponseMetadata = (
         tradeoffCount,
         chainHash,
         licenseContext,
-        // TODO(workflow-execution-metadata): Remove modelVersion once all
-        // metadata consumers have migrated to execution[] as canonical.
+        // TODO(workflow-execution-metadata): Remove modelVersion after metadata
+        // consumers migrate to execution[] as canonical timeline authority.
         // Compatibility mirror for legacy consumers that still read only a
         // single model string.
         modelVersion:

--- a/packages/backend/src/services/responseMetadataHeuristics.ts
+++ b/packages/backend/src/services/responseMetadataHeuristics.ts
@@ -154,6 +154,9 @@ type ProvenanceClassificationResult = {
 export const classifyProvenanceWithSignals = (
     input: ProvenanceClassificationInput
 ): ProvenanceClassificationResult => {
+    // TODO(provenance-structural-first): Keep this deterministic classifier,
+    // but retire heuristic fallbacks that can be replaced by explicit runtime
+    // execution evidence once those signals are universally available.
     const citationsPresent = input.citationCount > 0;
     const assistantDeclaredSpeculative =
         input.assistantProvenance === 'Speculative';

--- a/packages/backend/src/services/steerabilityControlPrecedence.ts
+++ b/packages/backend/src/services/steerabilityControlPrecedence.ts
@@ -1,0 +1,174 @@
+/**
+ * @description: Resolves deterministic precedence for current internal steerability controls.
+ * @footnote-scope: core
+ * @footnote-module: SteerabilityControlPrecedence
+ * @footnote-risk: medium - Precedence drift here can silently change conflict outcomes across orchestration and metadata paths.
+ * @footnote-ethics: high - Authority-boundary mistakes can misrepresent which controls are policy authority versus presentation or preference.
+ */
+
+type ProfilePreferenceSource = 'request_override' | 'planner_output';
+
+export type ProviderPreferenceOutcomeState =
+    | 'requested_honored'
+    | 'requested_overridden'
+    | 'advisory_honored'
+    | 'advisory_overridden'
+    | 'fallback_resolved';
+
+export type PersonaToneOverlayOutcomeState =
+    | 'presentation_applied'
+    | 'presentation_not_applied';
+
+export type SteerabilityAuthorityClass =
+    | 'execution_policy'
+    | 'preference_signal'
+    | 'presentation_only';
+
+export type InternalSteerabilityPrecedenceRule = {
+    higherAuthority: SteerabilityAuthorityClass;
+    lowerAuthority: SteerabilityAuthorityClass;
+    outcome: 'higher_wins';
+    rationale: string;
+};
+
+export const INTERNAL_STEERABILITY_PRECEDENCE_MATRIX: readonly InternalSteerabilityPrecedenceRule[] =
+    [
+        {
+            higherAuthority: 'execution_policy',
+            lowerAuthority: 'preference_signal',
+            outcome: 'higher_wins',
+            rationale:
+                'Execution-policy controls remain authoritative when provider preference conflicts with runtime policy/capability routing.',
+        },
+        {
+            higherAuthority: 'execution_policy',
+            lowerAuthority: 'presentation_only',
+            outcome: 'higher_wins',
+            rationale:
+                'Presentation controls shape tone only and cannot alter execution-policy authority.',
+        },
+        {
+            higherAuthority: 'preference_signal',
+            lowerAuthority: 'presentation_only',
+            outcome: 'higher_wins',
+            rationale:
+                'Provider preference controls profile selection only; persona tone overlay remains presentation-scoped.',
+        },
+    ] as const;
+
+const trimOptional = (value: string | undefined): string | undefined => {
+    const trimmed = value?.trim();
+    return trimmed && trimmed.length > 0 ? trimmed : undefined;
+};
+
+export type ResolveInternalSteerabilityControlConflictsInput = {
+    requestedProfileId?: string;
+    plannerSelectedProfileId?: string;
+    selectedProfileId: string;
+    personaOverlaySource: 'none' | 'inline' | 'file';
+};
+
+export type ProviderPreferenceConflictOutcome = {
+    authorityClass: 'preference_signal';
+    source: ProfilePreferenceSource | 'fail_open_default';
+    state: ProviderPreferenceOutcomeState;
+    requestedProfileId?: string;
+    advisoryProfileId?: string;
+    resolvedProfileId: string;
+    wasOverriddenByExecutionPolicy: boolean;
+    canEscalateIntoExecutionPolicyAuthority: false;
+};
+
+export type PersonaToneOverlayConflictOutcome = {
+    authorityClass: 'presentation_only';
+    state: PersonaToneOverlayOutcomeState;
+    overlaySource: 'none' | 'inline' | 'file';
+    overlayApplied: boolean;
+    canEscalateIntoExecutionPolicyAuthority: false;
+};
+
+export type InternalSteerabilityConflictResolution = {
+    precedenceMatrix: readonly InternalSteerabilityPrecedenceRule[];
+    providerPreference: ProviderPreferenceConflictOutcome;
+    personaToneOverlay: PersonaToneOverlayConflictOutcome;
+};
+
+const resolveProviderPreferenceConflict = (input: {
+    requestedProfileId?: string;
+    plannerSelectedProfileId?: string;
+    selectedProfileId: string;
+}): ProviderPreferenceConflictOutcome => {
+    const requestedProfileId = trimOptional(input.requestedProfileId);
+    if (requestedProfileId !== undefined) {
+        const state: ProviderPreferenceOutcomeState =
+            requestedProfileId === input.selectedProfileId
+                ? 'requested_honored'
+                : 'requested_overridden';
+        return {
+            authorityClass: 'preference_signal',
+            source: 'request_override',
+            state,
+            requestedProfileId,
+            resolvedProfileId: input.selectedProfileId,
+            wasOverriddenByExecutionPolicy: state === 'requested_overridden',
+            canEscalateIntoExecutionPolicyAuthority: false,
+        };
+    }
+
+    const plannerSelectedProfileId = trimOptional(
+        input.plannerSelectedProfileId
+    );
+    if (plannerSelectedProfileId !== undefined) {
+        const state: ProviderPreferenceOutcomeState =
+            plannerSelectedProfileId === input.selectedProfileId
+                ? 'advisory_honored'
+                : 'advisory_overridden';
+        return {
+            authorityClass: 'preference_signal',
+            source: 'planner_output',
+            state,
+            advisoryProfileId: plannerSelectedProfileId,
+            resolvedProfileId: input.selectedProfileId,
+            wasOverriddenByExecutionPolicy: state === 'advisory_overridden',
+            canEscalateIntoExecutionPolicyAuthority: false,
+        };
+    }
+
+    return {
+        authorityClass: 'preference_signal',
+        source: 'fail_open_default',
+        state: 'fallback_resolved',
+        resolvedProfileId: input.selectedProfileId,
+        wasOverriddenByExecutionPolicy: false,
+        canEscalateIntoExecutionPolicyAuthority: false,
+    };
+};
+
+const resolvePersonaToneOverlayConflict = (
+    personaOverlaySource: 'none' | 'inline' | 'file'
+): PersonaToneOverlayConflictOutcome => {
+    const overlayApplied = personaOverlaySource !== 'none';
+    return {
+        authorityClass: 'presentation_only',
+        state: overlayApplied
+            ? 'presentation_applied'
+            : 'presentation_not_applied',
+        overlaySource: personaOverlaySource,
+        overlayApplied,
+        canEscalateIntoExecutionPolicyAuthority: false,
+    };
+};
+
+export const resolveInternalSteerabilityControlConflicts = (
+    input: ResolveInternalSteerabilityControlConflictsInput
+): InternalSteerabilityConflictResolution => ({
+    precedenceMatrix: INTERNAL_STEERABILITY_PRECEDENCE_MATRIX,
+    providerPreference: resolveProviderPreferenceConflict({
+        requestedProfileId: input.requestedProfileId,
+        plannerSelectedProfileId: input.plannerSelectedProfileId,
+        selectedProfileId: input.selectedProfileId,
+    }),
+    personaToneOverlay: resolvePersonaToneOverlayConflict(
+        input.personaOverlaySource
+    ),
+});

--- a/packages/backend/src/services/steerabilityControls.ts
+++ b/packages/backend/src/services/steerabilityControls.ts
@@ -13,6 +13,10 @@ import type {
     WorkflowModeDecision,
 } from '@footnote/contracts/ethics-core';
 import { deriveReviewIntensityFromWorkflowBehavior } from './workflowProfileRegistry.js';
+import {
+    resolveInternalSteerabilityControlConflicts,
+    type ProviderPreferenceOutcomeState,
+} from './steerabilityControlPrecedence.js';
 
 type ProfileSelection = {
     profileId: string;
@@ -58,18 +62,6 @@ const mapWorkflowModeSource = (
     return 'fail_open_default';
 };
 
-const trimOptional = (value: string | undefined): string | undefined => {
-    const trimmed = value?.trim();
-    return trimmed && trimmed.length > 0 ? trimmed : undefined;
-};
-
-type ProviderPreferenceState =
-    | 'requested_honored'
-    | 'requested_overridden'
-    | 'advisory_honored'
-    | 'advisory_overridden'
-    | 'fallback_resolved';
-
 /**
  * Provider preference is intentionally honest about intent vs outcome:
  * - requested/advisory origin
@@ -80,19 +72,23 @@ type ProviderPreferenceState =
 const buildProviderPreferenceControl = (
     input: BuildSteerabilityControlsInput
 ): SteerabilityControlRecord => {
-    const requestedProfileId = trimOptional(input.requestedProfileId);
-    const plannerSelectedProfileId = trimOptional(
-        input.plannerSelectedProfileId
-    );
+    const conflictResolution = resolveInternalSteerabilityControlConflicts({
+        requestedProfileId: input.requestedProfileId,
+        plannerSelectedProfileId: input.plannerSelectedProfileId,
+        selectedProfileId: input.selectedProfile.profileId,
+        personaOverlaySource: input.persona.overlaySource,
+    });
+    const providerPreference = conflictResolution.providerPreference;
+    const selectedProfileSummary = `${input.selectedProfile.profileId}(${input.selectedProfile.provider}/${input.selectedProfile.model})`;
 
-    if (requestedProfileId !== undefined) {
-        const state: ProviderPreferenceState =
-            requestedProfileId === input.selectedProfile.profileId
-                ? 'requested_honored'
-                : 'requested_overridden';
+    if (
+        providerPreference.source === 'request_override' &&
+        providerPreference.requestedProfileId !== undefined
+    ) {
+        const state: ProviderPreferenceOutcomeState = providerPreference.state;
         return {
             controlId: 'provider_preference',
-            value: `state:${state};requested:${requestedProfileId};resolved:${input.selectedProfile.profileId}(${input.selectedProfile.provider}/${input.selectedProfile.model})`,
+            value: `state:${state};requested:${providerPreference.requestedProfileId};resolved:${selectedProfileSummary}`,
             source: 'request_override',
             rationale:
                 state === 'requested_honored'
@@ -103,14 +99,14 @@ const buildProviderPreferenceControl = (
         };
     }
 
-    if (plannerSelectedProfileId !== undefined) {
-        const state: ProviderPreferenceState =
-            plannerSelectedProfileId === input.selectedProfile.profileId
-                ? 'advisory_honored'
-                : 'advisory_overridden';
+    if (
+        providerPreference.source === 'planner_output' &&
+        providerPreference.advisoryProfileId !== undefined
+    ) {
+        const state: ProviderPreferenceOutcomeState = providerPreference.state;
         return {
             controlId: 'provider_preference',
-            value: `state:${state};advisory:${plannerSelectedProfileId};resolved:${input.selectedProfile.profileId}(${input.selectedProfile.provider}/${input.selectedProfile.model})`,
+            value: `state:${state};advisory:${providerPreference.advisoryProfileId};resolved:${selectedProfileSummary}`,
             source: 'planner_output',
             rationale:
                 state === 'advisory_honored'
@@ -123,7 +119,7 @@ const buildProviderPreferenceControl = (
 
     return {
         controlId: 'provider_preference',
-        value: `state:fallback_resolved;resolved:${input.selectedProfile.profileId}(${input.selectedProfile.provider}/${input.selectedProfile.model})`,
+        value: `state:fallback_resolved;resolved:${selectedProfileSummary}`,
         source: 'fail_open_default',
         rationale:
             'No requested or advisory profile preference was present, so runtime fallback resolution selected the provider/model profile.',
@@ -188,7 +184,14 @@ export const buildSteerabilityControls = (
     const reviewIntensity = deriveReviewIntensityFromWorkflowBehavior(
         input.workflowMode.behavior
     );
-    const personaHasOverlay = input.persona.overlaySource !== 'none';
+    const conflictResolution = resolveInternalSteerabilityControlConflicts({
+        requestedProfileId: input.requestedProfileId,
+        plannerSelectedProfileId: input.plannerSelectedProfileId,
+        selectedProfileId: input.selectedProfile.profileId,
+        personaOverlaySource: input.persona.overlaySource,
+    });
+    const personaOutcome = conflictResolution.personaToneOverlay;
+    const personaHasOverlay = personaOutcome.overlayApplied;
 
     const controls: SteerabilityControlRecord[] = [
         {
@@ -225,7 +228,7 @@ export const buildSteerabilityControls = (
         buildProviderPreferenceControl(input),
         {
             controlId: 'persona_tone_overlay',
-            value: `${input.persona.personaId}:${input.persona.overlaySource}`,
+            value: `state:${personaOutcome.state};persona:${input.persona.personaId};source:${personaOutcome.overlaySource}`,
             source: 'surface_profile',
             rationale: personaHasOverlay
                 ? 'Backend persona overlay shaped answer presentation/tone only; it did not change execution-contract authority, evidence posture, or review authority.'

--- a/packages/backend/src/services/steerabilityControls.ts
+++ b/packages/backend/src/services/steerabilityControls.ts
@@ -15,6 +15,7 @@ import type {
 import { deriveReviewIntensityFromWorkflowBehavior } from './workflowProfileRegistry.js';
 import {
     resolveInternalSteerabilityControlConflicts,
+    type InternalSteerabilityConflictResolution,
     type ProviderPreferenceOutcomeState,
 } from './steerabilityControlPrecedence.js';
 
@@ -70,14 +71,9 @@ const mapWorkflowModeSource = (
  * This is not a policy command language; it is traceable outcome metadata.
  */
 const buildProviderPreferenceControl = (
-    input: BuildSteerabilityControlsInput
+    input: BuildSteerabilityControlsInput,
+    conflictResolution: InternalSteerabilityConflictResolution
 ): SteerabilityControlRecord => {
-    const conflictResolution = resolveInternalSteerabilityControlConflicts({
-        requestedProfileId: input.requestedProfileId,
-        plannerSelectedProfileId: input.plannerSelectedProfileId,
-        selectedProfileId: input.selectedProfile.profileId,
-        personaOverlaySource: input.persona.overlaySource,
-    });
     const providerPreference = conflictResolution.providerPreference;
     const selectedProfileSummary = `${input.selectedProfile.profileId}(${input.selectedProfile.provider}/${input.selectedProfile.model})`;
 
@@ -225,7 +221,7 @@ export const buildSteerabilityControls = (
             impactedTargets:
                 reviewIntensity !== 'none' ? ['review_loop_execution'] : [],
         },
-        buildProviderPreferenceControl(input),
+        buildProviderPreferenceControl(input, conflictResolution),
         {
             controlId: 'persona_tone_overlay',
             value: `state:${personaOutcome.state};persona:${input.persona.personaId};source:${personaOutcome.overlaySource}`,

--- a/packages/backend/src/services/workflowProfileRegistry.ts
+++ b/packages/backend/src/services/workflowProfileRegistry.ts
@@ -449,6 +449,9 @@ export const resolveWorkflowRuntimeConfig = (input: {
     maxDurationMs: number;
     ExecutionContract?: Pick<ExecutionContract, 'response' | 'limits'>;
 }): ResolvedWorkflowRuntimeConfig => {
+    // TODO(workflow-mode-escalation-attachment): Initial mode selection is
+    // not revisable in v1. Attach any future mode-escalation policy here so
+    // routing revisions stay centralized instead of split across callers.
     const modeResolution = resolveWorkflowModeDecision({
         modeId: input.modeId,
         executionContractResponseMode:

--- a/packages/backend/test/steerabilityControlPrecedence.test.ts
+++ b/packages/backend/test/steerabilityControlPrecedence.test.ts
@@ -1,0 +1,82 @@
+/**
+ * @description: Verifies deterministic precedence outcomes for current internal steerability control conflicts.
+ * @footnote-scope: test
+ * @footnote-module: SteerabilityControlPrecedenceTests
+ * @footnote-risk: medium - Missing tests can allow drift where preference or presentation controls look authoritative.
+ * @footnote-ethics: high - Authority-boundary regressions can mislead operators about what governed execution behavior.
+ */
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import {
+    INTERNAL_STEERABILITY_PRECEDENCE_MATRIX,
+    resolveInternalSteerabilityControlConflicts,
+} from '../src/services/steerabilityControlPrecedence.js';
+
+test('precedence matrix keeps execution_policy above preference and presentation controls', () => {
+    const executionOverPreference =
+        INTERNAL_STEERABILITY_PRECEDENCE_MATRIX.find(
+            (rule) =>
+                rule.higherAuthority === 'execution_policy' &&
+                rule.lowerAuthority === 'preference_signal'
+        );
+    const executionOverPresentation =
+        INTERNAL_STEERABILITY_PRECEDENCE_MATRIX.find(
+            (rule) =>
+                rule.higherAuthority === 'execution_policy' &&
+                rule.lowerAuthority === 'presentation_only'
+        );
+
+    assert.ok(executionOverPreference);
+    assert.equal(executionOverPreference?.outcome, 'higher_wins');
+    assert.ok(executionOverPresentation);
+    assert.equal(executionOverPresentation?.outcome, 'higher_wins');
+});
+
+test('requested provider preference cannot override execution-policy-selected profile', () => {
+    const resolved = resolveInternalSteerabilityControlConflicts({
+        requestedProfileId: 'openai-text-quality',
+        plannerSelectedProfileId: 'openai-text-quality',
+        selectedProfileId: 'openai-text-fast',
+        personaOverlaySource: 'none',
+    });
+
+    assert.equal(resolved.providerPreference.state, 'requested_overridden');
+    assert.equal(
+        resolved.providerPreference.wasOverriddenByExecutionPolicy,
+        true
+    );
+    assert.equal(
+        resolved.providerPreference.canEscalateIntoExecutionPolicyAuthority,
+        false
+    );
+});
+
+test('planner advisory provider preference emits advisory_overridden when runtime policy selects different profile', () => {
+    const resolved = resolveInternalSteerabilityControlConflicts({
+        requestedProfileId: undefined,
+        plannerSelectedProfileId: 'openai-text-quality',
+        selectedProfileId: 'openai-text-fast',
+        personaOverlaySource: 'none',
+    });
+
+    assert.equal(resolved.providerPreference.source, 'planner_output');
+    assert.equal(resolved.providerPreference.state, 'advisory_overridden');
+    assert.equal(
+        resolved.providerPreference.wasOverriddenByExecutionPolicy,
+        true
+    );
+});
+
+test('persona tone overlay remains presentation-only and non-authoritative', () => {
+    const resolved = resolveInternalSteerabilityControlConflicts({
+        selectedProfileId: 'openai-text-fast',
+        personaOverlaySource: 'file',
+    });
+
+    assert.equal(resolved.personaToneOverlay.state, 'presentation_applied');
+    assert.equal(resolved.personaToneOverlay.overlayApplied, true);
+    assert.equal(
+        resolved.personaToneOverlay.canEscalateIntoExecutionPolicyAuthority,
+        false
+    );
+});

--- a/packages/backend/test/steerabilityControls.test.ts
+++ b/packages/backend/test/steerabilityControls.test.ts
@@ -133,6 +133,35 @@ test('provider_preference records fallback_resolved state when no request or adv
     );
 });
 
+test('requested provider preference override does not mutate execution-policy control values', () => {
+    const controls = buildSteerabilityControls(
+        createBaseControlsInput({
+            requestedProfileId: 'openai-text-quality',
+            selectedProfile: {
+                profileId: 'openai-text-fast',
+                provider: 'openai',
+                model: 'gpt-5-mini',
+            },
+        })
+    );
+    const providerPreference = controls.controls.find(
+        (control) => control.controlId === 'provider_preference'
+    );
+    const evidenceStrictness = controls.controls.find(
+        (control) => control.controlId === 'evidence_strictness'
+    );
+    const reviewIntensity = controls.controls.find(
+        (control) => control.controlId === 'review_intensity'
+    );
+
+    assert.equal(
+        providerPreference?.value,
+        'state:requested_overridden;requested:openai-text-quality;resolved:openai-text-fast(openai/gpt-5-mini)'
+    );
+    assert.equal(evidenceStrictness?.value, 'strict');
+    assert.equal(reviewIntensity?.value, 'high');
+});
+
 test('mattered reflects observable causal impact instead of record presence', () => {
     const controls = buildSteerabilityControls(
         createBaseControlsInput({
@@ -200,6 +229,10 @@ test('persona_tone_overlay rationale stays non-authoritative over execution poli
     assert.match(
         personaControl?.rationale ?? '',
         /did not change execution-contract authority, evidence posture, or review authority/i
+    );
+    assert.match(
+        personaControl?.value ?? '',
+        /^state:presentation_applied;persona:myuri;source:file$/
     );
 });
 

--- a/packages/contracts/src/web/schemas.ts
+++ b/packages/contracts/src/web/schemas.ts
@@ -694,6 +694,9 @@ const TraceCardChipDataSchema = z
 
 /**
  * Response metadata is intentionally tolerant so new backend fields do not break clients.
+ * TODO(metadata-stability-tiers): Once field stability tiers are published for
+ * external consumers, tighten this boundary deliberately without breaking
+ * compatibility-shaped rollout paths.
  */
 export const ResponseMetadataSchema: z.ZodType<ResponseMetadata> = z
     .object(responseMetadataShape)


### PR DESCRIPTION
## Summary
This PR hardens internal steerability conflict handling so authority boundaries are deterministic and inspectable, then follows through with a branch-finish semantic cleanup pass to reduce wording drift around planner authority, routing revisability, and transitional metadata semantics.

## What changed
- Added a dedicated internal precedence resolver in `packages/backend/src/services/steerabilityControlPrecedence.ts`.
- Defined and exported an explicit precedence matrix for current authority classes (`execution_policy`, `preference_signal`, `presentation_only`).
- Added explicit provider preference outcome states (`requested_honored`, `requested_overridden`, `advisory_honored`, `advisory_overridden`, `fallback_resolved`) and persona overlay outcome states (`presentation_applied`, `presentation_not_applied`).
- Wired steerability control assembly to use shared conflict-resolution outcomes, including non-escalation guardrails (`canEscalateIntoExecutionPolicyAuthority: false`).
- Added focused tests in `packages/backend/test/steerabilityControlPrecedence.test.ts` and extended `packages/backend/test/steerabilityControls.test.ts` to prove authority boundaries and outcome state behavior.
- Documented the precedence model and rationale in `docs/architecture/2026-04-steerability-foundation.md`.
- Performed branch-finish semantic hardening across orchestrator/mode/metadata seams (comments and docs) to align wording with implemented reality, including explicit TODO attachment points for future planner lineage, mode escalation, provenance structuralization, and metadata stability tightening.

## Why these changes were made
The branch goal is to prevent preference or tone controls from silently behaving like policy authority. Before adding more adaptive behavior, we need deterministic internal conflict handling for current controls and clearer semantics that tell contributors what is implemented now versus what is intentionally transitional.

## Important implementation details
- `provider_preference` remains non-authoritative by design: it can be honored or overridden, but cannot escalate into execution-policy authority.
- `persona_tone_overlay` remains presentation-only and is explicitly prevented from crossing into execution-policy authority.
- Resolver outcomes are explicit and structured so downstream metadata and observability can describe conflicts without ambiguity.
- Planner wording was tightened to reflect bounded execution input selected by backend policy, not execution-contract authority.
- Initial workflow mode selection is documented as non-revisable today, with TODO seams marking where future escalation should attach instead of introducing parallel routing paths.
- Provenance/metadata comments now call out transitional heuristic/compatibility surfaces and point toward structural-first convergence.

This PR was written using [Vibe Kanban](https://vibekanban.com)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added detailed precedence rules for resolving conflicting steerability controls, including provider preference, persona tone/presentation overlays, and execution-policy ordering.
  * Clarified that provider preference and persona tone overlays cannot escalate into execution-policy authority, and introduced explicit presentation outcomes (presentation_applied / presentation_not_applied).
  * Confirmed initial workflow mode remains final for the current runtime.

* **Tests**
  * Added tests validating deterministic precedence and conflict-resolution outcomes for provider preference and persona tone overlays.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->