### PR TITLE
Clarify bounded planner semantics and lineage seams (Vibe Kanban)

### DIFF
--- a/docs/api/openapi.yaml
+++ b/docs/api/openapi.yaml
@@ -2441,21 +2441,21 @@ components:
                             purpose:
                                 type: string
                                 enum: [chat_orchestrator_action_selection]
-                                description: Required for planner events. Canonical planner invocation purpose.
+                                description: Required for planner events. Canonical bounded planner invocation purpose; not policy ownership.
                             contractType:
                                 type: string
                                 enum: [structured, text_json, fallback]
-                                description: Required for planner events. Planner decision contract execution style.
+                                description: Required for planner events. Planner decision contract execution style used by backend-owned orchestration.
                             applyOutcome:
                                 type: string
                                 enum: [applied, adjusted_by_policy, not_applied]
-                                description: Required for planner events. Indicates whether planner output was applied as-is, adjusted by policy, or not applied.
+                                description: Required for planner events. Indicates whether planner output became execution input as-is, was adjusted by workflow policy, or was not applied.
                             mattered:
                                 type: boolean
-                                description: Required for planner events. Mirrors mattered=true semantics for observable planner impact.
+                                description: Required for planner events. Observable planner influence signal, not a claim of policy authority.
                             matteredControlIds:
                                 type: array
-                                description: Required for planner events. Control IDs that explain why planner influence materially affected execution.
+                                description: Required for planner events. Control IDs that explain where planner influence materially affected execution.
                                 items:
                                     type: string
                             originalProfileId:

