### PR TITLE
Clarify workflow mode/profile ownership and escalation seams (Vibe Kanban)

### DIFF
--- a/docs/architecture/workflow-mode-routing.md
+++ b/docs/architecture/workflow-mode-routing.md
@@ -10,6 +10,11 @@ high-level choice, and workflow profile is the concrete step pattern. TRACE is
 about answer temperament, while provenance and evidence metadata are about what
 actually happened.
 
+In short:
+
+- mode chooses the kind of run,
+- profile chooses the executable workflow shape.
+
 Keep contract posture and workflow mechanics separate. The Execution Contract
 preset answers "what kind of run should govern this request?" The workflow
 profile id answers "what step pattern should execute this run?" Mixing them
@@ -44,6 +49,8 @@ workflow profile (`bounded-review`) but differ in posture and limits.
 
 This keeps the system available while preferring the more careful default
 posture.
+These fallback steps are initial routing fallback only. They are not runtime
+mode escalation.
 Initial mode selection is not revisable later in current runtime behavior.
 Future escalation should attach to the centralized mode resolver path instead
 of introducing parallel routing logic.

--- a/docs/architecture/workflow-profiles-v1-engine-vs-profile-semantics.md
+++ b/docs/architecture/workflow-profiles-v1-engine-vs-profile-semantics.md
@@ -21,6 +21,9 @@ Think of the system in three layers:
 - workflow profile semantics
 - caller/executor adapters
 
+Workflow mode routing sits one level above this document. Mode chooses the kind
+of run first, then profile semantics choose the executable step shape.
+
 The engine runs the workflow safely.
 The profile describes what kind of workflow it is.
 The adapter connects that workflow to the real route, model, and persistence

--- a/packages/backend/src/services/chatOrchestrator.ts
+++ b/packages/backend/src/services/chatOrchestrator.ts
@@ -364,7 +364,7 @@ export const createChatOrchestrator = ({
             );
         }
         // Contract-governed routing boundary:
-        // 1) resolve high-level workflow mode
+        // 1) resolve initial high-level workflow mode (fixed for this run in v1)
         // 2) derive Execution Contract preset from mode
         // 3) execute orchestration within that contract
         const workflowModeResolution = resolveWorkflowModeDecision({
@@ -373,8 +373,9 @@ export const createChatOrchestrator = ({
                 generationForExecution.responseIntentHint?.responseMode,
         });
         // TODO(workflow-mode-escalation): Add optional runtime mode transitions
-        // (for example fast -> grounded) when later retrieval/sufficiency signals
-        // justify escalation. Keep transition policy governed by Execution Contract.
+        // (for example fast -> grounded) when later retrieval/sufficiency
+        // signals justify escalation. This is future behavior only, and should
+        // stay attached to centralized mode routing policy.
         const resolvedExecutionContract = resolveExecutionContract({
             presetId:
                 workflowModeResolution.modeDecision.behavior

--- a/packages/backend/src/services/chatService.ts
+++ b/packages/backend/src/services/chatService.ts
@@ -540,8 +540,9 @@ export const createChatService = ({
                 search: normalizedGeneration.search,
             }),
         };
-        // Execution Contract governs allowed policy shape; runtime resolution
-        // here only composes workflow execution settings within that contract.
+        // Execution Contract governs allowed policy shape. Runtime resolution
+        // here applies initial mode routing, then profile shape selection,
+        // and composes workflow execution settings within that contract.
         const workflowRuntimeConfig = resolveWorkflowRuntimeConfig({
             modeId: workflowModeId ?? chatWorkflowConfig.modeId,
             reviewLoopEnabled: chatWorkflowConfig.reviewLoopEnabled,
@@ -800,9 +801,9 @@ export const createChatService = ({
                 'P_EVID'
             ) === true;
         // TODO(workflow-mode-escalation): Initial mode selection is not
-        // revisable in current runtime behavior. If mode transitions are added,
-        // capture transition records here (planned mode -> effective mode)
-        // instead of inferring revisions from downstream effects.
+        // revisable in current runtime behavior. If future escalation allows
+        // mode transitions, record explicit planned->final mode lineage here
+        // instead of inferring mode changes from fallback side effects.
         const hasSearchIntent = normalizedGeneration?.search !== undefined;
         const upstreamToolExecution = executionContext?.tool;
         const effectiveToolExecutionContext:

--- a/packages/backend/src/services/workflowProfileRegistry.ts
+++ b/packages/backend/src/services/workflowProfileRegistry.ts
@@ -1,6 +1,8 @@
 /**
- * @description: Resolves workflow modes and workflow profiles into concrete runtime
- * workflow settings within Execution Contract guardrails.
+ * @description: Resolves workflow mode and workflow profile into concrete chat
+ * runtime settings within Execution Contract guardrails.
+ *
+ * Mode chooses the kind of run. Profile chooses the executable workflow shape.
  * @footnote-scope: core
  * @footnote-module: WorkflowProfileRegistry
  * @footnote-risk: medium - Incorrect profile resolution can alter runtime execution paths.
@@ -29,14 +31,15 @@ type BuiltinWorkflowProfileId = 'bounded-review' | 'generate-only';
 type BuiltinWorkflowModeId = WorkflowModeId;
 
 /**
- * Profile policies are concrete workflow implementation shapes:
- * - reviewed profile (`bounded-review`): generate + assess + revise
- * - direct profile (`generate-only`): generate-only workflow
+ * Workflow profiles are concrete executable shapes:
+ * - reviewed (`bounded-review`): generate + assess + revise
+ * - direct (`generate-only`): generate only
  *
  * Registry ownership here is assembly glue only:
+ * - Mode resolution decides run kind and default posture.
+ * - Profile resolution decides executable step shape.
  * - Execution Contract remains the governing contract language.
  * - Chat orchestrator remains the runtime coordinator.
- * - This module maps mode/profile inputs to runtime workflow shapes.
  */
 const EXECUTION_CONTRACT_QUALITY_GROUNDED_WORKFLOW_POLICY_PRESET: Readonly<
     RuntimeWorkflowProfile['policy']
@@ -258,11 +261,15 @@ export type WorkflowModeResolution = {
 };
 
 /**
- * Resolves one explicit workflow mode decision that drives execution preset,
- * workflow profile routing, review posture, and metadata explanation.
+ * Resolves one initial workflow mode decision for this request.
+ *
+ * That decision drives execution preset, profile routing, review posture, and
+ * metadata explanation.
  *
  * `modeDecision.modeId` is always the canonical high-level id
  * (`fast|balanced|grounded`).
+ *
+ * In v1, this initial mode decision is not revised later in runtime.
  */
 export const resolveWorkflowModeDecision = (input: {
     modeId: string | null | undefined;
@@ -386,7 +393,7 @@ export type WorkflowProfileRegistryResolution = {
  * - Input is trimmed before lookup.
  * - Unknown/blank ids fail open to `DEFAULT_RUNTIME_WORKFLOW_PROFILE_ID`.
  * - `requestedProfileId` may differ from `runtimeProfile.profileId` when
- *   fallback is applied.
+ *   fallback is applied at initial profile selection time.
  *
  * This function is registry assembly glue and is not a policy ontology owner.
  */
@@ -419,6 +426,8 @@ export const resolveWorkflowProfileRegistry = (
 };
 
 export type ResolvedWorkflowRuntimeConfig = {
+    // TODO(workflow-mode-final-posture): If runtime mode revisability is added,
+    // split mode metadata into initial and final ids instead of overloading one field.
     requestedModeId: string;
     modeId: WorkflowModeId;
     modeDecision: WorkflowModeDecision;
@@ -430,12 +439,13 @@ export type ResolvedWorkflowRuntimeConfig = {
 };
 
 /**
- * Resolves chat workflow runtime execution settings from config + profile
- * policy.
+ * Resolves chat workflow runtime settings from initial mode routing +
+ * profile policy.
  *
  * Invariants:
  * - This is the single workflow-execution gating assembly surface for chat runtime.
- * - Callers should not branch on workflow profile ids directly.
+ * - Mode decides run kind first; profile decides executable shape second.
+ * - Callers should not branch on workflow mode/profile ids directly.
  * - `forceWorkflowExecution` is the explicit profile-level override for
  *   workflow execution when review-loop gating would otherwise disable it.
  *
@@ -468,8 +478,8 @@ export const resolveWorkflowRuntimeConfig = (input: {
             ? executionContract.response.responseMode === 'quality_grounded'
             : input.reviewLoopEnabled === true;
     // TODO(workflow-mode-escalation): Add explicit mode-transition handling
-    // here when runtime can escalate from lighter modes based on retrieval
-    // sufficiency or downstream review signals.
+    // here if runtime mode escalation is introduced later. Current downstream
+    // fallback behavior does not revise the initial mode decision.
     const workflowExecutionEnabled =
         modeDecision.behavior.workflowExecution === 'disabled'
             ? false


### PR DESCRIPTION
## Summary
This PR clarifies the ownership boundary between workflow mode selection, workflow profile selection, and future mode-escalation seams.

## What Changed
- Updated backend resolver and call-site comments/JSDoc to make the split explicit:
  - mode chooses the kind of run
  - profile chooses the executable workflow shape
- Clarified that initial mode selection is fixed for the run in current v1 behavior.
- Clarified that current fallback handling is not runtime mode escalation.
- Added targeted future-seam TODO markers where escalation/reconsideration should attach if introduced later.
- Updated architecture docs to match runtime wording and reduce ambiguity for new contributors.

Files updated:
- `packages/backend/src/services/workflowProfileRegistry.ts`
- `packages/backend/src/services/chatOrchestrator.ts`
- `packages/backend/src/services/chatService.ts`
- `docs/architecture/workflow-mode-routing.md`
- `docs/architecture/workflow-profiles-v1-engine-vs-profile-semantics.md`

## Why These Changes Were Made
The branch goal is architecture simplification around a real but easy-to-misread split:
- mode is top-level routing intent
- profile is execution shape

Without explicit wording, contributors can accidentally flatten mode/profile together or treat downstream fallback behavior as if runtime mode escalation already exists. These edits harden that boundary in the places most likely to be read first (resolver code, call-site comments, and architecture notes).

## Important Implementation Details
- No routing redesign was introduced.
- No mode escalation behavior was added.
- No public interface/schema changes were made.
- Existing fail-open behavior remains intact.
- Future-facing seams are marked with TODOs at centralized attachment points rather than distributed branch logic.

## Behavior Impact
- Runtime behavior is unchanged.
- This is a boundary-clarification and documentation/comment quality pass.

This PR was written using [Vibe Kanban](https://vibekanban.com)