### PR TITLE
Add Bounded Workflow Mode Escalation Seam and Metadata Lineage (Vibe Kanban)

### DIFF
--- a/docs/architecture/workflow-mode-routing.md
+++ b/docs/architecture/workflow-mode-routing.md
@@ -51,13 +51,23 @@ This keeps the system available while preferring the more careful default
 posture.
 These fallback steps are initial routing fallback only. They are not runtime
 mode escalation.
-Initial mode selection is not revisable later in current runtime behavior.
-Future escalation should attach to the centralized mode resolver path instead
-of introducing parallel routing logic.
+
+## Escalation Seam
+
+Workflow mode escalation is attached at one bounded seam in
+`resolveWorkflowRuntimeConfig` (`packages/backend/src/services/workflowProfileRegistry.ts`).
+
+Rules for this seam:
+
+- Resolve initial mode once using the normal selection order.
+- Optionally apply one workflow-owned escalation request.
+- Never run recursive or unbounded mode re-evaluation loops.
+- Keep escalation routing centralized in workflow resolver code, not callers.
 
 ## Metadata Contract
 
 `workflowMode` in response metadata records `modeId`, `selectedBy`,
-`selectionReason`, optional `requestedModeId`, optional
+`selectionReason`, `initial_mode`, optional `escalated_mode`, optional
+`escalation_reason`, optional `requestedModeId`, optional
 `executionContractResponseMode`, and `behavior` (the concrete mapped behavior
 tuple).

--- a/packages/backend/src/services/chatService.ts
+++ b/packages/backend/src/services/chatService.ts
@@ -41,7 +41,10 @@ import type { ChatGenerationPlan } from './chatGenerationTypes.js';
 import type { ExecutionContract } from './executionContract.js';
 import { renderConversationPromptLayers } from './prompts/conversationPromptLayers.js';
 import { resolveNoGenerationHandlingFromTermination } from './workflowProfileContract.js';