--- a/packages/backend/src/services/chatOrchestrator.ts
+++ b/packages/backend/src/services/chatOrchestrator.ts
@@ -282,9 +282,9 @@ export const createChatOrchestrator = ({
             normalizedRequest,
             chatOrchestratorLogger
         );
-        // Planner remains a bounded workflow-owned step. It can recommend
-        // action-selection details but cannot redefine Execution Contract
-        // authority or become a second orchestrator.
+        // Planner is a bounded, execution-relevant helper. It can suggest
+        // action-selection details, but it is not policy authority, contract
+        // authority, runtime ownership, or a second orchestrator.
         // TODO(workflow-planner-lineage): Planner is orchestrator-frontloaded
         // today. When planner becomes workflow-native, persist it as a
         // first-class workflow step in workflow lineage.
@@ -603,7 +603,8 @@ export const createChatOrchestrator = ({
         };
 
         // Planner output is injected as a final system message so generation
-        // follows one bounded planner payload selected by backend policy.
+        // follows one bounded payload selected by backend policy.
+        // This payload is execution input only, never policy authority.
         const conversationMessages: Array<
             Pick<ChatConversationMessage, 'role' | 'content'>
         > = [
@@ -693,6 +694,8 @@ export const createChatOrchestrator = ({
             executionContext: {
                 // Planner execution metadata is sourced from ChatPlannerResult
                 // so traces can distinguish successful planning from fallback.
+                // This metadata reports planner influence; it does not delegate
+                // orchestration ownership or policy authority to planner.
                 // TODO(workflow-planner-lineage): Keep this metadata bridge
                 // until planner execution is represented directly as workflow
                 // lineage instead of orchestrator-frontloaded context.

--- a/packages/backend/src/services/chatPlannerInvocation.ts
+++ b/packages/backend/src/services/chatPlannerInvocation.ts
@@ -8,9 +8,11 @@
 import type { PostChatRequest } from '@footnote/contracts/web';
 
 /**
- * Planner is a bounded workflow-owned step.
- * It does not act as a second orchestrator and cannot redefine Execution
- * Contract authority.
+ * Planner is a bounded execution helper owned by workflow orchestration.
+ * It is execution-relevant, but it is not policy authority, contract
+ * authority, or runtime ownership.
+ * TODO(workflow-planner-step-lineage): When planner becomes workflow-native,
+ * bind this invocation context to first-class workflow step IDs.
  */
 export type ChatPlannerInvocationPurpose = 'chat_orchestrator_action_selection';
 

--- a/packages/backend/src/services/openaiService.ts
+++ b/packages/backend/src/services/openaiService.ts
@@ -908,6 +908,7 @@ const buildResponseMetadata = (
         // in lineage yet. If workflows support multiple planner invocations,
         // add explicit attempt/correlation metadata without letting planner
         // events redefine orchestration authority or step ownership.
+        // Treat this block as metadata ingestion only, not a policy hook.
         const normalizedPlannerReasonCode = normalizePlannerReasonCode(
             plannerExecution.status,
             plannerExecution.reasonCode

--- a/packages/contracts/src/ethics-core/types.ts
+++ b/packages/contracts/src/ethics-core/types.ts
@@ -130,6 +130,7 @@ export type PlannerExecutionReasonCode = Extract<
 /**
  * Canonical planner invocation purpose labels.
  * Keep additive and serializable for trace auditability.
+ * Purpose labels describe bounded planner intent, not policy ownership.
  */
 export type PlannerExecutionPurpose = 'chat_orchestrator_action_selection';
 
@@ -142,7 +143,8 @@ export type PlannerExecutionContractType =
     | 'fallback';
 
 /**
- * How planner output was applied by orchestration/policy.
+ * How planner output was applied by workflow-owned policy/routing.
+ * This records execution effect, not planner authority.
  */
 export type PlannerExecutionApplyOutcome =
     | 'applied'
@@ -317,6 +319,8 @@ type ProfileExecutionEvent = BaseExecutionEvent & {
 
 export type PlannerExecutionEvent = ProfileExecutionEvent & {
     kind: 'planner';
+    // TODO(workflow-planner-step-alignment): If planner becomes a workflow
+    // native step, add correlation fields that map this event to step records.
     purpose: PlannerExecutionPurpose;
     contractType: PlannerExecutionContractType;
     applyOutcome: PlannerExecutionApplyOutcome;


### PR DESCRIPTION
## Summary
This PR hardens planner semantics so contributors can read the codebase and immediately understand planner boundaries.

## What Changed
- Clarified planner boundary language in backend seam points:
  - `packages/backend/src/services/chatPlannerInvocation.ts`
  - `packages/backend/src/services/chatOrchestrator.ts`
  - `packages/backend/src/services/openaiService.ts`
- Tightened planner metadata type comments in shared contracts:
  - `packages/contracts/src/ethics-core/types.ts`
- Updated OpenAPI execution-field descriptions to match runtime semantics:
  - `docs/api/openapi.yaml`
- Added targeted seam TODOs for future lineage work:
  - `workflow-planner-step-lineage` (invocation context to workflow step IDs)
  - `workflow-planner-step-alignment` (planner execution event to workflow step correlation)

## Why
The planner is already contract-bounded at runtime, but wording and placement could still be misread. This update reduces the risk that contributors treat planner as:
- a second orchestrator,
- a policy authority,
- a contract authority, or
- the runtime owner.

The goal is architecture clarity at code seams, not only in docs.

## Important Implementation Details
- No planner authority was expanded.
- No planner contract shape was redesigned.
- No workflow-engine move or planner-as-step implementation was introduced.
- Existing `workflow-planner-lineage` and `workflow-planner-step-metadata` workstreams remain deferred and explicitly marked by TODO seam comments.
- Behavior is unchanged; this is semantics/documentation hardening in code comments, type semantics, and API descriptions.

## Validation
- `pnpm lint:fix`
- `pnpm lint`

This PR was written using [Vibe Kanban](https://vibekanban.com)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified planner execution semantics in API schema descriptions and internal documentation, emphasizing its role as an execution-relevant helper rather than policy authority.
  * Updated descriptions for execution metadata fields to accurately reflect planner influence reporting and execution input handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->