### PR TITLE
Clarify Metadata Semantics and Stability Boundaries (Vibe Kanban)

### DIFF
--- a/packages/backend/src/services/openaiService.ts
+++ b/packages/backend/src/services/openaiService.ts
@@ -643,6 +643,8 @@ type ResponseMetadataRuntimeContext = {
     modelVersion: string;
     conversationSnapshot: string;
     totalDurationMs?: number;
+    // Planner TRACE target posture. This is answer-shape intent metadata,
+    // not source-grounding or retrieval truth.
     plannerTemperament?: PartialResponseTemperament;
     retrieval?: ResponseMetadataRetrievalContext;
     trustGraphEvidenceAvailable?: boolean;
@@ -816,6 +818,12 @@ const normalizeToolReasonCode = (
 /**
  * Builds canonical ResponseMetadata for trace storage and UI rendering.
  * All values are derived from control-plane context and API annotations.
+ *
+ * Semantics guardrail:
+ * - execution/workflow/workflowMode/steerabilityControls are structural records.
+ * - provenance/provenanceAssessment/chip scores may include deterministic
+ *   heuristic derivation when structural evidence is partial.
+ * - TRACE temperament is response posture metadata, separate from provenance.
  */
 const buildResponseMetadata = (
     assistantMetadata: AssistantResponseMetadata,

--- a/packages/backend/src/services/responseMetadataHeuristics.ts
+++ b/packages/backend/src/services/responseMetadataHeuristics.ts
@@ -1,5 +1,5 @@
 /**
- * @description: Centralizes deterministic TRACE metadata fallbacks used during reflect response assembly.
+ * @description: Centralizes deterministic (but heuristic-derived) TRACE/provenance metadata fallbacks used during reflect response assembly.
  * @footnote-scope: utility
  * @footnote-module: ResponseMetadataHeuristics
  * @footnote-risk: medium - Incorrect fallback rules can misstate metadata chips or tradeoff visibility.
@@ -150,6 +150,10 @@ type ProvenanceClassificationResult = {
 /**
  * Deterministic multi-signal provenance classification with explicit method
  * disclosure, conflict signaling, and conservative uncertainty language.
+ *
+ * This function does not emit structural execution fact records. It emits a
+ * compact classification from available signals, and explicitly records where
+ * those signals conflict or remain incomplete.
  */
 export const classifyProvenanceWithSignals = (
     input: ProvenanceClassificationInput

--- a/packages/contracts/src/ethics-core/types.ts
+++ b/packages/contracts/src/ethics-core/types.ts
@@ -26,6 +26,10 @@ export type SafetyRuleId =
 
 /**
  * Provenance describes where the answer "came from" at a high level.
+ *
+ * This is a backend classification label. It is deterministic for a given
+ * signal set, but signal availability is still evolving, so callers should
+ * treat this as a compact summary rather than raw execution truth.
  */
 export type Provenance = 'Retrieved' | 'Inferred' | 'Speculative';
 
@@ -94,6 +98,9 @@ export type ResponseTemperament = {
 /**
  * PartialResponseTemperament allows missing TRACE axes.
  * Missing values are interpreted by renderers as unavailable.
+ *
+ * TRACE is answer-posture metadata, not source-grounding metadata. Do not
+ * treat this as a provenance substitute.
  */
 export type PartialResponseTemperament = Partial<ResponseTemperament>;
 
@@ -613,28 +620,35 @@ export type TrustGraphMetadata = {
  * ResponseMetadata is the compact record attached to a model response.
  */
 export type ResponseMetadata = {
+    // TODO(metadata-stability-tiers): Publish explicit stability tiers
+    // (structural, heuristic, transitional) in one machine-readable contract
+    // so consumers do not infer truth guarantees from optionality alone.
     responseId: string; // Short id for trace lookups and links.
-    provenance: Provenance; // High-level origin label for the response.
+    provenance: Provenance; // High-level grounding classification for the response.
     safetyTier: SafetyTier; // Sensitivity level used by UI and reviewers.
-    tradeoffCount: number; // Number of trade-offs the model surfaced.
+    tradeoffCount: number; // Heuristic-friendly summary count from assistant metadata with planner fallback.
     chainHash: string; // Short hash to help detect tampering.
     licenseContext: string; // Human-readable license label.
     /** @deprecated Prefer execution[] as the canonical model/runtime timeline. */
+    // TODO(metadata-compat-model-version): Remove after downstream consumers
+    // migrate to execution[] generation events as their model authority.
     modelVersion: string; // Compatibility mirror of the final generation model.
     staleAfter: string; // ISO timestamp after which the data is stale.
     totalDurationMs?: number; // End-to-end orchestration duration when available.
     citations: Citation[]; // Sources used for the answer.
-    provenanceAssessment?: ProvenanceAssessment; // Deterministic method disclosure for provenance labeling.
-    execution?: ExecutionEvent[]; // Canonical execution timeline for model/tool visibility.
+    provenanceAssessment?: ProvenanceAssessment; // Method disclosure for provenance classification, including conflicts and limitations.
+    execution?: ExecutionEvent[]; // Preferred structural execution timeline for model/tool visibility.
     workflow?: WorkflowRecord; // Optional workflow provenance record for bounded multi-step execution.
     workflowMode?: WorkflowModeDecision; // Explicit mode routing decision and behavior mapping.
     steerabilityControls?: SteerabilityControls; // Canonical control records explaining which steering choices shaped execution.
     evaluator?: EvaluatorOutcome; // Deterministic evaluator decision captured before breaker enforcement.
     imageDescriptions?: string[]; // Optional captions for any images used.
-    evidenceScore?: TraceAxisScore; // Optional TRACE evidence chip score (1..5).
-    freshnessScore?: TraceAxisScore; // Optional TRACE freshness chip score (1..5).
+    evidenceScore?: TraceAxisScore; // Optional TRACE chip; may be derived when Retrieved and explicit chip values are absent.
+    freshnessScore?: TraceAxisScore; // Optional TRACE chip; may be derived when Retrieved and explicit chip values are absent.
     // TODO(TRACE-rollout): Make required after TRACE ingestion and rendering
     // paths are fully implemented and validated across surfaces.
+    // TODO(trace-target-vs-final-contract): Split target vs final TRACE once
+    // review-time runtime can revise response posture after planning.
     temperament?: PartialResponseTemperament;
     trustGraph?: TrustGraphMetadata;
 };

--- a/packages/contracts/src/web/schemas.ts
+++ b/packages/contracts/src/web/schemas.ts
@@ -667,7 +667,7 @@ const responseMetadataShape = {
     tradeoffCount: z.number().nonnegative(),
     chainHash: z.string(),
     licenseContext: z.string(),
-    // Deprecated compatibility field; prefer execution[].
+    // Deprecated compatibility field; prefer execution[] as structural timeline authority.
     modelVersion: z.string(),
     staleAfter: z.string(),
     totalDurationMs: z.number().int().nonnegative().optional(),
@@ -681,6 +681,7 @@ const responseMetadataShape = {
     imageDescriptions: z.array(z.string()).optional(),
     evidenceScore: TraceAxisScoreSchema.optional(),
     freshnessScore: TraceAxisScoreSchema.optional(),
+    // TRACE posture metadata; related to provenance but not equivalent.
     temperament: PartialResponseTemperamentSchema.optional(),
     trustGraph: TrustGraphMetadataSchema.optional(),
 } as const;
@@ -693,10 +694,21 @@ const TraceCardChipDataSchema = z
     .strict();
 
 /**
- * Response metadata is intentionally tolerant so new backend fields do not break clients.
+ * Response metadata is intentionally tolerant so additive backend fields do not
+ * break clients.
+ *
+ * Stability guidance for consumers:
+ * - Prefer execution/workflow/workflowMode/steerabilityControls/trustGraph for
+ *   structural runtime facts when present.
+ * - Treat provenance/provenanceAssessment/tradeoffCount/chip scores as
+ *   compact classifications that can include heuristic derivation.
+ * - Treat modelVersion as compatibility-shaped and transitional.
+ *
  * TODO(metadata-stability-tiers): Once field stability tiers are published for
  * external consumers, tighten this boundary deliberately without breaking
  * compatibility-shaped rollout paths.
+ * TODO(metadata-compat-model-version): Remove modelVersion from this shape
+ * once compatibility consumers migrate fully to execution[] generation events.
  */
 export const ResponseMetadataSchema: z.ZodType<ResponseMetadata> = z
     .object(responseMetadataShape)


### PR DESCRIPTION
## What Changed
- Clarified metadata semantics in the core contracts so contributors can distinguish structural runtime records from heuristic-derived summaries and transitional compatibility fields.
- Added explicit TRACE vs provenance guidance in shared metadata types and web schema comments.
- Updated backend metadata assembly comments to document semantic guardrails during `ResponseMetadata` construction.
- Added targeted TODO seam markers for:
  - metadata stability tier publication
  - eventual retirement of the `modelVersion` compatibility mirror
  - future TRACE target-vs-final separation

## Why This Was Needed
The current metadata surface is useful, but fields do not all carry the same kind of truth. This PR reduces the risk of contributors or downstream consumers treating heuristic or compatibility-shaped fields as hard execution fact.

It aligns the implementation with the architecture goal of clearer metadata meaning without redesigning schemas or changing runtime behavior.

## Important Implementation Details
- Scope is intentionally narrow and comment/JSDoc-focused across boundary files:
  - `packages/contracts/src/ethics-core/types.ts`
  - `packages/contracts/src/web/schemas.ts`
  - `packages/backend/src/services/openaiService.ts`
  - `packages/backend/src/services/responseMetadataHeuristics.ts`
- Clarifications explicitly separate:
  - structural records (`execution`, `workflow`, `workflowMode`, `steerabilityControls`, `trustGraph`)
  - deterministic but heuristic classifications (`provenance`, `provenanceAssessment`, chip derivations, tradeoff count)
  - transitional compatibility mirrors (`modelVersion`)
- No schema shape changes or behavior changes were introduced.

This PR was written using [Vibe Kanban](https://vibekanban.com)
