### PR TITLE
Improve boundary comments and JSDoc readability (Vibe Kanban)

### DIFF
--- a/packages/backend/src/services/chatOrchestrator.ts
+++ b/packages/backend/src/services/chatOrchestrator.ts
@@ -80,8 +80,12 @@ const plannerFallbackTelemetryRollup = createPlannerFallbackTelemetryRollup({
 });
 
 /**
- * The orchestrator keeps surface-specific policy in one place while reusing the
- * shared message-generation service for any branch that ends in text output.
+ * Builds the backend chat orchestration entry point shared by web and Discord.
+ *
+ * Ownership here is narrow but important:
+ * - this module coordinates the order of decisions for one request
+ * - it does not redefine planner policy, workflow contracts, or model catalog rules
+ * - it delegates final text generation to ChatService once routing is settled
  */
 export const createChatOrchestrator = ({
     generationRuntime,
@@ -183,11 +187,11 @@ export const createChatOrchestrator = ({
     });
 
     /**
-     * Runs one chat request end-to-end:
-     * 1) normalize conversation shape by surface
-     * 2) plan action/modality
-     * 3) apply surface policy guardrails
-     * 4) execute message generation when action requires text output
+     * Runs one chat request end-to-end.
+     *
+     * Order matters here. Earlier steps produce the facts that later steps are
+     * allowed to use, so this function is the place to read when response
+     * ownership or precedence feels unclear.
      */
     const runChat = async (
         request: PostChatRequest
@@ -372,6 +376,8 @@ export const createChatOrchestrator = ({
             executionContractResponseMode:
                 generationForExecution.responseIntentHint?.responseMode,
         });
+        // Mode chooses the intended run posture first. The execution contract
+        // then makes that posture concrete for the rest of orchestration.
         // TODO(workflow-mode-escalation): Add optional runtime mode transitions
         // (for example fast -> grounded) when later retrieval/sufficiency
         // signals justify escalation. This is future behavior only, and should
@@ -655,8 +661,9 @@ export const createChatOrchestrator = ({
         const executionContractScopeTuple =
             buildExecutionContractScopeTuple(normalizedRequest);
 
-        // Generation receives resolved provider/capabilities from the active
-        // default model profile instead of relying on provider-name checks.
+        // Generation receives resolved provider/capabilities from the selected
+        // response profile. By this point, planner suggestions and request
+        // hints have already been reduced to one backend-owned execution plan.
         const response = await chatService.runChatMessages({
             messages: conversationMessages,
             conversationSnapshot: JSON.stringify({

--- a/packages/backend/src/services/chatOrchestrator.ts
+++ b/packages/backend/src/services/chatOrchestrator.ts
@@ -80,12 +80,11 @@ const plannerFallbackTelemetryRollup = createPlannerFallbackTelemetryRollup({
 });
 
 /**
- * Builds the backend chat orchestration entry point shared by web and Discord.
+ * Entry point for chat requests from web and Discord.
  *
- * Ownership here is narrow but important:
- * - this module coordinates the order of decisions for one request
- * - it does not redefine planner policy, workflow contracts, or model catalog rules
- * - it delegates final text generation to ChatService once routing is settled
+ * Most of the work here is deciding what kind of response we are about to
+ * produce. Once that is settled, ChatService handles the actual text
+ * generation.
  */
 export const createChatOrchestrator = ({
     generationRuntime,
@@ -189,9 +188,9 @@ export const createChatOrchestrator = ({
     /**
      * Runs one chat request end-to-end.
      *
-     * Order matters here. Earlier steps produce the facts that later steps are
-     * allowed to use, so this function is the place to read when response
-     * ownership or precedence feels unclear.
+     * The order is easy to miss: normalize the request, run the evaluator,
+     * ask the planner, narrow the profile and tool choices, then generate if
+     * we still owe the caller a message.
      */
     const runChat = async (
         request: PostChatRequest
@@ -376,8 +375,8 @@ export const createChatOrchestrator = ({
             executionContractResponseMode:
                 generationForExecution.responseIntentHint?.responseMode,
         });
-        // Mode chooses the intended run posture first. The execution contract
-        // then makes that posture concrete for the rest of orchestration.
+        // Pick the run mode first, then derive the contract from it. That keeps
+        // later branches from inventing their own policy rules.
         // TODO(workflow-mode-escalation): Add optional runtime mode transitions
         // (for example fast -> grounded) when later retrieval/sufficiency
         // signals justify escalation. This is future behavior only, and should
@@ -661,9 +660,9 @@ export const createChatOrchestrator = ({
         const executionContractScopeTuple =
             buildExecutionContractScopeTuple(normalizedRequest);
 
-        // Generation receives resolved provider/capabilities from the selected
-        // response profile. By this point, planner suggestions and request
-        // hints have already been reduced to one backend-owned execution plan.
+        // By the time we call ChatService, planner output and request overrides
+        // have already been folded into one concrete profile and generation
+        // plan.
         const response = await chatService.runChatMessages({
             messages: conversationMessages,
             conversationSnapshot: JSON.stringify({

--- a/packages/backend/src/services/chatOrchestrator/actionResolution.ts
+++ b/packages/backend/src/services/chatOrchestrator/actionResolution.ts
@@ -37,6 +37,9 @@ export const resolveNonMessagePlannerAction = (
     input: ResolvePlannerActionInput,
     runtime: ResolvePlannerActionRuntime
 ): PostChatResponse | undefined => {
+    // This helper only handles branches that return before text generation.
+    // Message responses continue through the main orchestrator path because
+    // they still need profile resolution, generation, and metadata assembly.
     if (input.executionPlan.action === 'ignore') {
         runtime.notifyBreakerEvent({
             responseId: null,
@@ -85,6 +88,8 @@ export const resolveNonMessagePlannerAction = (
         input.executionPlan.action === 'image' &&
         !input.executionPlan.imageRequest
     ) {
+        // An image action without image instructions is not actionable.
+        // Fall back to ignore instead of guessing at a prompt.
         runtime.fallbackReasons.push('image_action_missing_image_request');
         runtime.warn(
             `Chat planner returned image without imageRequest; falling back to ignore. surface=${input.normalizedRequest.surface} trigger=${input.normalizedRequest.trigger.kind} latestUserInputLength=${input.normalizedRequest.latestUserInput.length}`

--- a/packages/backend/src/services/chatOrchestrator/plannerPayload.ts
+++ b/packages/backend/src/services/chatOrchestrator/plannerPayload.ts
@@ -14,10 +14,21 @@ type PlannerWeatherFailureMarker = {
     reason: 'weather_tool_failed';
 };
 
+/**
+ * Planner generation payload after execution-time normalization.
+ *
+ * This stays close to `ChatGenerationPlan`, but it can carry a small amount of
+ * transitional runtime context needed by prompt rendering.
+ */
 export type PlannerGenerationForPrompt = Omit<ChatGenerationPlan, 'weather'> & {
     weather?: ChatGenerationPlan['weather'] | PlannerWeatherFailureMarker;
 };
 
+/**
+ * Planner decision payload serialized into generation prompts.
+ *
+ * This is a transport shape between backend stages, not a public API contract.
+ */
 export type PlannerPayloadChatPlan = Omit<ChatPlan, 'generation'> & {
     generation: PlannerGenerationForPrompt;
 };

--- a/packages/backend/src/services/chatOrchestrator/profileResolution.ts
+++ b/packages/backend/src/services/chatOrchestrator/profileResolution.ts
@@ -57,6 +57,17 @@ type ResolveExecutionProfileResult = {
     fallbackReasons: PlannerFallbackReason[];
 };
 
+/**
+ * Resolves the final response profile for one request after planning.
+ *
+ * This is the main precedence seam for profile choice:
+ * - request profile may win when policy allows explicit override
+ * - planner capability selection may win when routing is capability-first
+ * - default profile remains the fail-open landing point
+ *
+ * This resolver does not execute tools and does not treat the planner as final
+ * authority. It picks the safest usable profile for the rest of orchestration.
+ */
 export const resolveExecutionProfile = (
     input: ResolveExecutionProfileInput,
     onWarn: {
@@ -197,6 +208,9 @@ export const resolveExecutionProfile = (
         generationForExecution.search &&
         !selectedResponseProfile.capabilities.canUseSearch
     ) {
+        // Search intent stays attached to the request, but the selected profile
+        // may not be able to fulfill it. Reroute logic lives here so callers do
+        // not have to duplicate "search requested vs search possible" handling.
         const searchPolicySelectionSource: PlannerSelectionSource =
             selectedCapabilityDecision.reasonCode ===
             'planner_requested_capability_profile_no_floor_match'

--- a/packages/backend/src/services/chatOrchestrator/profileResolution.ts
+++ b/packages/backend/src/services/chatOrchestrator/profileResolution.ts
@@ -58,15 +58,11 @@ type ResolveExecutionProfileResult = {
 };
 
 /**
- * Resolves the final response profile for one request after planning.
+ * Chooses the model profile we will actually use for this response.
  *
- * This is the main precedence seam for profile choice:
- * - request profile may win when policy allows explicit override
- * - planner capability selection may win when routing is capability-first
- * - default profile remains the fail-open landing point
- *
- * This resolver does not execute tools and does not treat the planner as final
- * authority. It picks the safest usable profile for the rest of orchestration.
+ * The easy mistake is to treat planner output as the final answer. It is only
+ * one input here. A request-level override may win, and the default profile is
+ * still the fallback if the requested or planned choice is missing or disabled.
  */
 export const resolveExecutionProfile = (
     input: ResolveExecutionProfileInput,
@@ -208,9 +204,9 @@ export const resolveExecutionProfile = (
         generationForExecution.search &&
         !selectedResponseProfile.capabilities.canUseSearch
     ) {
-        // Search intent stays attached to the request, but the selected profile
-        // may not be able to fulfill it. Reroute logic lives here so callers do
-        // not have to duplicate "search requested vs search possible" handling.
+        // A plan can ask for search and still land on a profile that cannot
+        // search. Handle that mismatch here so the rest of the orchestrator can
+        // work with one resolved profile.
         const searchPolicySelectionSource: PlannerSelectionSource =
             selectedCapabilityDecision.reasonCode ===
             'planner_requested_capability_profile_no_floor_match'

--- a/packages/backend/src/services/chatPlanner.ts
+++ b/packages/backend/src/services/chatPlanner.ts
@@ -84,7 +84,7 @@ export type ChatPlannerExecution = {
 
 export type ChatPlannerResult = {
     // Always populated: either planner-derived or fail-open fallback plan.
-    // Callers should branch on this internal plan, not on raw planner output.
+    // Use this normalized plan, not the raw model output.
     plan: ChatPlan;
     // Execution telemetry used by orchestrator metadata emission.
     execution: ChatPlannerExecution;
@@ -105,14 +105,14 @@ type PlannerContextReasonCode =
     | 'planner_context_timeout_fail_open';
 
 export type PlannerNormalizationResult = {
-    // Backend-owned plan after coercion, validation, and safe defaults.
+    // Plan after we cleaned up planner output and filled in safe defaults.
     plan: ChatPlan;
-    // How much cleanup or fallback was needed to make planner output usable.
+    // How much we had to correct or fall back before the plan was safe to use.
     fallbackTier: PlannerFallbackTier;
     correctionCodes: string[];
     contextNeed: PlannerContextNeed;
     contextTier: PlannerContextTier;
-    // Whether workflow-owned policy applied the candidate cleanly.
+    // Whether the caller could use the candidate as-is or had to adjust it.
     applyOutcome: PlannerOutputApplyOutcome;
     outOfContractFields: string[];
     authorityFieldAttempts: string[];
@@ -127,9 +127,9 @@ const UNICODE_SINGLE_EMOJI_PATTERN =
  * Planner decision consumed by the chat orchestrator after the raw LLM
  * output has been normalized and safety-checked.
  *
- * This is an execution suggestion, not an authority record. The orchestrator
- * may still coerce the action for surface limits, profile policy, or tool
- * availability.
+ * This is what the planner wanted us to do after normalization. It is still
+ * just input to orchestration. Surface rules, profile selection, and tool
+ * availability can still change the final behavior.
  */
 export type ChatPlan = {
     action: ChatPlannerAction;
@@ -149,8 +149,8 @@ export type ChatPlan = {
 
 export type ChatPlannerCapabilityProfileOption = {
     id: CapabilityProfileId;
-    // Human-readable hint for the planner. This is guidance, not a guarantee
-    // that the final response will use this exact profile.
+    // Short description shown to the planner so it can ask for the right kind
+    // of model. The final model can still change after routing and fallback.
     description: string;
 };
 
@@ -1229,11 +1229,11 @@ const normalizePlan = (
 };
 
 /**
- * Builds the planner adapter used by chat orchestration.
+ * Creates the planner wrapper used by chat orchestration.
  *
- * This factory owns planner execution, normalization, and compatibility
- * fallback. It does not own the final decision to run tools, pick a response
- * profile, or emit a user-visible action unchanged.
+ * This code runs the planner, cleans up its output, and falls back when the
+ * model returns something unusable. It does not get the last word on tools,
+ * profiles, or the final response.
  */
 export const createChatPlanner = ({
     executePlanner,
@@ -1250,8 +1250,8 @@ export const createChatPlanner = ({
         );
     }
 
-    // Keep planner context intentionally narrow so the model can choose among
-    // stable options without learning backend-only catalog details.
+    // Keep this input small. The planner needs enough context to choose well,
+    // but not the whole profile catalog or backend config.
     const plannerCapabilityContext =
         availableCapabilityProfiles.length > 0
             ? JSON.stringify(

--- a/packages/backend/src/services/chatPlanner.ts
+++ b/packages/backend/src/services/chatPlanner.ts
@@ -84,6 +84,7 @@ export type ChatPlannerExecution = {
 
 export type ChatPlannerResult = {
     // Always populated: either planner-derived or fail-open fallback plan.
+    // Callers should branch on this internal plan, not on raw planner output.
     plan: ChatPlan;
     // Execution telemetry used by orchestrator metadata emission.
     execution: ChatPlannerExecution;
@@ -104,11 +105,14 @@ type PlannerContextReasonCode =
     | 'planner_context_timeout_fail_open';
 
 export type PlannerNormalizationResult = {
+    // Backend-owned plan after coercion, validation, and safe defaults.
     plan: ChatPlan;
+    // How much cleanup or fallback was needed to make planner output usable.
     fallbackTier: PlannerFallbackTier;
     correctionCodes: string[];
     contextNeed: PlannerContextNeed;
     contextTier: PlannerContextTier;
+    // Whether workflow-owned policy applied the candidate cleanly.
     applyOutcome: PlannerOutputApplyOutcome;
     outOfContractFields: string[];
     authorityFieldAttempts: string[];
@@ -122,6 +126,10 @@ const UNICODE_SINGLE_EMOJI_PATTERN =
 /**
  * Planner decision consumed by the chat orchestrator after the raw LLM
  * output has been normalized and safety-checked.
+ *
+ * This is an execution suggestion, not an authority record. The orchestrator
+ * may still coerce the action for surface limits, profile policy, or tool
+ * availability.
  */
 export type ChatPlan = {
     action: ChatPlannerAction;
@@ -141,7 +149,8 @@ export type ChatPlan = {
 
 export type ChatPlannerCapabilityProfileOption = {
     id: CapabilityProfileId;
-    // Human-readable capability hint shown to planner.
+    // Human-readable hint for the planner. This is guidance, not a guarantee
+    // that the final response will use this exact profile.
     description: string;
 };
 
@@ -1220,9 +1229,11 @@ const normalizePlan = (
 };
 
 /**
- * Builds the backend-native planner used by the universal chat workflow.
- * It returns an internal plan shape and logs its reasoning in development so
- * planner drift is visible during pre-production rollout.
+ * Builds the planner adapter used by chat orchestration.
+ *
+ * This factory owns planner execution, normalization, and compatibility
+ * fallback. It does not own the final decision to run tools, pick a response
+ * profile, or emit a user-visible action unchanged.
  */
 export const createChatPlanner = ({
     executePlanner,
@@ -1239,8 +1250,8 @@ export const createChatPlanner = ({
         );
     }
 
-    // Keep planner context intentionally narrow.
-    // We expose only decision-relevant fields, not full raw catalog config.
+    // Keep planner context intentionally narrow so the model can choose among
+    // stable options without learning backend-only catalog details.
     const plannerCapabilityContext =
         availableCapabilityProfiles.length > 0
             ? JSON.stringify(

--- a/packages/backend/src/services/executionContractResolver.ts
+++ b/packages/backend/src/services/executionContractResolver.ts
@@ -58,15 +58,25 @@ const isBuiltinExecutionContractPresetId = (
     Object.prototype.hasOwnProperty.call(EXECUTION_CONTRACT_PRESETS, value);
 
 export type ExecutionContractResolverInput = {
+    /** Optional named preset requested by config or caller assembly. */
     presetId?: ExecutionContractPresetId | null;
+    /** Optional explicit policy id override for the final assembled contract. */
     policyId?: ExecutionContractId;
+    /** Optional display label override for logs and operator views. */
     displayName?: string;
+    /** Final field-level overrides applied after preset defaults. */
     overrides?: ExecutionContractOverrides;
 };
 
 export type ExecutionContractResolverResolution = {
+    /**
+     * Preset id after trimming. This may still be unknown.
+     * Use `isKnownPresetId` to tell whether it matched a built-in preset.
+     */
     requestedPresetId?: ExecutionContractPresetId;
+    /** `true` only when the requested id mapped to a built-in preset. */
     isKnownPresetId: boolean;
+    /** Final canonical contract used by runtime code. */
     policyContract: ExecutionContract;
 };
 
@@ -75,6 +85,9 @@ export type ExecutionContractResolverResolution = {
  * 1) canonical defaults in the builder,
  * 2) optional built-in preset overrides,
  * 3) explicit call-site overrides.
+ *
+ * Unknown preset ids do not fail closed. They are preserved for reporting, then
+ * the resolver falls back to the default built-in descriptor.
  */
 export const resolveExecutionContract = (
     input: ExecutionContractResolverInput

--- a/packages/backend/src/services/executionContractResolver.ts
+++ b/packages/backend/src/services/executionContractResolver.ts
@@ -58,25 +58,24 @@ const isBuiltinExecutionContractPresetId = (
     Object.prototype.hasOwnProperty.call(EXECUTION_CONTRACT_PRESETS, value);
 
 export type ExecutionContractResolverInput = {
-    /** Optional named preset requested by config or caller assembly. */
+    /** Preset id requested by config or the caller. */
     presetId?: ExecutionContractPresetId | null;
-    /** Optional explicit policy id override for the final assembled contract. */
+    /** Override for the final policy id, if the caller wants one. */
     policyId?: ExecutionContractId;
-    /** Optional display label override for logs and operator views. */
+    /** Display name override for logs and operator views. */
     displayName?: string;
-    /** Final field-level overrides applied after preset defaults. */
+    /** Field-level overrides applied after defaults and any preset. */
     overrides?: ExecutionContractOverrides;
 };
 
 export type ExecutionContractResolverResolution = {
     /**
-     * Preset id after trimming. This may still be unknown.
-     * Use `isKnownPresetId` to tell whether it matched a built-in preset.
+     * Preset id after trimming. This may still be an unknown value.
      */
     requestedPresetId?: ExecutionContractPresetId;
-    /** `true` only when the requested id mapped to a built-in preset. */
+    /** Whether the requested id matched one of the built-in presets. */
     isKnownPresetId: boolean;
-    /** Final canonical contract used by runtime code. */
+    /** Final contract the runtime will use. */
     policyContract: ExecutionContract;
 };
 
@@ -86,8 +85,8 @@ export type ExecutionContractResolverResolution = {
  * 2) optional built-in preset overrides,
  * 3) explicit call-site overrides.
  *
- * Unknown preset ids do not fail closed. They are preserved for reporting, then
- * the resolver falls back to the default built-in descriptor.
+ * If the preset id is unknown, keep it for reporting and fall back to the
+ * default built-in preset instead of throwing.
  */
 export const resolveExecutionContract = (
     input: ExecutionContractResolverInput

--- a/packages/backend/src/services/executionContractTrustGraph/runtimeWiring.ts
+++ b/packages/backend/src/services/executionContractTrustGraph/runtimeWiring.ts
@@ -43,6 +43,13 @@ const requireHttpAdapterConfig = (input: {
     };
 };
 
+/**
+ * Converts TrustGraph runtime config into the optional chat-service seam.
+ *
+ * This module wires adapters and validators. It does not decide whether
+ * external evidence is sufficient for an answer, and it does not create a
+ * second policy authority beside the backend execution contract.
+ */
 export const resolveExecutionContractTrustGraphRuntimeOptions = (
     config: ExecutionContractTrustGraphRuntimeConfig
 ): CreateChatServiceOptions['executionContractTrustGraph'] | undefined => {
@@ -92,6 +99,8 @@ export const resolveExecutionContractTrustGraphRuntimeOptions = (
           >['scopeOwnershipValidator']
         | undefined;
     if (config.ownership.bindingMode === 'http') {
+        // Missing ownership wiring fails open at the adapter seam. Retrieval may
+        // still be disabled later by downstream validation or caller policy.
         if (!isNonEmptyString(config.ownership.endpointUrl)) {
             logger.warn({
                 event: 'chat.execution_contract_trustgraph.ownership_wiring',

--- a/packages/backend/src/services/openaiService/metadata.ts
+++ b/packages/backend/src/services/openaiService/metadata.ts
@@ -37,7 +37,7 @@ import type {
 } from './types.js';
 
 // Owns: response metadata assembly and normalization of execution metadata fields.
-// Does not own: provider request execution, planner authority, or orchestrator policy decisions.
+// Does not own: making provider calls or deciding chat policy.
 
 const TRACE_AXIS_KEYS = [
     'tightness',
@@ -303,9 +303,9 @@ const buildResponseMetadata = (
         // add explicit attempt/correlation metadata without letting planner
         // events redefine orchestration authority or step ownership.
         // Treat this block as metadata ingestion only, not a policy hook.
-        // This block converts runtime-local planner metadata into the shared
-        // execution timeline contract. Invalid fields are dropped here instead
-        // of leaking partial planner records into stored traces.
+        // Turn the planner record from runtime context into the shared
+        // execution-event shape. If required fields are missing, drop it here
+        // instead of storing something half-valid.
         const normalizedPlannerReasonCode = normalizePlannerReasonCode(
             plannerExecution.status,
             plannerExecution.reasonCode
@@ -413,8 +413,8 @@ const buildResponseMetadata = (
     }
     const evaluatorExecution = runtimeContext.executionContext?.evaluator;
     if (evaluatorExecution) {
-        // Evaluator records are already policy outcomes. Metadata assembly only
-        // mirrors them into the canonical response timeline.
+        // The evaluator already decided this. We are only copying that result
+        // into the response timeline.
         const normalizedEvaluatorReasonCode = normalizeEvaluatorReasonCode(
             evaluatorExecution.status,
             evaluatorExecution.reasonCode
@@ -435,8 +435,8 @@ const buildResponseMetadata = (
     }
     const toolExecution = runtimeContext.executionContext?.tool;
     if (toolExecution) {
-        // Tool metadata stays compact on purpose. This timeline says what
-        // happened, not every request argument or result payload.
+        // Keep the tool event compact. Readers usually need to know whether it
+        // ran and how it ended, not the full request payload.
         const normalizedToolReasonCode = normalizeToolReasonCode(
             toolExecution.status,
             toolExecution.reasonCode
@@ -455,8 +455,8 @@ const buildResponseMetadata = (
     }
     const generationExecution = runtimeContext.executionContext?.generation;
     if (generationExecution) {
-        // Generation remains the source of truth for the final response model.
-        // `modelVersion` below is only a compatibility mirror for older readers.
+        // The generation event is the real source of model information.
+        // `modelVersion` below only exists for older consumers.
         const normalizedGenerationReasonCode = normalizeGenerationReasonCode(
             generationExecution.status,
             generationExecution.reasonCode

--- a/packages/backend/src/services/openaiService/metadata.ts
+++ b/packages/backend/src/services/openaiService/metadata.ts
@@ -37,7 +37,7 @@ import type {
 } from './types.js';
 
 // Owns: response metadata assembly and normalization of execution metadata fields.
-// Does not own: provider request execution or orchestrator policy decisions.
+// Does not own: provider request execution, planner authority, or orchestrator policy decisions.
 
 const TRACE_AXIS_KEYS = [
     'tightness',
@@ -303,6 +303,9 @@ const buildResponseMetadata = (
         // add explicit attempt/correlation metadata without letting planner
         // events redefine orchestration authority or step ownership.
         // Treat this block as metadata ingestion only, not a policy hook.
+        // This block converts runtime-local planner metadata into the shared
+        // execution timeline contract. Invalid fields are dropped here instead
+        // of leaking partial planner records into stored traces.
         const normalizedPlannerReasonCode = normalizePlannerReasonCode(
             plannerExecution.status,
             plannerExecution.reasonCode
@@ -410,6 +413,8 @@ const buildResponseMetadata = (
     }
     const evaluatorExecution = runtimeContext.executionContext?.evaluator;
     if (evaluatorExecution) {
+        // Evaluator records are already policy outcomes. Metadata assembly only
+        // mirrors them into the canonical response timeline.
         const normalizedEvaluatorReasonCode = normalizeEvaluatorReasonCode(
             evaluatorExecution.status,
             evaluatorExecution.reasonCode
@@ -430,6 +435,8 @@ const buildResponseMetadata = (
     }
     const toolExecution = runtimeContext.executionContext?.tool;
     if (toolExecution) {
+        // Tool metadata stays compact on purpose. This timeline says what
+        // happened, not every request argument or result payload.
         const normalizedToolReasonCode = normalizeToolReasonCode(
             toolExecution.status,
             toolExecution.reasonCode
@@ -448,6 +455,8 @@ const buildResponseMetadata = (
     }
     const generationExecution = runtimeContext.executionContext?.generation;
     if (generationExecution) {
+        // Generation remains the source of truth for the final response model.
+        // `modelVersion` below is only a compatibility mirror for older readers.
         const normalizedGenerationReasonCode = normalizeGenerationReasonCode(
             generationExecution.status,
             generationExecution.reasonCode

--- a/packages/backend/src/services/workflowProfileRegistry.ts
+++ b/packages/backend/src/services/workflowProfileRegistry.ts
@@ -256,7 +256,9 @@ const inferWorkflowModeIdFromExecutionContract = (
 };
 
 export type WorkflowModeResolution = {
+    /** Final mode record used by downstream runtime assembly. */
     modeDecision: WorkflowModeDecision;
+    /** Whether the request matched a built-in mode directly. */
     isKnownRequestedModeId: boolean;
 };
 
@@ -382,7 +384,9 @@ const toWorkflowProfileContract = (
 export type WorkflowProfileRegistryResolution = {
     requestedProfileId?: string;
     isKnownProfileId: boolean;
+    /** Runtime shape with hooks used by workflow execution. */
     runtimeProfile: RuntimeWorkflowProfile;
+    /** Serializable mirror safe to expose beyond backend runtime. */
     profileContract: WorkflowProfileContract;
 };
 
@@ -428,6 +432,7 @@ export const resolveWorkflowProfileRegistry = (
 export type ResolvedWorkflowRuntimeConfig = {
     // TODO(workflow-mode-final-posture): If runtime mode revisability is added,
     // split mode metadata into initial and final ids instead of overloading one field.
+    /** Requested mode after trimming. Falls back to the resolved mode id. */
     requestedModeId: string;
     modeId: WorkflowModeId;
     modeDecision: WorkflowModeDecision;
@@ -468,6 +473,8 @@ export const resolveWorkflowRuntimeConfig = (input: {
             input.ExecutionContract?.response.responseMode,
     });
     const modeDecision = modeResolution.modeDecision;
+    // Mode picks the posture first. The profile lookup then turns that posture
+    // into a concrete executable workflow shape.
     const profileResolution = resolveWorkflowProfileRegistry(
         modeDecision.behavior.workflowProfileId
     );

--- a/packages/contracts/src/ethics-core/types.ts
+++ b/packages/contracts/src/ethics-core/types.ts
@@ -528,7 +528,7 @@ export type ToolInvocationIntent = {
 
 /**
  * Orchestrator-owned tool eligibility decision before runtime execution.
- * This says whether a tool may be attempted, not whether it eventually ran.
+ * This is the pre-check: should we even try the tool?
  */
 export type ToolInvocationRequest = {
     toolName: ToolInvocationName;
@@ -539,7 +539,7 @@ export type ToolInvocationRequest = {
 
 /**
  * Runtime-owned final tool outcome emitted into execution metadata.
- * This is the "what happened" record after execution or skip handling.
+ * This is the outcome after that check: ran, skipped, or failed.
  */
 export type ToolExecutionContext = {
     toolName: ToolInvocationName;
@@ -588,8 +588,8 @@ export type TrustGraphScopeValidationResult =
       };
 
 export type TrustGraphMetadata = {
-    // TrustGraph metadata is advisory provenance/evidence context. It is not a
-    // replacement for the backend execution contract or workflow decisions.
+    // This says what TrustGraph contributed to the response. It does not
+    // replace the backend's own execution and policy records.
     adapterStatus: 'off' | 'scope_denied' | 'success' | 'timeout' | 'error';
     scopeValidation: TrustGraphScopeValidationResult;
     terminalAuthority: 'backend_execution_contract';
@@ -623,10 +623,9 @@ export type TrustGraphMetadata = {
 /**
  * ResponseMetadata is the compact record attached to a model response.
  *
- * Keep the distinction between fields clear:
- * - structural fields record runtime decisions and execution facts
- * - heuristic fields summarize inferred state when direct evidence is partial
- * - compatibility fields exist only to help older consumers migrate safely
+ * Not every field means the same thing. Some values are direct runtime facts,
+ * some are best-effort summaries, and a few are only here to keep older
+ * consumers working while newer fields roll out.
  */
 export type ResponseMetadata = {
     // TODO(metadata-stability-tiers): Publish explicit stability tiers

--- a/packages/contracts/src/ethics-core/types.ts
+++ b/packages/contracts/src/ethics-core/types.ts
@@ -528,6 +528,7 @@ export type ToolInvocationIntent = {
 
 /**
  * Orchestrator-owned tool eligibility decision before runtime execution.
+ * This says whether a tool may be attempted, not whether it eventually ran.
  */
 export type ToolInvocationRequest = {
     toolName: ToolInvocationName;
@@ -538,6 +539,7 @@ export type ToolInvocationRequest = {
 
 /**
  * Runtime-owned final tool outcome emitted into execution metadata.
+ * This is the "what happened" record after execution or skip handling.
  */
 export type ToolExecutionContext = {
     toolName: ToolInvocationName;
@@ -586,6 +588,8 @@ export type TrustGraphScopeValidationResult =
       };
 
 export type TrustGraphMetadata = {
+    // TrustGraph metadata is advisory provenance/evidence context. It is not a
+    // replacement for the backend execution contract or workflow decisions.
     adapterStatus: 'off' | 'scope_denied' | 'success' | 'timeout' | 'error';
     scopeValidation: TrustGraphScopeValidationResult;
     terminalAuthority: 'backend_execution_contract';
@@ -618,6 +622,11 @@ export type TrustGraphMetadata = {
 
 /**
  * ResponseMetadata is the compact record attached to a model response.
+ *
+ * Keep the distinction between fields clear:
+ * - structural fields record runtime decisions and execution facts
+ * - heuristic fields summarize inferred state when direct evidence is partial
+ * - compatibility fields exist only to help older consumers migrate safely
  */
 export type ResponseMetadata = {
     // TODO(metadata-stability-tiers): Publish explicit stability tiers

--- a/packages/contracts/src/model-profiles.ts
+++ b/packages/contracts/src/model-profiles.ts
@@ -10,8 +10,8 @@ import { z } from 'zod';
 import { supportedProviders } from './providers.js';
 
 /**
- * Stable tier aliases used by callers that want intent-level routing instead of
- * naming one concrete catalog profile id.
+ * Shorthand labels for callers that want "fast" or "quality" style routing
+ * without naming a specific profile id.
  */
 export const modelTierAliases = [
     'text-fast',
@@ -31,8 +31,8 @@ export type ModelLatencyClass = (typeof modelLatencyClasses)[number];
 /**
  * Runtime-facing capability flags for one model profile.
  *
- * These flags describe what the backend may ask this profile to do. They do
- * not override execution policy by themselves.
+ * These are routing hints. A profile advertising a capability does not force
+ * the backend to use it.
  */
 export interface ModelProfileCapabilities {
     canUseSearch: boolean;
@@ -58,7 +58,7 @@ export interface ModelProfile {
 }
 
 /**
- * Runtime capability schema shared by config loading and tests.
+ * Schema used when loading and testing capability flags.
  */
 export const ModelProfileCapabilitiesSchema = z
     .object({
@@ -68,7 +68,7 @@ export const ModelProfileCapabilitiesSchema = z
     .strict();
 
 /**
- * Canonical schema for one catalog entry.
+ * Schema for one model profile entry.
  */
 export const ModelProfileSchema: z.ZodType<ModelProfile> = z
     .object({
@@ -87,10 +87,10 @@ export const ModelProfileSchema: z.ZodType<ModelProfile> = z
     .strict();
 
 /**
- * Canonical schema for the full model profile catalog.
+ * Schema for the full model profile list.
  *
- * Duplicate ids are rejected here so routing code can safely treat `id` as the
- * stable lookup key.
+ * Duplicate ids are rejected here because the rest of the code treats `id` as
+ * the lookup key.
  */
 export const ModelProfileCatalogSchema = z
     .array(ModelProfileSchema)

--- a/packages/contracts/src/model-profiles.ts
+++ b/packages/contracts/src/model-profiles.ts
@@ -9,6 +9,10 @@
 import { z } from 'zod';
 import { supportedProviders } from './providers.js';
 
+/**
+ * Stable tier aliases used by callers that want intent-level routing instead of
+ * naming one concrete catalog profile id.
+ */
 export const modelTierAliases = [
     'text-fast',
     'text-medium',
@@ -16,14 +20,19 @@ export const modelTierAliases = [
 ] as const;
 export type ModelTierAlias = (typeof modelTierAliases)[number];
 
+/** Optional coarse cost bucket for UI and policy hints. */
 export const modelCostClasses = ['low', 'medium', 'high'] as const;
 export type ModelCostClass = (typeof modelCostClasses)[number];
 
+/** Optional coarse latency bucket for UI and policy hints. */
 export const modelLatencyClasses = ['low', 'medium', 'high'] as const;
 export type ModelLatencyClass = (typeof modelLatencyClasses)[number];
 
 /**
  * Runtime-facing capability flags for one model profile.
+ *
+ * These flags describe what the backend may ask this profile to do. They do
+ * not override execution policy by themselves.
  */
 export interface ModelProfileCapabilities {
     canUseSearch: boolean;
@@ -48,6 +57,9 @@ export interface ModelProfile {
     latencyClass?: ModelLatencyClass;
 }
 
+/**
+ * Runtime capability schema shared by config loading and tests.
+ */
 export const ModelProfileCapabilitiesSchema = z
     .object({
         canUseSearch: z.boolean(),
@@ -55,6 +67,9 @@ export const ModelProfileCapabilitiesSchema = z
     })
     .strict();
 
+/**
+ * Canonical schema for one catalog entry.
+ */
 export const ModelProfileSchema: z.ZodType<ModelProfile> = z
     .object({
         id: z.string().regex(/^[a-z0-9][a-z0-9-]{0,63}$/),
@@ -71,6 +86,12 @@ export const ModelProfileSchema: z.ZodType<ModelProfile> = z
     })
     .strict();
 
+/**
+ * Canonical schema for the full model profile catalog.
+ *
+ * Duplicate ids are rejected here so routing code can safely treat `id` as the
+ * stable lookup key.
+ */
 export const ModelProfileCatalogSchema = z
     .array(ModelProfileSchema)
     .superRefine((profiles, context) => {

--- a/packages/contracts/src/web/types.ts
+++ b/packages/contracts/src/web/types.ts
@@ -309,6 +309,12 @@ export type ChatImageRequest = {
 };
 
 /**
+ * Transport-neutral chat request sent into backend orchestration.
+ *
+ * `capabilities` tells the backend what this caller can render or perform.
+ * It does not grant permission to force an action. `surfaceContext` carries
+ * lightweight routing context and should stay serializable.
+ *
  * @api.operationId: postChat
  * @api.path: POST /api/chat
  */
@@ -338,6 +344,9 @@ export type PostChatRequest = {
 };
 
 /**
+ * Text reply variant. This is the only chat response shape that carries
+ * response metadata because it represents a completed generated answer.
+ *
  * @api.operationId: postChat
  * @api.path: POST /api/chat
  */
@@ -349,6 +358,9 @@ export type ChatMessageActionResponse = {
 };
 
 /**
+ * Reaction variant for surfaces that can acknowledge briefly without a full
+ * generated message.
+ *
  * @api.operationId: postChat
  * @api.path: POST /api/chat
  */
@@ -359,6 +371,9 @@ export type ChatReactActionResponse = {
 };
 
 /**
+ * Explicit no-reply variant used when orchestration decides the assistant
+ * should stay silent.
+ *
  * @api.operationId: postChat
  * @api.path: POST /api/chat
  */
@@ -368,6 +383,9 @@ export type ChatIgnoreActionResponse = {
 };
 
 /**
+ * Planner-produced image handoff. The backend returns instructions, not the
+ * rendered asset itself, so surfaces can decide how to fulfill the request.
+ *
  * @api.operationId: postChat
  * @api.path: POST /api/chat
  */
@@ -378,6 +396,9 @@ export type ChatImageActionResponse = {
 };
 
 /**
+ * Unified chat response union for transport-neutral callers.
+ * Check `action` first, then read the fields for that variant.
+ *
  * @api.operationId: postChat
  * @api.path: POST /api/chat
  */

--- a/packages/contracts/src/web/types.ts
+++ b/packages/contracts/src/web/types.ts
@@ -309,11 +309,11 @@ export type ChatImageRequest = {
 };
 
 /**
- * Transport-neutral chat request sent into backend orchestration.
+ * Chat request shape shared by web and Discord callers.
  *
- * `capabilities` tells the backend what this caller can render or perform.
- * It does not grant permission to force an action. `surfaceContext` carries
- * lightweight routing context and should stay serializable.
+ * `capabilities` tells the backend which response types are usable on this
+ * surface. `surfaceContext` is just lightweight request context, not a full
+ * event payload from the caller.
  *
  * @api.operationId: postChat
  * @api.path: POST /api/chat
@@ -344,8 +344,8 @@ export type PostChatRequest = {
 };
 
 /**
- * Text reply variant. This is the only chat response shape that carries
- * response metadata because it represents a completed generated answer.
+ * Text reply. This is the only variant that carries response metadata because
+ * it represents a completed generated answer.
  *
  * @api.operationId: postChat
  * @api.path: POST /api/chat
@@ -358,7 +358,7 @@ export type ChatMessageActionResponse = {
 };
 
 /**
- * Reaction variant for surfaces that can acknowledge briefly without a full
+ * Reaction response for surfaces that can acknowledge briefly without a full
  * generated message.
  *
  * @api.operationId: postChat
@@ -371,8 +371,7 @@ export type ChatReactActionResponse = {
 };
 
 /**
- * Explicit no-reply variant used when orchestration decides the assistant
- * should stay silent.
+ * Explicit no-reply response when the assistant should stay silent.
  *
  * @api.operationId: postChat
  * @api.path: POST /api/chat
@@ -383,8 +382,8 @@ export type ChatIgnoreActionResponse = {
 };
 
 /**
- * Planner-produced image handoff. The backend returns instructions, not the
- * rendered asset itself, so surfaces can decide how to fulfill the request.
+ * Image handoff from planning. The backend returns instructions here, not the
+ * rendered asset, so the caller can decide how to fulfill the request.
  *
  * @api.operationId: postChat
  * @api.path: POST /api/chat
@@ -396,8 +395,8 @@ export type ChatImageActionResponse = {
 };
 
 /**
- * Unified chat response union for transport-neutral callers.
- * Check `action` first, then read the fields for that variant.
+ * Union of all chat response variants. Check `action` first, then read the
+ * fields for that branch.
  *
  * @api.operationId: postChat
  * @api.path: POST /api/chat


### PR DESCRIPTION
## Summary
Improves comment quality and JSDoc coverage in boundary-heavy backend and contracts code so contributors can read behavior and responsibilities directly from the code.

## What Changed
- Refined comments and JSDoc across 12 files in `packages/backend` and `packages/contracts`.
- Focused updates on orchestration flow, profile-resolution precedence, planner normalization intent, metadata assembly, trust/tool/execution contract types, and chat API response/request contract notes.
- Reworked newly added comments to read more naturally for maintainers (less glossary-style wording, more local code context).
- Kept scope intentionally narrow to comment/JSDoc changes only.

## Why
Recent semantics hardening made boundaries and transitional behavior more explicit in implementation. This PR makes those decisions easier to understand in-place, reducing misreads around:
- where decisions are made vs. where they are only recorded,
- which inputs are advisory vs. final at runtime,
- and how fallback/compatibility paths are intended to behave.

## Implementation Notes
- No runtime logic changes; this is documentation-in-code only.
- Prioritized files where contributors are most likely to misread responsibility or precedence:
  - chat orchestration and planner integration
  - execution/profile resolvers
  - response metadata assembly
  - shared contracts used across surfaces
- Comments were revised to explain likely confusion points and bad assumptions, not to restate obvious code.

This PR was written using [Vibe Kanban](https://vibekanban.com)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Improved internal code documentation and comments across backend services and contract definitions to clarify system behavior, execution flow, and component responsibilities without functional changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->