### PR TITLE
Separate TRACE target/final metadata and clarify lifecycle seams (Vibe Kanban)

### DIFF
--- a/.pr-276-body.md
+++ b/.pr-276-body.md
@@ -1,0 +1,30 @@
+## What changed
+- Added canonical TRACE posture fields in response metadata:
+  - `trace_target`
+  - `trace_final`
+  - `trace_final_reason_code` (when posture changes)
+- Enforced the target/final divergence invariant in contracts schema validation:
+  - if `trace_target` and `trace_final` differ, reason code is required
+  - if they match, reason code must be omitted
+- Updated backend metadata assembly to emit the canonical TRACE fields and keep separation clear between:
+  - workflow mode (policy/routing)
+  - TRACE (answer posture)
+  - provenance (grounding/event record)
+- Updated trace-card and Discord provenance paths to consume `trace_final` where delivered posture is displayed.
+- Updated tests across contracts/backend/discord for the new canonical fields and invariants.
+- Added a small semantic hardening follow-up:
+  - targeted `TODO(trace-lifecycle...)` seam comments at the contract/schema/metadata seams
+  - wording clarifications in docs/OpenAPI to state current fields are summary-state and lifecycle/history semantics are future work.
+
+## Why
+The runtime can legitimately alter posture during orchestration (for example, escalation/reconsideration). This PR makes that explicit and auditable now, while avoiding a premature full lifecycle redesign.
+
+It also prevents a key failure mode: treating TRACE as a proxy for workflow mode or provenance.
+
+## Important implementation details
+- This PR does **not** add lifecycle arrays/state (`trace[]`, `trace_lifecycle`) or migration scaffolding.
+- This PR keeps behavior fail-open and focuses on explicit, serializable metadata semantics.
+- The lifecycle direction is documented only as forward-looking seam TODOs; current implementation remains summary-field based.
+- OpenAPI/architecture wording was aligned with the implemented reality so contributors are not misled about lifecycle completeness.
+
+This PR was written using [Vibe Kanban](https://vibekanban.com)

--- a/docs/api/openapi.yaml
+++ b/docs/api/openapi.yaml
@@ -722,7 +722,7 @@ paths:
                 - packages/contracts/src/web/types.ts#PostTraceCardFromTraceResponse
             summary: Generate and store a trace-card from an existing trace
             description: |
-                Load stored trace metadata by response id, use stored TRACE temperament and optional chip scores,
+                Load stored trace metadata by response id, use stored final TRACE posture and optional chip scores,
                 regenerate/store the canonical SVG asset, and return a PNG payload for inline display.
                 TraceToken required.
             tags:
@@ -2556,9 +2556,9 @@ components:
                     minimum: 1
                     maximum: 5
                     description: Optional TRACE freshness chip score.
-                temperament:
+                trace_target:
                     type: object
-                    description: Optional partial TRACE temperament profile with named 1-5 integer axes.
+                    description: Canonical intended TRACE answer posture (partial 1-5 axis map).
                     properties:
                         tightness:
                             type: integer
@@ -2586,6 +2586,40 @@ components:
                             minimum: 1
                             maximum: 5
                     additionalProperties: false
+                trace_final:
+                    type: object
+                    description: Canonical delivered TRACE answer posture (partial 1-5 axis map).
+                    properties:
+                        tightness:
+                            type: integer
+                            description: 1 to 5, where higher means stronger concision and structural efficiency.
+                            minimum: 1
+                            maximum: 5
+                        rationale:
+                            type: integer
+                            description: 1 to 5, where higher means more visible rationale and trade-off explanation.
+                            minimum: 1
+                            maximum: 5
+                        attribution:
+                            type: integer
+                            description: 1 to 5, where higher means clearer sourced vs inferred boundaries.
+                            minimum: 1
+                            maximum: 5
+                        caution:
+                            type: integer
+                            description: 1 to 5, where higher means stronger safeguards and overclaim restraint.
+                            minimum: 1
+                            maximum: 5
+                        extent:
+                            type: integer
+                            description: 1 to 5, where higher means broader options and perspectives.
+                            minimum: 1
+                            maximum: 5
+                    additionalProperties: false
+                trace_final_reason_code:
+                    type: string
+                    description: Required when trace_final differs from trace_target.
+                    enum: [runtime_posture_adjustment]
                 trustGraph:
                     type: object
                     properties:
@@ -2791,6 +2825,8 @@ components:
                 - modelVersion
                 - staleAfter
                 - citations
+                - trace_target
+                - trace_final
             additionalProperties: true
 
         ResponseMetadata:

--- a/docs/api/openapi.yaml
+++ b/docs/api/openapi.yaml
@@ -2558,7 +2558,7 @@ components:
                     description: Optional TRACE freshness chip score.
                 trace_target:
                     type: object
-                    description: Canonical intended TRACE answer posture (partial 1-5 axis map).
+                    description: Current summary field for intended TRACE answer posture (partial 1-5 axis map).
                     properties:
                         tightness:
                             type: integer
@@ -2588,7 +2588,7 @@ components:
                     additionalProperties: false
                 trace_final:
                     type: object
-                    description: Canonical delivered TRACE answer posture (partial 1-5 axis map).
+                    description: Current summary field for delivered TRACE answer posture (partial 1-5 axis map).
                     properties:
                         tightness:
                             type: integer

--- a/docs/architecture/2026-04-steerability-foundation.md
+++ b/docs/architecture/2026-04-steerability-foundation.md
@@ -270,6 +270,7 @@ A few expansion points are already visible, and they need to stay bounded.
   posture during review, `trace_target` and `trace_final` must both be
   recorded with an explicit `trace_final_reason_code`. `workflowMode` remains
   routing metadata. TRACE remains answer-posture metadata.
+  Current runtime does not implement a full TRACE lifecycle/history model yet.
 
 The trace should show what the runtime actually did, in a form contributors
 can follow.

--- a/docs/architecture/2026-04-steerability-foundation.md
+++ b/docs/architecture/2026-04-steerability-foundation.md
@@ -266,9 +266,10 @@ A few expansion points are already visible, and they need to stay bounded.
   alongside `applyOutcome`. Do not overload the top-level enum.
 - If multiple planner passes or retries are introduced, add explicit
   correlation while keeping planner ownership bounded by workflow logic.
-- If runtime can revise TRACE posture during review, keep target TRACE and
-  final TRACE separate. `workflowMode` remains routing metadata. TRACE remains
-  answer-posture metadata.
+- TRACE posture uses separate target/final contract fields. If runtime revises
+  posture during review, `trace_target` and `trace_final` must both be
+  recorded with an explicit `trace_final_reason_code`. `workflowMode` remains
+  routing metadata. TRACE remains answer-posture metadata.
 
 The trace should show what the runtime actually did, in a form contributors
 can follow.

--- a/docs/architecture/workflow-mode-routing.md
+++ b/docs/architecture/workflow-mode-routing.md
@@ -7,8 +7,8 @@ A workflow mode is the explicit high-level routing decision for chat execution.
 Each part has a different job. The Execution Contract sets the allowed posture.
 The chat orchestrator runs within that contract. Workflow mode is the
 high-level choice, and workflow profile is the concrete step pattern. TRACE is
-about answer temperament, while provenance and evidence metadata are about what
-actually happened.
+about answer temperament (`trace_target` and `trace_final`), while provenance
+and evidence metadata are about what actually happened.
 
 In short:
 

--- a/packages/backend/src/handlers/trace.ts
+++ b/packages/backend/src/handlers/trace.ts
@@ -629,9 +629,8 @@ const createTraceHandlers = ({
                     modelVersion: 'trace-card-preview',
                     staleAfter: new Date(now + ninetyDaysMs).toISOString(),
                     citations: [],
-                    ...(parsedPayload.data.temperament && {
-                        temperament: parsedPayload.data.temperament,
-                    }),
+                    trace_target: parsedPayload.data.temperament ?? {},
+                    trace_final: parsedPayload.data.temperament ?? {},
                     ...(parsedPayload.data.chips?.evidenceScore && {
                         evidenceScore: parsedPayload.data.chips.evidenceScore,
                     }),
@@ -733,7 +732,7 @@ const createTraceHandlers = ({
             }
 
             const { svg, png } = renderTraceCardPng({
-                temperament: metadata.temperament,
+                temperament: metadata.trace_final,
                 chips: {
                     evidenceScore: metadata.evidenceScore,
                     freshnessScore: metadata.freshnessScore,

--- a/packages/backend/src/services/openaiService/metadata.ts
+++ b/packages/backend/src/services/openaiService/metadata.ts
@@ -209,7 +209,9 @@ const normalizeToolReasonCode = (
  * - execution/workflow/workflowMode/steerabilityControls are structural records.
  * - provenance/provenanceAssessment/chip scores may include deterministic
  *   heuristic derivation when structural evidence is partial.
- * - TRACE temperament is response posture metadata, separate from provenance.
+ * - workflowMode is policy/routing metadata.
+ * - TRACE is answer-posture metadata.
+ * - provenance is grounding/event metadata.
  */
 const buildResponseMetadata = (
     assistantMetadata: AssistantResponseMetadata,
@@ -251,13 +253,28 @@ const buildResponseMetadata = (
         assistantMetadata.tradeoffCount,
         runtimeContext.plannerTemperament
     );
-    const temperament = normalizePlannerTemperament(
-        runtimeContext.plannerTemperament
-    );
-    // TODO(trace-target-vs-final): If review-time runtime can revise TRACE
-    // posture, persist both target and final TRACE values. Preserve the
-    // invariant that workflow mode is routing metadata while TRACE remains
-    // answer-posture metadata.
+    const traceTarget =
+        normalizePlannerTemperament(runtimeContext.plannerTemperament) ?? {};
+    const traceFinal =
+        normalizePlannerTemperament(runtimeContext.finalTemperament) ??
+        traceTarget;
+    const traceChanged =
+        JSON.stringify(traceTarget) !== JSON.stringify(traceFinal);
+    const traceFinalReasonCode = traceChanged
+        ? (runtimeContext.temperamentFinalizationReasonCode ??
+          'runtime_posture_adjustment')
+        : undefined;
+    if (
+        traceChanged &&
+        runtimeContext.temperamentFinalizationReasonCode === undefined
+    ) {
+        logger.warn(
+            'TRACE target/final divergence reason code missing; defaulting to runtime_posture_adjustment.',
+            {
+                responseId,
+            }
+        );
+    }
     const evidenceScore = isTraceAxisScore(assistantMetadata.evidenceScore)
         ? assistantMetadata.evidenceScore
         : undefined;
@@ -522,7 +539,11 @@ const buildResponseMetadata = (
         ...(evaluatorExecution?.outcome !== undefined && {
             evaluator: evaluatorExecution.outcome,
         }),
-        ...(temperament && { temperament }),
+        trace_target: traceTarget,
+        trace_final: traceFinal,
+        ...(traceFinalReasonCode !== undefined && {
+            trace_final_reason_code: traceFinalReasonCode,
+        }),
         ...(finalEvidenceScore !== undefined && {
             evidenceScore: finalEvidenceScore,
         }),

--- a/packages/backend/src/services/openaiService/metadata.ts
+++ b/packages/backend/src/services/openaiService/metadata.ts
@@ -253,6 +253,10 @@ const buildResponseMetadata = (
         assistantMetadata.tradeoffCount,
         runtimeContext.plannerTemperament
     );
+    // TODO(trace-lifecycle): TRACE may eventually evolve through planning /
+    // workflow / review steps. If that model is added, keep canonical
+    // lifecycle/history state and derive summary fields from it.
+    // Current runtime stays summary-only and does not implement lifecycle.
     const traceTarget =
         normalizePlannerTemperament(runtimeContext.plannerTemperament) ?? {};
     const traceFinal =

--- a/packages/backend/src/services/openaiService/types.ts
+++ b/packages/backend/src/services/openaiService/types.ts
@@ -155,6 +155,11 @@ export type ResponseMetadataRuntimeContext = {
     // Planner TRACE target posture. This is answer-shape intent metadata,
     // not source-grounding or retrieval truth.
     plannerTemperament?: PartialResponseTemperament;
+    // Final TRACE posture delivered by runtime. If omitted, metadata assembly
+    // treats target and final as the same posture.
+    finalTemperament?: PartialResponseTemperament;
+    // Required when finalTemperament diverges from plannerTemperament.
+    temperamentFinalizationReasonCode?: ResponseMetadata['trace_final_reason_code'];
     retrieval?: ResponseMetadataRetrievalContext;
     trustGraphEvidenceAvailable?: boolean;
     trustGraphEvidenceUsed?: boolean;

--- a/packages/backend/src/services/traceStore.ts
+++ b/packages/backend/src/services/traceStore.ts
@@ -36,7 +36,7 @@ const storeTrace = async (
         // Trace-card generation stays out of this write path so trace storage
         // remains lightweight and fail-open even when rendering dependencies
         // or image generation are unavailable.
-        if (metadata.temperament) {
+        if (Object.keys(metadata.trace_final).length > 0) {
             logger.debug(
                 `Deferring trace-card generation to trace-card handler path for "${responseId}".`
             );

--- a/packages/backend/test/chatHandler.test.ts
+++ b/packages/backend/test/chatHandler.test.ts
@@ -101,6 +101,8 @@ const createMetadata = (): ResponseMetadata => ({
     modelVersion: 'gpt-5-mini',
     staleAfter: new Date(Date.now() + 60000).toISOString(),
     citations: [],
+    trace_target: {},
+    trace_final: {},
 });
 
 const createChatRequest = (

--- a/packages/backend/test/chatHandler.test.ts
+++ b/packages/backend/test/chatHandler.test.ts
@@ -15,6 +15,7 @@ import type {
 } from '@footnote/agent-runtime';
 import type { ResponseMetadata } from '@footnote/contracts/ethics-core';
 import type { PostChatRequest } from '@footnote/contracts/web';
+import { createMetadata } from './fixtures/responseMetadataFixture.js';
 import { createChatHandler } from '../src/handlers/chat.js';
 import { runtimeConfig } from '../src/config.js';
 import type { RuntimeConfig } from '../src/config/types.js';
@@ -90,20 +91,6 @@ const createExecutionContractTrustGraphRuntimeConfig = (
         ...rest,
     };
 };
-
-const createMetadata = (): ResponseMetadata => ({
-    responseId: 'chat_test_response',
-    provenance: 'Inferred',
-    safetyTier: 'Low',
-    tradeoffCount: 0,
-    chainHash: 'abc123def456',
-    licenseContext: 'MIT + HL3',
-    modelVersion: 'gpt-5-mini',
-    staleAfter: new Date(Date.now() + 60000).toISOString(),
-    citations: [],
-    trace_target: {},
-    trace_final: {},
-});
 
 const createChatRequest = (
     overrides: Partial<PostChatRequest> = {}

--- a/packages/backend/test/chatOrchestrator.test.ts
+++ b/packages/backend/test/chatOrchestrator.test.ts
@@ -9,8 +9,8 @@ import test from 'node:test';
 import assert from 'node:assert/strict';
 
 import type { GenerationRuntime } from '@footnote/agent-runtime';
-import type { ResponseMetadata } from '@footnote/contracts/ethics-core';
 import type { PostChatRequest } from '@footnote/contracts/web';
+import { createMetadata } from './fixtures/responseMetadataFixture.js';
 import type { BotProfileConfig } from '../src/config/profile.js';
 import { runtimeConfig } from '../src/config.js';
 import { createChatOrchestrator } from '../src/services/chatOrchestrator.js';
@@ -24,20 +24,6 @@ import type { WeatherForecastTool } from '../src/services/weatherGovForecastTool
 import { logger } from '../src/utils/logger.js';
 
 const PLANNER_TOKEN_SENTINEL = 1200;
-
-const createMetadata = (): ResponseMetadata => ({
-    responseId: 'chat_test_response',
-    provenance: 'Inferred',
-    safetyTier: 'Low',
-    tradeoffCount: 0,
-    chainHash: 'abc123def456',
-    licenseContext: 'MIT + HL3',
-    modelVersion: 'gpt-5-mini',
-    staleAfter: new Date(Date.now() + 60000).toISOString(),
-    citations: [],
-    trace_target: {},
-    trace_final: {},
-});
 
 const createChatRequest = (
     overrides: Partial<PostChatRequest> = {}

--- a/packages/backend/test/chatOrchestrator.test.ts
+++ b/packages/backend/test/chatOrchestrator.test.ts
@@ -35,6 +35,8 @@ const createMetadata = (): ResponseMetadata => ({
     modelVersion: 'gpt-5-mini',
     staleAfter: new Date(Date.now() + 60000).toISOString(),
     citations: [],
+    trace_target: {},
+    trace_final: {},
 });
 
 const createChatRequest = (

--- a/packages/backend/test/chatOrchestratorExecutionContractTrustGraph.test.ts
+++ b/packages/backend/test/chatOrchestratorExecutionContractTrustGraph.test.ts
@@ -11,6 +11,7 @@ import assert from 'node:assert/strict';
 import type { GenerationRuntime } from '@footnote/agent-runtime';
 import type { ResponseMetadata } from '@footnote/contracts/ethics-core';
 import type { PostChatRequest } from '@footnote/contracts/web';
+import { createMetadata } from './fixtures/responseMetadataFixture.js';
 import { createChatOrchestrator } from '../src/services/chatOrchestrator.js';
 import {
     createScopeOwnershipValidatorFromTenancyService,
@@ -43,20 +44,6 @@ type TrustGraphMetadata = {
     provenanceJoin?: { externalEvidenceBundleId?: string };
     adapterBundle?: unknown;
 };
-
-const createMetadata = (): ResponseMetadata => ({
-    responseId: 'chat_test_response',
-    provenance: 'Inferred',
-    safetyTier: 'Low',
-    tradeoffCount: 0,
-    chainHash: 'abc123def456',
-    licenseContext: 'MIT + HL3',
-    modelVersion: 'gpt-5-mini',
-    staleAfter: new Date(Date.now() + 60000).toISOString(),
-    citations: [],
-    trace_target: {},
-    trace_final: {},
-});
 
 const createChatRequest = (
     overrides: Partial<PostChatRequest> = {}

--- a/packages/backend/test/chatOrchestratorExecutionContractTrustGraph.test.ts
+++ b/packages/backend/test/chatOrchestratorExecutionContractTrustGraph.test.ts
@@ -54,6 +54,8 @@ const createMetadata = (): ResponseMetadata => ({
     modelVersion: 'gpt-5-mini',
     staleAfter: new Date(Date.now() + 60000).toISOString(),
     citations: [],
+    trace_target: {},
+    trace_final: {},
 });
 
 const createChatRequest = (

--- a/packages/backend/test/chatService.test.ts
+++ b/packages/backend/test/chatService.test.ts
@@ -15,6 +15,7 @@ import type {
 import { createVoltAgentRuntime } from '@footnote/agent-runtime';
 import type { ResponseMetadata } from '@footnote/contracts/ethics-core';
 import { ResponseMetadataSchema } from '@footnote/contracts/web';
+import { createMetadata } from './fixtures/responseMetadataFixture.js';
 import {
     buildResponseMetadata,
     type ResponseMetadataRetrievalContext,
@@ -29,20 +30,6 @@ import {
 } from '../src/services/executionContractTrustGraph/index.js';
 import type { BackendLLMCostRecord } from '../src/services/llmCostRecorder.js';
 import type { RunBoundedReviewWorkflowResult } from '../src/services/workflowEngine.js';
-
-const createMetadata = (): ResponseMetadata => ({
-    responseId: 'chat_test_response',
-    provenance: 'Inferred',
-    safetyTier: 'Low',
-    tradeoffCount: 0,
-    chainHash: 'abc123def456',
-    licenseContext: 'MIT + HL3',
-    modelVersion: 'gpt-5-mini',
-    staleAfter: new Date(Date.now() + 60000).toISOString(),
-    citations: [],
-    trace_target: {},
-    trace_final: {},
-});
 
 const createRuntime = (
     overrides: Partial<GenerationResult> = {}

--- a/packages/backend/test/chatService.test.ts
+++ b/packages/backend/test/chatService.test.ts
@@ -40,6 +40,8 @@ const createMetadata = (): ResponseMetadata => ({
     modelVersion: 'gpt-5-mini',
     staleAfter: new Date(Date.now() + 60000).toISOString(),
     citations: [],
+    trace_target: {},
+    trace_final: {},
 });
 
 const createRuntime = (

--- a/packages/backend/test/fixtures/responseMetadataFixture.ts
+++ b/packages/backend/test/fixtures/responseMetadataFixture.ts
@@ -1,0 +1,23 @@
+/**
+ * @description: Shared test fixture for baseline response metadata used across backend chat tests.
+ * @footnote-scope: test
+ * @footnote-module: ResponseMetadataFixture
+ * @footnote-risk: low - Fixture drift can cause inconsistent test setup across backend suites.
+ * @footnote-ethics: low - Uses synthetic metadata and no user-identifying values.
+ */
+
+import type { ResponseMetadata } from '@footnote/contracts/ethics-core';
+
+export const createMetadata = (): ResponseMetadata => ({
+    responseId: 'chat_test_response',
+    provenance: 'Inferred',
+    safetyTier: 'Low',
+    tradeoffCount: 0,
+    chainHash: 'abc123def456',
+    licenseContext: 'MIT + HL3',
+    modelVersion: 'gpt-5-mini',
+    staleAfter: new Date(Date.now() + 60000).toISOString(),
+    citations: [],
+    trace_target: {},
+    trace_final: {},
+});

--- a/packages/backend/test/openaiService.metadata.test.ts
+++ b/packages/backend/test/openaiService.metadata.test.ts
@@ -255,6 +255,54 @@ test('buildResponseMetadata defaults tradeoffCount to 0 when assistant and plann
     assert.equal(metadata.tradeoffCount, 0);
 });
 
+test('buildResponseMetadata emits canonical trace_target and trace_final fields', () => {
+    const metadata = buildResponseMetadata(
+        baseAssistantMetadata(),
+        baseRuntimeContext({
+            plannerTemperament: {
+                tightness: 4,
+                rationale: 3,
+            },
+        })
+    );
+
+    assert.deepEqual(metadata.trace_target, {
+        tightness: 4,
+        rationale: 3,
+    });
+    assert.deepEqual(metadata.trace_final, {
+        tightness: 4,
+        rationale: 3,
+    });
+    assert.equal(metadata.trace_final_reason_code, undefined);
+});
+
+test('buildResponseMetadata emits trace_final_reason_code when final posture differs', () => {
+    const metadata = buildResponseMetadata(
+        baseAssistantMetadata(),
+        baseRuntimeContext({
+            plannerTemperament: {
+                tightness: 2,
+            },
+            finalTemperament: {
+                tightness: 4,
+            },
+            temperamentFinalizationReasonCode: 'runtime_posture_adjustment',
+        })
+    );
+
+    assert.deepEqual(metadata.trace_target, {
+        tightness: 2,
+    });
+    assert.deepEqual(metadata.trace_final, {
+        tightness: 4,
+    });
+    assert.equal(
+        metadata.trace_final_reason_code,
+        'runtime_posture_adjustment'
+    );
+});
+
 test('buildResponseMetadata includes steerability controls when provided by runtime context', () => {
     const metadata = buildResponseMetadata(
         baseAssistantMetadata(),

--- a/packages/backend/test/openaiService.metadata.test.ts
+++ b/packages/backend/test/openaiService.metadata.test.ts
@@ -303,6 +303,31 @@ test('buildResponseMetadata emits trace_final_reason_code when final posture dif
     );
 });
 
+test('buildResponseMetadata defaults trace_final_reason_code when final posture differs without explicit code', () => {
+    const metadata = buildResponseMetadata(
+        baseAssistantMetadata(),
+        baseRuntimeContext({
+            plannerTemperament: {
+                tightness: 2,
+            },
+            finalTemperament: {
+                tightness: 4,
+            },
+        })
+    );
+
+    assert.deepEqual(metadata.trace_target, {
+        tightness: 2,
+    });
+    assert.deepEqual(metadata.trace_final, {
+        tightness: 4,
+    });
+    assert.equal(
+        metadata.trace_final_reason_code,
+        'runtime_posture_adjustment'
+    );
+});
+
 test('buildResponseMetadata includes steerability controls when provided by runtime context', () => {
     const metadata = buildResponseMetadata(
         baseAssistantMetadata(),

--- a/packages/backend/test/traceCardHandler.test.ts
+++ b/packages/backend/test/traceCardHandler.test.ts
@@ -14,6 +14,7 @@ import path from 'node:path';
 
 import { createTraceHandlers } from '../src/handlers/trace.js';
 import { SimpleRateLimiter } from '../src/services/rateLimiter.js';
+import { renderTraceCardSvg } from '../src/services/traceCard/traceCardSvg.js';
 import { SqliteTraceStore } from '../src/storage/traces/sqliteTraceStore.js';
 
 type TestServer = {
@@ -257,6 +258,20 @@ test('GET trace-card SVG returns 404 when asset is missing', async () => {
 test('POST /api/trace-cards/from-trace uses stored metadata trace_final and chip scores', async () => {
     const server = await createTestServer();
     const responseId = 'from_trace_response_123';
+    const traceTarget = {
+        tightness: 2,
+        rationale: 3,
+        attribution: 5,
+        caution: 2,
+        extent: 4,
+    } as const;
+    const traceFinal = {
+        tightness: 5,
+        rationale: 4,
+        attribution: 5,
+        caution: 2,
+        extent: 4,
+    } as const;
 
     try {
         await server.store.upsert({
@@ -269,20 +284,9 @@ test('POST /api/trace-cards/from-trace uses stored metadata trace_final and chip
             modelVersion: 'gpt-5-mini',
             staleAfter: new Date(Date.now() + 60000).toISOString(),
             citations: [],
-            trace_target: {
-                tightness: 4,
-                rationale: 3,
-                attribution: 5,
-                caution: 2,
-                extent: 4,
-            },
-            trace_final: {
-                tightness: 4,
-                rationale: 3,
-                attribution: 5,
-                caution: 2,
-                extent: 4,
-            },
+            trace_target: traceTarget,
+            trace_final: traceFinal,
+            trace_final_reason_code: 'runtime_posture_adjustment',
             evidenceScore: 4,
             freshnessScore: 3,
         });
@@ -308,6 +312,30 @@ test('POST /api/trace-cards/from-trace uses stored metadata trace_final and chip
         };
         assert.equal(payload.responseId, responseId);
         assert.ok(payload.pngBase64.length > 32);
+        const storedSvg = await server.store.getTraceCardSvg(responseId);
+        assert.ok(storedSvg);
+        assert.equal(
+            storedSvg,
+            renderTraceCardSvg({
+                temperament: traceFinal,
+                chips: {
+                    evidenceScore: 4,
+                    freshnessScore: 3,
+                },
+            }),
+            'trace-card should render from trace_final'
+        );
+        assert.notEqual(
+            storedSvg,
+            renderTraceCardSvg({
+                temperament: traceTarget,
+                chips: {
+                    evidenceScore: 4,
+                    freshnessScore: 3,
+                },
+            }),
+            'trace-card should not render from trace_target when values differ'
+        );
     } finally {
         await server.close();
         await server.cleanup();

--- a/packages/backend/test/traceCardHandler.test.ts
+++ b/packages/backend/test/traceCardHandler.test.ts
@@ -254,7 +254,7 @@ test('GET trace-card SVG returns 404 when asset is missing', async () => {
     }
 });
 
-test('POST /api/trace-cards/from-trace uses stored metadata temperament and chip scores', async () => {
+test('POST /api/trace-cards/from-trace uses stored metadata trace_final and chip scores', async () => {
     const server = await createTestServer();
     const responseId = 'from_trace_response_123';
 
@@ -269,7 +269,14 @@ test('POST /api/trace-cards/from-trace uses stored metadata temperament and chip
             modelVersion: 'gpt-5-mini',
             staleAfter: new Date(Date.now() + 60000).toISOString(),
             citations: [],
-            temperament: {
+            trace_target: {
+                tightness: 4,
+                rationale: 3,
+                attribution: 5,
+                caution: 2,
+                extent: 4,
+            },
+            trace_final: {
                 tightness: 4,
                 rationale: 3,
                 attribution: 5,
@@ -322,7 +329,14 @@ test('POST /api/trace-cards/from-trace renders successfully when stored chip sco
             modelVersion: 'gpt-5-mini',
             staleAfter: new Date(Date.now() + 60000).toISOString(),
             citations: [],
-            temperament: {
+            trace_target: {
+                tightness: 4,
+                rationale: 3,
+                attribution: 5,
+                caution: 2,
+                extent: 4,
+            },
+            trace_final: {
                 tightness: 4,
                 rationale: 3,
                 attribution: 5,
@@ -356,9 +370,9 @@ test('POST /api/trace-cards/from-trace renders successfully when stored chip sco
     }
 });
 
-test('POST /api/trace-cards/from-trace renders successfully when stored temperament is missing', async () => {
+test('POST /api/trace-cards/from-trace renders successfully when stored trace_final is empty', async () => {
     const server = await createTestServer();
-    const responseId = 'from_trace_missing_temperament';
+    const responseId = 'from_trace_missing_trace_final';
 
     try {
         await server.store.upsert({
@@ -371,6 +385,8 @@ test('POST /api/trace-cards/from-trace renders successfully when stored temperam
             modelVersion: 'gpt-5-mini',
             staleAfter: new Date(Date.now() + 60000).toISOString(),
             citations: [],
+            trace_target: {},
+            trace_final: {},
         });
 
         const response = await fetch(

--- a/packages/backend/test/traceStore.test.ts
+++ b/packages/backend/test/traceStore.test.ts
@@ -39,6 +39,8 @@ test('TraceStore round trips metadata with citation URLs', async () => {
                 url: 'https://example.com/string',
             },
         ],
+        trace_target: {},
+        trace_final: {},
     };
 
     try {
@@ -96,6 +98,8 @@ test('TraceStore round trips trace-card SVG assets', async () => {
             modelVersion: 'gpt-5-mini',
             staleAfter: new Date(Date.now() + 60000).toISOString(),
             citations: [],
+            trace_target: {},
+            trace_final: {},
         });
 
         await store.upsertTraceCardSvg(responseId, initialSvg);
@@ -132,6 +136,8 @@ test('TraceStore delete removes both trace metadata and trace-card SVG', async (
             modelVersion: 'gpt-5-mini',
             staleAfter: new Date(Date.now() + 60000).toISOString(),
             citations: [],
+            trace_target: {},
+            trace_final: {},
         });
         await store.upsertTraceCardSvg(responseId, '<svg>trace-card</svg>');
 

--- a/packages/backend/test/traceStoreService.test.ts
+++ b/packages/backend/test/traceStoreService.test.ts
@@ -24,6 +24,8 @@ const createMetadata = (
     modelVersion: 'gpt-5-mini',
     staleAfter: new Date(Date.now() + 60000).toISOString(),
     citations: [],
+    trace_target: {},
+    trace_final: {},
     ...overrides,
 });
 
@@ -43,7 +45,14 @@ test('storeTrace writes metadata and skips trace-card SVG auto-generation', asyn
     await storeTrace(
         traceStore,
         createMetadata({
-            temperament: {
+            trace_target: {
+                tightness: 5,
+                rationale: 3,
+                attribution: 4,
+                caution: 3,
+                extent: 4,
+            },
+            trace_final: {
                 tightness: 5,
                 rationale: 3,
                 attribution: 4,
@@ -57,7 +66,7 @@ test('storeTrace writes metadata and skips trace-card SVG auto-generation', asyn
     assert.equal(traceCardCalled, false);
 });
 
-test('storeTrace skips trace-card write when temperament is missing', async () => {
+test('storeTrace skips trace-card write when trace_final has no populated axes', async () => {
     let traceCardCalled = false;
 
     const traceStore = {
@@ -89,7 +98,14 @@ test('storeTrace stays fail-open when trace upsert throws', async () => {
         storeTrace(
             traceStore,
             createMetadata({
-                temperament: {
+                trace_target: {
+                    tightness: 5,
+                    rationale: 3,
+                    attribution: 4,
+                    caution: 3,
+                    extent: 4,
+                },
+                trace_final: {
                     tightness: 5,
                     rationale: 3,
                     attribution: 4,

--- a/packages/contracts/src/ethics-core/index.ts
+++ b/packages/contracts/src/ethics-core/index.ts
@@ -18,6 +18,7 @@ export type {
     Citation,
     ProvenanceAssessment,
     TraceAxisScore,
+    TraceFinalizationReasonCode,
     ResponseTemperament,
     PartialResponseTemperament,
     ExecutionStatus,

--- a/packages/contracts/src/ethics-core/types.ts
+++ b/packages/contracts/src/ethics-core/types.ts
@@ -669,6 +669,9 @@ export type ResponseMetadata = {
     // TRACE posture is answer-shape metadata only.
     // Keep this separate from workflowMode (policy/routing) and provenance
     // (what happened / grounding classification).
+    // TODO(trace-lifecycle-summary): Current TRACE contract is summary-state.
+    // If TRACE later evolves across multiple runtime steps, model canonical
+    // lifecycle/history first and derive summary fields from it.
     trace_target: PartialResponseTemperament;
     trace_final: PartialResponseTemperament;
     trace_final_reason_code?: TraceFinalizationReasonCode;

--- a/packages/contracts/src/ethics-core/types.ts
+++ b/packages/contracts/src/ethics-core/types.ts
@@ -104,6 +104,15 @@ export type ResponseTemperament = {
  */
 export type PartialResponseTemperament = Partial<ResponseTemperament>;
 
+/**
+ * Reason code for cases where delivered TRACE posture differs from the
+ * intended TRACE posture.
+ *
+ * Keep this narrow in v1. Additive expansion is allowed when runtime
+ * divergence classes become contract-stable.
+ */
+export type TraceFinalizationReasonCode = 'runtime_posture_adjustment';
+
 export type ExecutionStatus = 'executed' | 'skipped' | 'failed';
 
 /**
@@ -657,10 +666,11 @@ export type ResponseMetadata = {
     imageDescriptions?: string[]; // Optional captions for any images used.
     evidenceScore?: TraceAxisScore; // Optional TRACE chip; may be derived when Retrieved and explicit chip values are absent.
     freshnessScore?: TraceAxisScore; // Optional TRACE chip; may be derived when Retrieved and explicit chip values are absent.
-    // TODO(TRACE-rollout): Make required after TRACE ingestion and rendering
-    // paths are fully implemented and validated across surfaces.
-    // TODO(trace-target-vs-final-contract): Split target vs final TRACE once
-    // review-time runtime can revise response posture after planning.
-    temperament?: PartialResponseTemperament;
+    // TRACE posture is answer-shape metadata only.
+    // Keep this separate from workflowMode (policy/routing) and provenance
+    // (what happened / grounding classification).
+    trace_target: PartialResponseTemperament;
+    trace_final: PartialResponseTemperament;
+    trace_final_reason_code?: TraceFinalizationReasonCode;
     trustGraph?: TrustGraphMetadata;
 };

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -34,6 +34,7 @@ export type {
     EvaluatorOutcome,
     ExecutionEvent,
     TraceAxisScore,
+    TraceFinalizationReasonCode,
     PartialResponseTemperament,
     ResponseTemperament,
     TrustGraphMetadata,

--- a/packages/contracts/src/web/schemas.ts
+++ b/packages/contracts/src/web/schemas.ts
@@ -153,6 +153,9 @@ const ResponseTemperamentSchema = z
     })
     .strict();
 const PartialResponseTemperamentSchema = ResponseTemperamentSchema.partial();
+const TraceFinalizationReasonCodeSchema = z.enum([
+    'runtime_posture_adjustment',
+]);
 const ExecutionStatusSchema = z.enum(WORKFLOW_STEP_STATUSES);
 const ExecutionReasonCodeSchema = z.enum([
     'planner_runtime_error',
@@ -685,10 +688,68 @@ const responseMetadataShape = {
     imageDescriptions: z.array(z.string()).optional(),
     evidenceScore: TraceAxisScoreSchema.optional(),
     freshnessScore: TraceAxisScoreSchema.optional(),
-    // TRACE posture metadata; related to provenance but not equivalent.
-    temperament: PartialResponseTemperamentSchema.optional(),
+    // TRACE posture metadata; policy/mode and provenance stay separate.
+    trace_target: PartialResponseTemperamentSchema,
+    trace_final: PartialResponseTemperamentSchema,
+    trace_final_reason_code: TraceFinalizationReasonCodeSchema.optional(),
     trustGraph: TrustGraphMetadataSchema.optional(),
 } as const;
+
+const hasDifferentTracePosture = (
+    target: z.infer<typeof PartialResponseTemperamentSchema>,
+    final: z.infer<typeof PartialResponseTemperamentSchema>
+): boolean => {
+    const normalizedTarget = {
+        tightness: target.tightness,
+        rationale: target.rationale,
+        attribution: target.attribution,
+        caution: target.caution,
+        extent: target.extent,
+    };
+    const normalizedFinal = {
+        tightness: final.tightness,
+        rationale: final.rationale,
+        attribution: final.attribution,
+        caution: final.caution,
+        extent: final.extent,
+    };
+
+    return JSON.stringify(normalizedTarget) !== JSON.stringify(normalizedFinal);
+};
+
+const requireTraceFinalReasonWhenChanged = (
+    value: {
+        trace_target: z.infer<typeof PartialResponseTemperamentSchema>;
+        trace_final: z.infer<typeof PartialResponseTemperamentSchema>;
+        trace_final_reason_code?: z.infer<
+            typeof TraceFinalizationReasonCodeSchema
+        >;
+    },
+    context: z.RefinementCtx
+): void => {
+    const traceChanged = hasDifferentTracePosture(
+        value.trace_target,
+        value.trace_final
+    );
+
+    if (traceChanged && value.trace_final_reason_code === undefined) {
+        context.addIssue({
+            code: z.ZodIssueCode.custom,
+            path: ['trace_final_reason_code'],
+            message:
+                'trace_final_reason_code is required when trace_final differs from trace_target.',
+        });
+    }
+
+    if (!traceChanged && value.trace_final_reason_code !== undefined) {
+        context.addIssue({
+            code: z.ZodIssueCode.custom,
+            path: ['trace_final_reason_code'],
+            message:
+                'trace_final_reason_code must be omitted when trace_final matches trace_target.',
+        });
+    }
+};
 
 const TraceCardChipDataSchema = z
     .object({
@@ -716,6 +777,7 @@ const TraceCardChipDataSchema = z
  */
 export const ResponseMetadataSchema: z.ZodType<ResponseMetadata> = z
     .object(responseMetadataShape)
+    .superRefine(requireTraceFinalReasonWhenChanged)
     .passthrough();
 
 /**
@@ -1063,7 +1125,10 @@ export const PostInternalTextResponseSchema = z.discriminatedUnion('task', [
  * @api.operationId: postTraces
  * @api.path: POST /api/traces
  */
-export const PostTracesRequestSchema = z.object(responseMetadataShape).strict();
+export const PostTracesRequestSchema = z
+    .object(responseMetadataShape)
+    .superRefine(requireTraceFinalReasonWhenChanged)
+    .strict();
 
 /**
  * @api.operationId: postTraces

--- a/packages/contracts/src/web/schemas.ts
+++ b/packages/contracts/src/web/schemas.ts
@@ -727,6 +727,10 @@ const requireTraceFinalReasonWhenChanged = (
     },
     context: z.RefinementCtx
 ): void => {
+    // TODO(trace-lifecycle): This validates the current summary-field model.
+    // If TRACE later becomes multi-step, keep one canonical lifecycle/history
+    // shape and derive these summary fields instead of treating the pair as
+    // the conceptual source of truth.
     const traceChanged = hasDifferentTracePosture(
         value.trace_target,
         value.trace_final

--- a/packages/contracts/test/breakerDecision.test.ts
+++ b/packages/contracts/test/breakerDecision.test.ts
@@ -27,6 +27,8 @@ const createMetadata = (
     modelVersion: 'gpt-5-mini',
     staleAfter: new Date(Date.now() + 60_000).toISOString(),
     citations: [],
+    trace_target: {},
+    trace_final: {},
     ...overrides,
 });
 

--- a/packages/contracts/test/webSchemas.test.ts
+++ b/packages/contracts/test/webSchemas.test.ts
@@ -84,6 +84,20 @@ const baseMetadata = {
             url: 'https://example.com/article',
         },
     ],
+    trace_target: {
+        tightness: 5,
+        rationale: 3,
+        attribution: 4,
+        caution: 3,
+        extent: 4,
+    },
+    trace_final: {
+        tightness: 5,
+        rationale: 3,
+        attribution: 4,
+        caution: 3,
+        extent: 4,
+    },
 } as const;
 
 const baseIncidentDetail = {
@@ -709,10 +723,17 @@ test('ResponseMetadataSchema rejects invalid execution timeline event kind/statu
     assert.equal(validNonAllowBreaker.success, true);
 });
 
-test('ResponseMetadataSchema accepts valid TRACE temperament metadata', () => {
+test('ResponseMetadataSchema accepts valid TRACE target/final metadata', () => {
     const parsed = ResponseMetadataSchema.safeParse({
         ...baseMetadata,
-        temperament: {
+        trace_target: {
+            tightness: 5,
+            rationale: 3,
+            attribution: 4,
+            caution: 3,
+            extent: 4,
+        },
+        trace_final: {
             tightness: 5,
             rationale: 3,
             attribution: 4,
@@ -724,10 +745,14 @@ test('ResponseMetadataSchema accepts valid TRACE temperament metadata', () => {
     assert.equal(parsed.success, true);
 });
 
-test('ResponseMetadataSchema accepts partial TRACE temperament metadata', () => {
+test('ResponseMetadataSchema accepts partial TRACE target/final metadata', () => {
     const parsed = ResponseMetadataSchema.safeParse({
         ...baseMetadata,
-        temperament: {
+        trace_target: {
+            tightness: 5,
+            attribution: 4,
+        },
+        trace_final: {
             tightness: 5,
             attribution: 4,
         },
@@ -736,16 +761,49 @@ test('ResponseMetadataSchema accepts partial TRACE temperament metadata', () => 
     assert.equal(parsed.success, true);
 });
 
-test('ResponseMetadataSchema rejects invalid TRACE temperament metadata', () => {
+test('ResponseMetadataSchema rejects invalid TRACE target/final metadata', () => {
     const parsed = ResponseMetadataSchema.safeParse({
         ...baseMetadata,
-        temperament: {
+        trace_target: {
             tightness: 6,
             rationale: 3,
             attribution: 4,
             caution: 3,
             extent: 4,
         },
+        trace_final: {
+            tightness: 5,
+            rationale: 3,
+            attribution: 4,
+            caution: 3,
+            extent: 4,
+        },
+    });
+
+    assert.equal(parsed.success, false);
+});
+
+test('ResponseMetadataSchema requires divergence reason code when trace_target and trace_final differ', () => {
+    const missingReason = ResponseMetadataSchema.safeParse({
+        ...baseMetadata,
+        trace_target: { tightness: 3 },
+        trace_final: { tightness: 5 },
+    });
+    assert.equal(missingReason.success, false);
+
+    const withReason = ResponseMetadataSchema.safeParse({
+        ...baseMetadata,
+        trace_target: { tightness: 3 },
+        trace_final: { tightness: 5 },
+        trace_final_reason_code: 'runtime_posture_adjustment',
+    });
+    assert.equal(withReason.success, true);
+});
+
+test('ResponseMetadataSchema rejects trace_final_reason_code when trace_target and trace_final match', () => {
+    const parsed = ResponseMetadataSchema.safeParse({
+        ...baseMetadata,
+        trace_final_reason_code: 'runtime_posture_adjustment',
     });
 
     assert.equal(parsed.success, false);

--- a/packages/discord-bot/src/interactions/button/provenanceButtons.ts
+++ b/packages/discord-bot/src/interactions/button/provenanceButtons.ts
@@ -179,6 +179,17 @@ function formatSummarySection(
     ].join('\n');
 }
 
+/**
+ * Build the TRACE section as Discord-flavored Markdown for a details payload.
+ *
+ * Produces either an unavailable message when provenance is missing, or a multiline TRACE
+ * block containing Target and Final fields for tightness, rationale, attribution, caution,
+ * and extent. Includes a "Final Reason" line only when an explicit final reason code is present
+ * or when any Target field differs from its Final counterpart, and appends Evidence and Freshness lines.
+ *
+ * @param payload - The response metadata or a resilient fallback payload to render
+ * @returns A Markdown-formatted TRACE section suitable for inclusion in the overall details message
+ */
 function formatTraceSection(
     payload: ResponseMetadata | DetailsFallbackPayload
 ): string {

--- a/packages/discord-bot/src/interactions/button/provenanceButtons.ts
+++ b/packages/discord-bot/src/interactions/button/provenanceButtons.ts
@@ -188,7 +188,17 @@ function formatTraceSection(
 
     const traceTarget = payload.trace_target;
     const traceFinal = payload.trace_final;
-    return [
+    const traceDiverged =
+        traceTarget.tightness !== traceFinal.tightness ||
+        traceTarget.rationale !== traceFinal.rationale ||
+        traceTarget.attribution !== traceFinal.attribution ||
+        traceTarget.caution !== traceFinal.caution ||
+        traceTarget.extent !== traceFinal.extent;
+    const hasExplicitFinalReason =
+        typeof payload.trace_final_reason_code === 'string' &&
+        payload.trace_final_reason_code.trim().length > 0;
+
+    const traceLines = [
         '**TRACE**',
         `- Target Tightness: \`${formatMarkdownValue(traceTarget.tightness)}\``,
         `- Target Rationale: \`${formatMarkdownValue(traceTarget.rationale)}\``,
@@ -200,10 +210,18 @@ function formatTraceSection(
         `- Final Attribution: \`${formatMarkdownValue(traceFinal.attribution)}\``,
         `- Final Caution: \`${formatMarkdownValue(traceFinal.caution)}\``,
         `- Final Extent: \`${formatMarkdownValue(traceFinal.extent)}\``,
-        `- Final Reason: \`${formatMarkdownValue(payload.trace_final_reason_code)}\``,
+    ];
+    if (hasExplicitFinalReason || traceDiverged) {
+        traceLines.push(
+            `- Final Reason: \`${formatMarkdownValue(payload.trace_final_reason_code)}\``
+        );
+    }
+    traceLines.push(
         `- Evidence: \`${formatMarkdownValue(payload.evidenceScore)}\``,
-        `- Freshness: \`${formatMarkdownValue(payload.freshnessScore)}\``,
-    ].join('\n');
+        `- Freshness: \`${formatMarkdownValue(payload.freshnessScore)}\``
+    );
+
+    return traceLines.join('\n');
 }
 
 /**

--- a/packages/discord-bot/src/interactions/button/provenanceButtons.ts
+++ b/packages/discord-bot/src/interactions/button/provenanceButtons.ts
@@ -186,14 +186,21 @@ function formatTraceSection(
         return ['**TRACE**', '- TRACE scores unavailable'].join('\n');
     }
 
-    const temperament = payload.temperament;
+    const traceTarget = payload.trace_target;
+    const traceFinal = payload.trace_final;
     return [
         '**TRACE**',
-        `- Tightness: \`${formatMarkdownValue(temperament?.tightness)}\``,
-        `- Rationale: \`${formatMarkdownValue(temperament?.rationale)}\``,
-        `- Attribution: \`${formatMarkdownValue(temperament?.attribution)}\``,
-        `- Caution: \`${formatMarkdownValue(temperament?.caution)}\``,
-        `- Extent: \`${formatMarkdownValue(temperament?.extent)}\``,
+        `- Target Tightness: \`${formatMarkdownValue(traceTarget.tightness)}\``,
+        `- Target Rationale: \`${formatMarkdownValue(traceTarget.rationale)}\``,
+        `- Target Attribution: \`${formatMarkdownValue(traceTarget.attribution)}\``,
+        `- Target Caution: \`${formatMarkdownValue(traceTarget.caution)}\``,
+        `- Target Extent: \`${formatMarkdownValue(traceTarget.extent)}\``,
+        `- Final Tightness: \`${formatMarkdownValue(traceFinal.tightness)}\``,
+        `- Final Rationale: \`${formatMarkdownValue(traceFinal.rationale)}\``,
+        `- Final Attribution: \`${formatMarkdownValue(traceFinal.attribution)}\``,
+        `- Final Caution: \`${formatMarkdownValue(traceFinal.caution)}\``,
+        `- Final Extent: \`${formatMarkdownValue(traceFinal.extent)}\``,
+        `- Final Reason: \`${formatMarkdownValue(payload.trace_final_reason_code)}\``,
         `- Evidence: \`${formatMarkdownValue(payload.evidenceScore)}\``,
         `- Freshness: \`${formatMarkdownValue(payload.freshnessScore)}\``,
     ].join('\n');

--- a/packages/discord-bot/src/utils/response/provenanceCgi.ts
+++ b/packages/discord-bot/src/utils/response/provenanceCgi.ts
@@ -34,7 +34,7 @@ function normalizeResponseId(responseId: string): string {
 }
 
 const normalizeTemperament = (
-    temperament: ResponseMetadata['temperament']
+    temperament: ResponseMetadata['trace_final']
 ): PartialResponseTemperament | undefined => {
     if (!temperament) {
         return undefined;
@@ -80,7 +80,7 @@ const normalizeTraceCardChips = (
 export function buildTraceCardRequest(
     metadata: ResponseMetadata
 ): PostTraceCardRequest {
-    const temperament = normalizeTemperament(metadata.temperament);
+    const temperament = normalizeTemperament(metadata.trace_final);
     const chips = normalizeTraceCardChips(metadata);
 
     return {

--- a/packages/discord-bot/src/utils/response/provenanceCgi.ts
+++ b/packages/discord-bot/src/utils/response/provenanceCgi.ts
@@ -28,6 +28,12 @@ const TRACE_AXIS_KEYS = [
     'extent',
 ] as const;
 
+/**
+ * Normalize a response identifier by trimming surrounding whitespace and substituting a fallback when empty.
+ *
+ * @param responseId - The response identifier to normalize
+ * @returns The trimmed `responseId`, or `unknown_response_id` when the trimmed value is empty
+ */
 function normalizeResponseId(responseId: string): string {
     const trimmed = responseId.trim();
     return trimmed.length > 0 ? trimmed : UNKNOWN_RESPONSE_ID_FALLBACK;
@@ -75,7 +81,10 @@ const normalizeTraceCardChips = (
 };
 
 /**
- * Builds the backend trace-card request from response metadata.
+ * Constructs a trace-card request payload from response metadata.
+ *
+ * @param metadata - Response metadata used to derive the request fields
+ * @returns A PostTraceCardRequest with a normalized `responseId`; includes `temperament` and `chips` only when those values are present after normalization
  */
 export function buildTraceCardRequest(
     metadata: ResponseMetadata

--- a/packages/discord-bot/test/incidentReporting.test.ts
+++ b/packages/discord-bot/test/incidentReporting.test.ts
@@ -43,6 +43,8 @@ test('handleIncidentReportButton opens a consent prompt and cancel clears it', a
             modelVersion: 'gpt-5-mini',
             staleAfter: new Date(Date.now() + 60000).toISOString(),
             citations: [],
+            trace_target: {},
+            trace_final: {},
         },
     })) as typeof botApi.getTrace;
 
@@ -124,6 +126,8 @@ test('incident report modal stores the incident and remediation outcome', async 
             modelVersion: 'gpt-5-mini',
             staleAfter: new Date(Date.now() + 60000).toISOString(),
             citations: [],
+            trace_target: {},
+            trace_final: {},
         },
     })) as typeof botApi.getTrace;
     botApi.reportIncident = (async (request) => {
@@ -289,6 +293,8 @@ test('incident report modal replies explicitly on backend failure', async () => 
             modelVersion: 'gpt-5-mini',
             staleAfter: new Date(Date.now() + 60000).toISOString(),
             citations: [],
+            trace_target: {},
+            trace_final: {},
         },
     })) as typeof botApi.getTrace;
     botApi.reportIncident = (async () => {
@@ -367,6 +373,8 @@ test('incident report modal keeps the deferred reply open when remediation persi
             modelVersion: 'gpt-5-mini',
             staleAfter: new Date(Date.now() + 60000).toISOString(),
             citations: [],
+            trace_target: {},
+            trace_final: {},
         },
     })) as typeof botApi.getTrace;
     botApi.reportIncident = (async () => ({
@@ -473,6 +481,8 @@ test('incident report retry resumes remediation persistence without creating a d
             modelVersion: 'gpt-5-mini',
             staleAfter: new Date(Date.now() + 60000).toISOString(),
             citations: [],
+            trace_target: {},
+            trace_final: {},
         },
     })) as typeof botApi.getTrace;
     botApi.reportIncident = (async () => {

--- a/packages/discord-bot/test/messageProcessor.chat.test.ts
+++ b/packages/discord-bot/test/messageProcessor.chat.test.ts
@@ -31,6 +31,8 @@ const createMetadata = (): ResponseMetadata => ({
     modelVersion: 'gpt-5-mini',
     staleAfter: new Date(Date.now() + 60000).toISOString(),
     citations: [],
+    trace_target: {},
+    trace_final: {},
 });
 
 const createBreakerMetadata = (
@@ -380,7 +382,7 @@ test('prepareProvenanceCgiPayload and sendPreparedProvenanceCgi send image plus 
         const preparedPayload =
             await processorAccess.prepareProvenanceCgiPayload({
                 ...createMetadata(),
-                temperament: {
+                trace_final: {
                     tightness: 5,
                     rationale: 3,
                 },

--- a/packages/discord-bot/test/messageProcessor.chat.test.ts
+++ b/packages/discord-bot/test/messageProcessor.chat.test.ts
@@ -386,6 +386,7 @@ test('prepareProvenanceCgiPayload and sendPreparedProvenanceCgi send image plus 
                     tightness: 5,
                     rationale: 3,
                 },
+                trace_final_reason_code: 'runtime_posture_adjustment',
                 evidenceScore: 4,
                 freshnessScore: 5,
             });

--- a/packages/discord-bot/test/provenanceButtons.test.ts
+++ b/packages/discord-bot/test/provenanceButtons.test.ts
@@ -53,7 +53,14 @@ test('details action renders markdown sections with execution table and trace vi
             totalDurationMs: 321,
             evidenceScore: 4,
             freshnessScore: 3,
-            temperament: {
+            trace_target: {
+                tightness: 4,
+                rationale: 4,
+                attribution: 5,
+                caution: 3,
+                extent: 4,
+            },
+            trace_final: {
                 tightness: 4,
                 rationale: 4,
                 attribution: 5,
@@ -171,7 +178,14 @@ test('details action truncates oversized payloads while preserving section reada
                     index % 3 === 0 ? 'tool_execution_error' : 'tool_not_used',
                 durationMs: 100 + index,
             })),
-            temperament: {
+            trace_target: {
+                tightness: 4,
+                rationale: 4,
+                attribution: 4,
+                caution: 3,
+                extent: 4,
+            },
+            trace_final: {
                 tightness: 4,
                 rationale: 4,
                 attribution: 4,

--- a/packages/discord-bot/test/provenanceButtons.test.ts
+++ b/packages/discord-bot/test/provenanceButtons.test.ts
@@ -63,10 +63,11 @@ test('details action renders markdown sections with execution table and trace vi
             trace_final: {
                 tightness: 4,
                 rationale: 4,
-                attribution: 5,
+                attribution: 3,
                 caution: 3,
                 extent: 4,
             },
+            trace_final_reason_code: 'runtime_posture_adjustment',
             citations: [
                 {
                     title: 'Primary source ] title',
@@ -76,7 +77,7 @@ test('details action renders markdown sections with execution table and trace vi
             ],
             execution: [
                 {
-                    kind: 'planner',
+                    kind: 'generation',
                     status: 'executed',
                     model: 'gpt-5-mini',
                     durationMs: 25,
@@ -131,6 +132,9 @@ test('details action renders markdown sections with execution table and trace vi
         assert.match(content, /\*\*Trace Viewer\*\*/);
         assert.match(content, /Open full trace/);
         assert.match(content, /\/traces\/resp_details_sections/);
+        assert.match(content, /Target Attribution: `5`/);
+        assert.match(content, /Final Attribution: `3`/);
+        assert.match(content, /Final Reason: `runtime_posture_adjustment`/);
         assert.match(content, /weaponization_request/);
         assert.match(content, /High\/Inferred\/block/);
         assert.match(content, /```text/);
@@ -189,9 +193,10 @@ test('details action truncates oversized payloads while preserving section reada
                 tightness: 4,
                 rationale: 4,
                 attribution: 4,
-                caution: 3,
+                caution: 2,
                 extent: 4,
             },
+            trace_final_reason_code: 'runtime_posture_adjustment',
         },
     })) as typeof botApi.getTrace;
 

--- a/packages/discord-bot/test/provenanceCgi.test.ts
+++ b/packages/discord-bot/test/provenanceCgi.test.ts
@@ -28,6 +28,8 @@ function createMetadata(): ResponseMetadata {
         modelVersion: 'gpt-5-mini',
         staleAfter: '2026-03-05T00:00:00.000Z',
         citations: [],
+        trace_target: {},
+        trace_final: {},
     };
 }
 
@@ -75,7 +77,7 @@ test('buildTraceCardRequest forwards metadata-provided TRACE values without defa
     const metadata = createMetadata();
     const request = buildTraceCardRequest({
         ...metadata,
-        temperament: {
+        trace_final: {
             tightness: 5,
             attribution: 3,
         },
@@ -99,7 +101,7 @@ test('buildTraceCardRequest omits invalid or missing TRACE values', () => {
     const request = buildTraceCardRequest({
         ...metadata,
         responseId: '   ',
-        temperament: {
+        trace_final: {
             tightness: 6 as unknown as 5,
         },
         evidenceScore: 2.4 as unknown as 1,

--- a/packages/discord-bot/test/provenanceInteractions.test.ts
+++ b/packages/discord-bot/test/provenanceInteractions.test.ts
@@ -102,6 +102,8 @@ test('resolveProvenanceMetadata rejects mismatched trace payload response IDs', 
                 modelVersion: 'gpt-5-mini',
                 staleAfter: new Date().toISOString(),
                 citations: [],
+                trace_target: {},
+                trace_final: {},
             },
         }) as Awaited<ReturnType<typeof botApi.getTrace>>;
 


### PR DESCRIPTION
## What changed
- Added canonical TRACE posture fields in response metadata:
  - `trace_target`
  - `trace_final`
  - `trace_final_reason_code` (when posture changes)
- Enforced the target/final divergence invariant in contracts schema validation:
  - if `trace_target` and `trace_final` differ, reason code is required
  - if they match, reason code must be omitted
- Updated backend metadata assembly to emit the canonical TRACE fields and keep separation clear between:
  - workflow mode (policy/routing)
  - TRACE (answer posture)
  - provenance (grounding/event record)
- Updated trace-card and Discord provenance paths to consume `trace_final` where delivered posture is displayed.
- Updated tests across contracts/backend/discord for the new canonical fields and invariants.
- Added a small semantic hardening follow-up:
  - targeted `TODO(trace-lifecycle...)` seam comments at the contract/schema/metadata seams
  - wording clarifications in docs/OpenAPI to state current fields are summary-state and lifecycle/history semantics are future work.

## Why
The runtime can legitimately alter posture during orchestration (for example, escalation/reconsideration). This PR makes that explicit and auditable now, while avoiding a premature full lifecycle redesign.

It also prevents a key failure mode: treating TRACE as a proxy for workflow mode or provenance.

## Important implementation details
- This PR does **not** add lifecycle arrays/state (`trace[]`, `trace_lifecycle`) or migration scaffolding.
- This PR keeps behavior fail-open and focuses on explicit, serializable metadata semantics.
- The lifecycle direction is documented only as forward-looking seam TODOs; current implementation remains summary-field based.
- OpenAPI/architecture wording was aligned with the implemented reality so contributors are not misled about lifecycle completeness.

This PR was written using [Vibe Kanban](https://vibekanban.com)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor / Data**
  * TRACE metadata now uses required trace_target (intended) and trace_final (delivered) posture fields; trace_final_reason_code is required when they differ and prohibited when they match.
* **User-facing**
  * Trace views and cards display both Target and Final posture and show a Final Reason when applicable.
* **Documentation & Tests**
  * Docs clarified; tests updated to enforce new fields and conditional validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->