-import { resolveWorkflowRuntimeConfig } from './workflowProfileRegistry.js';
+import {
+    resolveWorkflowRuntimeConfig,
+    type WorkflowModeEscalationRequest,
+} from './workflowProfileRegistry.js';
 import {
     runBoundedReviewWorkflow,
     type RunBoundedReviewWorkflowResult,
@@ -373,6 +376,7 @@ export type RunChatMessagesInput = {
     generation?: ChatGenerationPlan;
     executionContext?: ResponseMetadataRuntimeContext['executionContext'];
     workflowModeId?: string;
+    workflowModeEscalationRequest?: WorkflowModeEscalationRequest;
     toolRequest?: ToolInvocationRequest;
     executionContractTrustGraphContext?: ExecutionContractTrustGraphContext;
     ExecutionContract?: ExecutionContract;
@@ -495,6 +499,7 @@ export const createChatService = ({
         generation,
         executionContext,
         workflowModeId,
+        workflowModeEscalationRequest,
         toolRequest,
         executionContractTrustGraphContext,
         ExecutionContract,
@@ -555,6 +560,7 @@ export const createChatService = ({
                           limits: ExecutionContract.limits,
                       }
                     : undefined,
+            modeEscalationRequest: workflowModeEscalationRequest,
         });
         const workflowProfile = workflowRuntimeConfig.runtimeProfile;
         const workflowModeDecision = workflowRuntimeConfig.modeDecision;
@@ -800,10 +806,8 @@ export const createChatService = ({
             trustGraphResult?.provenanceJoin?.consumedByConsumers.includes(
                 'P_EVID'
             ) === true;
-        // TODO(workflow-mode-escalation): Initial mode selection is not
-        // revisable in current runtime behavior. If future escalation allows
-        // mode transitions, record explicit planned->final mode lineage here
-        // instead of inferring mode changes from fallback side effects.
+        // Any mode escalation lineage is resolved by workflowProfileRegistry.
+        // Runtime metadata here only carries the resolved decision payload.
         const hasSearchIntent = normalizedGeneration?.search !== undefined;
         const upstreamToolExecution = executionContext?.tool;
         const effectiveToolExecutionContext:

--- a/packages/backend/src/services/steerabilityControls.ts
+++ b/packages/backend/src/services/steerabilityControls.ts
@@ -60,6 +60,9 @@ const mapWorkflowModeSource = (
     if (selectedBy === 'inferred_from_execution_contract') {
         return 'execution_contract';
     }
+    if (selectedBy === 'workflow_mode_escalation') {
+        return 'execution_contract';
+    }
     return 'fail_open_default';
 };
 

--- a/packages/backend/src/services/workflowProfileRegistry.ts
+++ b/packages/backend/src/services/workflowProfileRegistry.ts
@@ -262,6 +262,11 @@ export type WorkflowModeResolution = {
     isKnownRequestedModeId: boolean;
 };
 
+export type WorkflowModeEscalationRequest = {
+    targetModeId: WorkflowModeId;
+    reason: string;
+};
+
 /**
  * Resolves one initial workflow mode decision for this request.
  *
@@ -290,6 +295,7 @@ export const resolveWorkflowModeDecision = (input: {
                 selectedBy: 'requested_mode',
                 selectionReason:
                     'Used requested workflow mode id from runtime configuration.',
+                initial_mode: normalizedRequestedMode.modeId,
                 requestedModeId,
                 ...(input.executionContractResponseMode !== undefined && {
                     executionContractResponseMode:
@@ -312,6 +318,7 @@ export const resolveWorkflowModeDecision = (input: {
                 selectedBy: 'inferred_from_execution_contract',
                 selectionReason:
                     'Requested mode was missing or unknown, so mode was inferred from Execution Contract response mode.',
+                initial_mode: inferredModeId,
                 ...(requestedModeId !== undefined && { requestedModeId }),
                 executionContractResponseMode:
                     input.executionContractResponseMode,
@@ -327,9 +334,48 @@ export const resolveWorkflowModeDecision = (input: {
             selectedBy: 'fail_open_default',
             selectionReason:
                 'Requested mode and Execution Contract hint were unavailable, so fallback default mode was used.',
+            initial_mode: DEFAULT_WORKFLOW_MODE_ID,
             ...(requestedModeId !== undefined && { requestedModeId }),
             behavior: WORKFLOW_MODE_BEHAVIOR_MAP[DEFAULT_WORKFLOW_MODE_ID],
         },
+    };
+};
+
+const normalizeEscalationReason = (
+    reason: string | null | undefined
+): string | undefined => {
+    const trimmedReason = reason?.trim();
+    return trimmedReason !== undefined && trimmedReason.length > 0
+        ? trimmedReason
+        : undefined;
+};
+
+const resolveEscalatedWorkflowModeDecision = (input: {
+    initialModeDecision: WorkflowModeDecision;
+    escalationRequest?: WorkflowModeEscalationRequest;
+}): WorkflowModeDecision => {
+    const initialModeDecision = input.initialModeDecision;
+    const escalationRequest = input.escalationRequest;
+    const escalationReason = normalizeEscalationReason(
+        escalationRequest?.reason
+    );
+    if (escalationRequest === undefined || escalationReason === undefined) {
+        return initialModeDecision;
+    }
+
+    if (escalationRequest.targetModeId === initialModeDecision.modeId) {
+        return initialModeDecision;
+    }
+
+    return {
+        ...initialModeDecision,
+        modeId: escalationRequest.targetModeId,
+        selectedBy: 'workflow_mode_escalation',
+        selectionReason: `Workflow escalation seam accepted one mode transition from "${initialModeDecision.modeId}" to "${escalationRequest.targetModeId}".`,
+        behavior: WORKFLOW_MODE_BEHAVIOR_MAP[escalationRequest.targetModeId],
+        initial_mode: initialModeDecision.initial_mode,
+        escalated_mode: escalationRequest.targetModeId,
+        escalation_reason: escalationReason,
     };
 };
 
@@ -463,16 +509,21 @@ export const resolveWorkflowRuntimeConfig = (input: {
     maxIterations: number;
     maxDurationMs: number;
     ExecutionContract?: Pick<ExecutionContract, 'response' | 'limits'>;
+    modeEscalationRequest?: WorkflowModeEscalationRequest;
 }): ResolvedWorkflowRuntimeConfig => {
-    // TODO(workflow-mode-escalation-attachment): Initial mode selection is
-    // not revisable in v1. Attach any future mode-escalation policy here so
-    // routing revisions stay centralized instead of split across callers.
+    // Bounded escalation seam:
+    // - Initial mode is selected once.
+    // - Optional escalation request can apply at most one transition.
+    // - No loop/re-evaluation is performed in this resolver.
     const modeResolution = resolveWorkflowModeDecision({
         modeId: input.modeId,
         executionContractResponseMode:
             input.ExecutionContract?.response.responseMode,
     });
-    const modeDecision = modeResolution.modeDecision;
+    const modeDecision = resolveEscalatedWorkflowModeDecision({
+        initialModeDecision: modeResolution.modeDecision,
+        escalationRequest: input.modeEscalationRequest,
+    });
     // Mode picks the posture first. The profile lookup then turns that posture
     // into a concrete executable workflow shape.
     const profileResolution = resolveWorkflowProfileRegistry(
@@ -484,9 +535,6 @@ export const resolveWorkflowRuntimeConfig = (input: {
         executionContract !== undefined
             ? executionContract.response.responseMode === 'quality_grounded'
             : input.reviewLoopEnabled === true;
-    // TODO(workflow-mode-escalation): Add explicit mode-transition handling
-    // here if runtime mode escalation is introduced later. Current downstream
-    // fallback behavior does not revise the initial mode decision.
     const workflowExecutionEnabled =
         modeDecision.behavior.workflowExecution === 'disabled'
             ? false

--- a/packages/backend/src/services/workflowProfileRegistry.ts
+++ b/packages/backend/src/services/workflowProfileRegistry.ts
@@ -350,6 +350,18 @@ const normalizeEscalationReason = (
         : undefined;
 };
 
+const deriveWorkflowBehaviorRestrictivenessRank = (
+    behavior: WorkflowModeBehavior
+): 0 | 1 | 2 => {
+    if (behavior.executionContractPresetId === 'fast-direct') {
+        return 0;
+    }
+    if (behavior.executionContractPresetId === 'balanced') {
+        return 1;
+    }
+    return 2;
+};
+
 const resolveEscalatedWorkflowModeDecision = (input: {
     initialModeDecision: WorkflowModeDecision;
     escalationRequest?: WorkflowModeEscalationRequest;
@@ -366,13 +378,24 @@ const resolveEscalatedWorkflowModeDecision = (input: {
     if (escalationRequest.targetModeId === initialModeDecision.modeId) {
         return initialModeDecision;
     }
+    const targetBehavior =
+        WORKFLOW_MODE_BEHAVIOR_MAP[escalationRequest.targetModeId];
+    const initialBehavior = initialModeDecision.behavior;
+    // Escalation seam only accepts equal-or-more-restrictive posture changes.
+    // Downward posture changes are ignored and runtime keeps the initial mode.
+    if (
+        deriveWorkflowBehaviorRestrictivenessRank(targetBehavior) <
+        deriveWorkflowBehaviorRestrictivenessRank(initialBehavior)
+    ) {
+        return initialModeDecision;
+    }
 
     return {
         ...initialModeDecision,
         modeId: escalationRequest.targetModeId,
         selectedBy: 'workflow_mode_escalation',
         selectionReason: `Workflow escalation seam accepted one mode transition from "${initialModeDecision.modeId}" to "${escalationRequest.targetModeId}".`,
-        behavior: WORKFLOW_MODE_BEHAVIOR_MAP[escalationRequest.targetModeId],
+        behavior: targetBehavior,
         initial_mode: initialModeDecision.initial_mode,
         escalated_mode: escalationRequest.targetModeId,
         escalation_reason: escalationReason,

--- a/packages/backend/src/services/workflowProfileRegistry.ts
+++ b/packages/backend/src/services/workflowProfileRegistry.ts
@@ -350,6 +350,20 @@ const normalizeEscalationReason = (
         : undefined;
 };
 
+const normalizeEscalationTargetModeId = (
+    modeId: unknown
+): WorkflowModeId | undefined => {
+    if (typeof modeId !== 'string') {
+        return undefined;
+    }
+    const trimmedModeId = modeId.trim();
+    if (trimmedModeId.length === 0) {
+        return undefined;
+    }
+
+    return normalizeWorkflowModeId(trimmedModeId)?.modeId;
+};
+
 const deriveWorkflowBehaviorRestrictivenessRank = (
     behavior: WorkflowModeBehavior
 ): 0 | 1 | 2 => {
@@ -375,11 +389,19 @@ const resolveEscalatedWorkflowModeDecision = (input: {
         return initialModeDecision;
     }
 
-    if (escalationRequest.targetModeId === initialModeDecision.modeId) {
+    const normalizedTargetModeId = normalizeEscalationTargetModeId(
+        escalationRequest.targetModeId
+    );
+    if (
+        normalizedTargetModeId === undefined ||
+        normalizedTargetModeId === initialModeDecision.modeId
+    ) {
         return initialModeDecision;
     }
-    const targetBehavior =
-        WORKFLOW_MODE_BEHAVIOR_MAP[escalationRequest.targetModeId];
+    const targetBehavior = WORKFLOW_MODE_BEHAVIOR_MAP[normalizedTargetModeId];
+    if (targetBehavior === undefined) {
+        return initialModeDecision;
+    }
     const initialBehavior = initialModeDecision.behavior;
     // Escalation seam only accepts equal-or-more-restrictive posture changes.
     // Downward posture changes are ignored and runtime keeps the initial mode.
@@ -392,12 +414,12 @@ const resolveEscalatedWorkflowModeDecision = (input: {
 
     return {
         ...initialModeDecision,
-        modeId: escalationRequest.targetModeId,
+        modeId: normalizedTargetModeId,
         selectedBy: 'workflow_mode_escalation',
-        selectionReason: `Workflow escalation seam accepted one mode transition from "${initialModeDecision.modeId}" to "${escalationRequest.targetModeId}".`,
+        selectionReason: `Workflow escalation seam accepted one mode transition from "${initialModeDecision.modeId}" to "${normalizedTargetModeId}".`,
         behavior: targetBehavior,
         initial_mode: initialModeDecision.initial_mode,
-        escalated_mode: escalationRequest.targetModeId,
+        escalated_mode: normalizedTargetModeId,
         escalation_reason: escalationReason,
     };
 };

--- a/packages/backend/test/chatService.test.ts
+++ b/packages/backend/test/chatService.test.ts
@@ -1634,6 +1634,7 @@ test('runChatMessages records workflow mode decision in metadata and applies fas
     assert.equal(directGenerationCalls, 1);
     assert.equal(reviewWorkflowCalls, 0);
     assert.equal(response.metadata.workflowMode?.modeId, 'fast');
+    assert.equal(response.metadata.workflowMode?.initial_mode, 'fast');
     assert.equal(
         response.metadata.workflowMode?.behavior.workflowExecution,
         'disabled'
@@ -1641,6 +1642,59 @@ test('runChatMessages records workflow mode decision in metadata and applies fas
     assert.equal(
         response.metadata.workflowMode?.behavior.evidencePosture,
         'minimal'
+    );
+});
+
+test('runChatMessages can emit bounded workflow escalation attachment metadata', async () => {
+    const generationRuntime: GenerationRuntime = {
+        kind: 'test-runtime',
+        async generate() {
+            return {
+                text: 'escalated path response',
+                model: 'gpt-5-mini',
+                usage: {
+                    promptTokens: 10,
+                    completionTokens: 5,
+                    totalTokens: 15,
+                },
+                provenance: 'Inferred',
+                citations: [],
+            };
+        },
+    };
+    const chatService = createChatService({
+        generationRuntime,
+        storeTrace: async () => undefined,
+        buildResponseMetadata,
+        defaultModel: 'gpt-5-mini',
+        recordUsage: () => undefined,
+        chatWorkflowConfig: {
+            modeId: 'fast',
+            reviewLoopEnabled: true,
+            maxIterations: 3,
+            maxDurationMs: 15000,
+        },
+    });
+
+    const response = await chatService.runChatMessages({
+        messages: [{ role: 'user', content: 'Summarize this.' }],
+        conversationSnapshot: 'Summarize this.',
+        workflowModeEscalationRequest: {
+            targetModeId: 'grounded',
+            reason: 'insufficient evidence confidence for fast mode',
+        },
+    });
+
+    assert.equal(response.metadata.workflowMode?.initial_mode, 'fast');
+    assert.equal(response.metadata.workflowMode?.escalated_mode, 'grounded');
+    assert.equal(
+        response.metadata.workflowMode?.escalation_reason,
+        'insufficient evidence confidence for fast mode'
+    );
+    assert.equal(response.metadata.workflowMode?.modeId, 'grounded');
+    assert.equal(
+        response.metadata.workflowMode?.selectedBy,
+        'workflow_mode_escalation'
     );
 });
 

--- a/packages/backend/test/steerabilityControlObservability.test.ts
+++ b/packages/backend/test/steerabilityControlObservability.test.ts
@@ -22,6 +22,7 @@ const createEnvelopeInput = (): Parameters<
             modeId: 'grounded',
             selectedBy: 'requested_mode',
             selectionReason: 'Configured mode selected.',
+            initial_mode: 'grounded',
             behavior: {
                 executionContractPresetId: 'quality-grounded',
                 workflowProfileClass: 'reviewed',

--- a/packages/backend/test/steerabilityControls.test.ts
+++ b/packages/backend/test/steerabilityControls.test.ts
@@ -16,6 +16,7 @@ const createBaseControlsInput = (
         modeId: 'grounded',
         selectedBy: 'requested_mode',
         selectionReason: 'Configured mode selected.',
+        initial_mode: 'grounded',
         behavior: {
             executionContractPresetId: 'quality-grounded',
             workflowProfileClass: 'reviewed',
@@ -169,6 +170,7 @@ test('mattered reflects observable causal impact instead of record presence', ()
                 modeId: 'fast',
                 selectedBy: 'requested_mode',
                 selectionReason: 'Configured fast mode selected.',
+                initial_mode: 'fast',
                 behavior: {
                     executionContractPresetId: 'fast-direct',
                     workflowProfileClass: 'direct',
@@ -243,6 +245,7 @@ test('review_intensity derives as light for low-deliberation reviewed behavior',
                 modeId: 'balanced',
                 selectedBy: 'requested_mode',
                 selectionReason: 'Configured balanced mode selected.',
+                initial_mode: 'balanced',
                 behavior: {
                     executionContractPresetId: 'balanced',
                     workflowProfileClass: 'reviewed',

--- a/packages/backend/test/workflowProfileRegistry.test.ts
+++ b/packages/backend/test/workflowProfileRegistry.test.ts
@@ -153,6 +153,7 @@ test('resolveWorkflowModeDecision maps requested mode ids and emits inspectable 
     });
     assert.equal(requested.isKnownRequestedModeId, true);
     assert.equal(requested.modeDecision.modeId, 'balanced');
+    assert.equal(requested.modeDecision.initial_mode, 'balanced');
     assert.equal(requested.modeDecision.selectedBy, 'requested_mode');
     assert.equal(
         requested.modeDecision.behavior.executionContractPresetId,
@@ -174,6 +175,7 @@ test('resolveWorkflowModeDecision fails open by inferring from execution contrac
     });
     assert.equal(inferred.isKnownRequestedModeId, false);
     assert.equal(inferred.modeDecision.modeId, 'grounded');
+    assert.equal(inferred.modeDecision.initial_mode, 'grounded');
     assert.equal(
         inferred.modeDecision.selectedBy,
         'inferred_from_execution_contract'
@@ -187,6 +189,7 @@ test('resolveWorkflowModeDecision fails open by inferring from execution contrac
         modeId: 'unknown-mode',
     });
     assert.equal(fallbackDefault.modeDecision.modeId, 'grounded');
+    assert.equal(fallbackDefault.modeDecision.initial_mode, 'grounded');
     assert.equal(fallbackDefault.modeDecision.selectedBy, 'fail_open_default');
 });
 
@@ -196,8 +199,31 @@ test('resolveWorkflowModeDecision treats non-canonical mode ids as unknown and f
     });
     assert.equal(legacyFast.isKnownRequestedModeId, false);
     assert.equal(legacyFast.modeDecision.modeId, 'grounded');
+    assert.equal(legacyFast.modeDecision.initial_mode, 'grounded');
     assert.equal(legacyFast.modeDecision.selectedBy, 'fail_open_default');
     assert.equal(legacyFast.modeDecision.requestedModeId, 'generate-only');
+});
+
+test('resolveWorkflowRuntimeConfig exposes bounded workflow-owned escalation metadata', () => {
+    const config = resolveWorkflowRuntimeConfig({
+        modeId: 'fast',
+        reviewLoopEnabled: true,
+        maxIterations: 3,
+        maxDurationMs: 9000,
+        modeEscalationRequest: {
+            targetModeId: 'grounded',
+            reason: 'retrieval required for grounded evidence posture',
+        },
+    });
+
+    assert.equal(config.modeDecision.initial_mode, 'fast');
+    assert.equal(config.modeDecision.escalated_mode, 'grounded');
+    assert.equal(
+        config.modeDecision.escalation_reason,
+        'retrieval required for grounded evidence posture'
+    );
+    assert.equal(config.modeDecision.modeId, 'grounded');
+    assert.equal(config.modeDecision.selectedBy, 'workflow_mode_escalation');
 });
 
 test('deriveReviewIntensityFromWorkflowBehavior centralizes review intensity mapping', () => {

--- a/packages/backend/test/workflowProfileRegistry.test.ts
+++ b/packages/backend/test/workflowProfileRegistry.test.ts
@@ -226,6 +226,28 @@ test('resolveWorkflowRuntimeConfig exposes bounded workflow-owned escalation met
     assert.equal(config.modeDecision.selectedBy, 'workflow_mode_escalation');
 });
 
+test('resolveWorkflowRuntimeConfig rejects downward mode changes and keeps initial behavior', () => {
+    const config = resolveWorkflowRuntimeConfig({
+        modeId: 'grounded',
+        reviewLoopEnabled: true,
+        maxIterations: 3,
+        maxDurationMs: 9000,
+        modeEscalationRequest: {
+            targetModeId: 'fast',
+            reason: 'attempt downgrade',
+        },
+    });
+
+    assert.equal(config.modeDecision.modeId, 'grounded');
+    assert.equal(config.modeDecision.selectedBy, 'requested_mode');
+    assert.equal(
+        config.modeDecision.behavior.executionContractPresetId,
+        'quality-grounded'
+    );
+    assert.equal(config.modeDecision.escalated_mode, undefined);
+    assert.equal(config.modeDecision.escalation_reason, undefined);
+});
+
 test('deriveReviewIntensityFromWorkflowBehavior centralizes review intensity mapping', () => {
     assert.equal(
         deriveReviewIntensityFromWorkflowBehavior({

--- a/packages/backend/test/workflowProfileRegistry.test.ts
+++ b/packages/backend/test/workflowProfileRegistry.test.ts
@@ -248,6 +248,27 @@ test('resolveWorkflowRuntimeConfig rejects downward mode changes and keeps initi
     assert.equal(config.modeDecision.escalation_reason, undefined);
 });
 
+test('resolveWorkflowRuntimeConfig fails open when escalation target mode id is malformed', () => {
+    const config = resolveWorkflowRuntimeConfig({
+        modeId: 'balanced',
+        reviewLoopEnabled: true,
+        maxIterations: 3,
+        maxDurationMs: 9000,
+        modeEscalationRequest: {
+            targetModeId: 'not-a-mode',
+            reason: 'unsafe runtime input',
+        } as unknown as {
+            targetModeId: 'fast' | 'balanced' | 'grounded';
+            reason: string;
+        },
+    });
+
+    assert.equal(config.modeDecision.modeId, 'balanced');
+    assert.equal(config.modeDecision.selectedBy, 'requested_mode');
+    assert.equal(config.modeDecision.escalated_mode, undefined);
+    assert.equal(config.modeDecision.escalation_reason, undefined);
+});
+
 test('deriveReviewIntensityFromWorkflowBehavior centralizes review intensity mapping', () => {
     assert.equal(
         deriveReviewIntensityFromWorkflowBehavior({

--- a/packages/contracts/src/ethics-core/types.ts
+++ b/packages/contracts/src/ethics-core/types.ts
@@ -436,7 +436,8 @@ export type WorkflowModeId = 'fast' | 'balanced' | 'grounded';
 export type WorkflowModeSelectionSource =
     | 'requested_mode'
     | 'inferred_from_execution_contract'
-    | 'fail_open_default';
+    | 'fail_open_default'
+    | 'workflow_mode_escalation';
 
 export type WorkflowModeEvidencePosture = 'minimal' | 'balanced' | 'strict';
 
@@ -456,6 +457,9 @@ export type WorkflowModeDecision = {
     modeId: WorkflowModeId;
     selectedBy: WorkflowModeSelectionSource;
     selectionReason: string;
+    initial_mode: WorkflowModeId;
+    escalated_mode?: WorkflowModeId;
+    escalation_reason?: string;
     requestedModeId?: string;
     executionContractResponseMode?: 'fast_direct' | 'quality_grounded';
     behavior: WorkflowModeBehavior;

--- a/packages/contracts/src/web/schemas.ts
+++ b/packages/contracts/src/web/schemas.ts
@@ -578,6 +578,7 @@ const WorkflowModeSelectionSourceSchema = z.enum([
     'requested_mode',
     'inferred_from_execution_contract',
     'fail_open_default',
+    'workflow_mode_escalation',
 ]);
 
 const WorkflowModeBehaviorSchema = z
@@ -603,6 +604,9 @@ const WorkflowModeDecisionSchema = z
         modeId: WorkflowModeIdSchema,
         selectedBy: WorkflowModeSelectionSourceSchema,
         selectionReason: z.string().min(1),
+        initial_mode: WorkflowModeIdSchema,
+        escalated_mode: WorkflowModeIdSchema.optional(),
+        escalation_reason: z.string().min(1).optional(),
         requestedModeId: z.string().min(1).optional(),
         executionContractResponseMode: z
             .enum(['fast_direct', 'quality_grounded'])

--- a/packages/contracts/test/webSchemas.test.ts
+++ b/packages/contracts/test/webSchemas.test.ts
@@ -379,6 +379,34 @@ test('ResponseMetadataSchema accepts structured steerability controls metadata',
     assert.equal(parsed.success, true);
 });
 
+test('ResponseMetadataSchema accepts workflow mode escalation attachment metadata', () => {
+    const parsed = ResponseMetadataSchema.safeParse({
+        ...baseMetadata,
+        workflowMode: {
+            modeId: 'grounded',
+            selectedBy: 'workflow_mode_escalation',
+            selectionReason:
+                'Workflow escalation seam accepted one mode transition.',
+            initial_mode: 'fast',
+            escalated_mode: 'grounded',
+            escalation_reason: 'insufficient evidence confidence for fast mode',
+            behavior: {
+                executionContractPresetId: 'quality-grounded',
+                workflowProfileClass: 'reviewed',
+                workflowProfileId: 'bounded-review',
+                workflowExecution: 'policy_gated',
+                reviewPass: 'included',
+                reviseStep: 'allowed',
+                evidencePosture: 'strict',
+                maxWorkflowSteps: 8,
+                maxDeliberationCalls: 4,
+            },
+        },
+    });
+
+    assert.equal(parsed.success, true);
+});
+
 test('ResponseMetadataSchema rejects steerability controls with unknown enums', () => {
     const parsed = ResponseMetadataSchema.safeParse({
         ...baseMetadata,


### PR DESCRIPTION
## Summary
Adds a bounded workflow-owned seam for mode escalation and standardizes workflow mode lineage metadata.

## Why This Change
Initial mode routing can be wrong in some requests. We need one safe, centralized place to attach escalation requests without introducing a broad policy engine or re-evaluation loops.

## What Changed
- Added canonical workflow mode lineage fields to metadata contracts:
  - `initial_mode`
  - `escalated_mode`
  - `escalation_reason`
- Added `workflow_mode_escalation` as a workflow mode selection source.
- Implemented a bounded escalation seam in `resolveWorkflowRuntimeConfig`:
  - initial mode is resolved once
  - optional escalation request applies at most one transition
  - no recursive or unbounded re-evaluation loops
- Threaded optional escalation requests through chat runtime input (`runChatMessages`) so workflow metadata can emit escalated lineage.
- Updated schema/type surfaces in contracts and backend to keep serialization and validation aligned.
- Updated steerability source mapping for escalated mode decisions.
- Documented the seam and metadata contract in workflow mode routing docs.

## Important Implementation Details
- Escalation behavior is intentionally narrow and centralized in `workflowProfileRegistry`.
- Existing fail-open posture is preserved: invalid/empty escalation requests do not block execution.
- Metadata remains explicit about initial vs final routed mode.
- Tests were added/updated to verify:
  - resolver-level escalation metadata emission
  - chat workflow path emission
  - schema acceptance for escalation fields
  - compatibility of related steerability tests

This PR was written using [Vibe Kanban](https://vibekanban.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * One-step bounded workflow mode escalation at runtime, with enforceable restrictiveness checks.
  * Runtime metadata now includes initial_mode, escalated_mode, and escalation_reason for observability.

* **Bug Fixes / Behavior**
  * Escalation routing centralized to prevent recursive or unbounded re-evaluations; less-restrictive requests are ignored.

* **Documentation**
  * Architecture docs updated to clarify escalation seam and rules.

* **Tests**
  * Added/updated tests for escalation success, rejection, malformed targets, and metadata emission.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->