### PR TITLE
Formalize Assess Output Contract in Workflow Lineage (Vibe Kanban)

### DIFF
--- a/docs/architecture/workflow-engine-and-provenance.md
+++ b/docs/architecture/workflow-engine-and-provenance.md
@@ -101,6 +101,8 @@ Each `StepRecord` includes an `outcome` with minimal typed fields:
 This keeps handoff data explicit without a separate top-level handoff type.
 `signals` means machine-readable control indicators used by transition logic
 (for example `goalMet`, `needsMoreEvidence`, `toolResultQuality`), not generic telemetry.
+For bounded review `assess` steps, use `reviewDecision` (`finalize` or `revise`)
+plus `reviewReason` as the canonical machine output seam.
 `recommendations` is advisory only and never overrides backend legality checks.
 
 ## Transition Legality

--- a/docs/architecture/workflow-profiles-v1-engine-vs-profile-semantics.md
+++ b/docs/architecture/workflow-profiles-v1-engine-vs-profile-semantics.md
@@ -110,6 +110,8 @@ Expected lifecycle:
 2. For each iteration (up to profile max):
 
 - `assess` runs and returns a profile decision: `finalize` or `revise`.
+  The assess `StepRecord.outcome.signals` is the canonical machine-readable
+  seam for this decision: `reviewDecision` + `reviewReason`.
     - If `finalize`, terminate with `goal_satisfied`.
     - If `revise`, run `revise`, then continue loop.
 

--- a/docs/status/2026-04-02-workflow-engine-rollout-status.md
+++ b/docs/status/2026-04-02-workflow-engine-rollout-status.md
@@ -2,7 +2,7 @@
 
 ## Last Updated
 
-2026-04-03
+2026-04-12
 
 ## Owners
 
@@ -23,6 +23,8 @@ Architecture reference:
 
 - Workflow metadata is now aligned to `WorkflowRecord` + `StepRecord`.
 - Step outcomes now have explicit machine-readable control signals.
+- Bounded review assess steps now emit canonical machine-readable decision and
+  reason signals in lineage (`reviewDecision`, `reviewReason`).
 - Workflow termination reasons are now contract-level.
 - Workflow profile contract now documents required profile hooks,
   blocked/no-generation behavior, and no-generation provenance invariants.

--- a/packages/backend/src/services/workflowEngine.ts
+++ b/packages/backend/src/services/workflowEngine.ts
@@ -8,6 +8,7 @@
 import type { WorkflowStepKind } from '@footnote/contracts/ethics-core';
 import type { WorkflowTerminationReason } from '@footnote/contracts/ethics-core';
 import type {
+    BoundedReviewAssessSignals,
     ExecutionReasonCode,
     StepRecord,
     WorkflowRecord,
@@ -58,11 +59,6 @@ export type WorkflowState = {
 export type ReviewDecision = {
     decision: 'finalize' | 'revise';
     reason: string;
-};
-
-type AssessStepSignals = {
-    reviewDecision: ReviewDecision['decision'];
-    reviewReason: string;
 };
 
 export const DEFAULT_REVIEW_DECISION_PROMPT = `Return plain JSON only.
@@ -704,7 +700,7 @@ export const runBoundedReviewWorkflow = async ({
                 break;
             }
 
-            const assessSignals: AssessStepSignals = {
+            const assessSignals: BoundedReviewAssessSignals = {
                 reviewDecision: decision.decision,
                 reviewReason: decision.reason,
             };

--- a/packages/backend/src/services/workflowEngine.ts
+++ b/packages/backend/src/services/workflowEngine.ts
@@ -60,6 +60,11 @@ export type ReviewDecision = {
     reason: string;
 };
 
+type AssessStepSignals = {
+    reviewDecision: ReviewDecision['decision'];
+    reviewReason: string;
+};
+
 export const DEFAULT_REVIEW_DECISION_PROMPT = `Return plain JSON only.
 Schema:
 {
@@ -670,19 +675,6 @@ export const runBoundedReviewWorkflow = async ({
                 reviewResult,
                 generationRequest.model
             );
-            const reviewStepId = captureStep({
-                stepKind: 'assess',
-                status: 'executed',
-                summary:
-                    'Assessment step evaluated draft quality and goal completion.',
-                startedAtMs: reviewStartedAt,
-                finishedAtMs: reviewFinishedAt,
-                model: reviewUsage.model,
-                usage: reviewResult.usage,
-                estimatedCost: reviewUsage.estimatedCost,
-                parentStepId: draftParentStepId,
-                attempt: iteration,
-            });
             workflowState = applyStepExecutionToState(
                 workflowState,
                 'assess',
@@ -692,12 +684,44 @@ export const runBoundedReviewWorkflow = async ({
             );
             const decision = effectiveParseReviewDecision(reviewResult.text);
             if (!decision) {
+                captureStep({
+                    stepKind: 'assess',
+                    status: 'failed',
+                    summary:
+                        'Assessment step returned invalid decision output; fail-open returned latest successful draft.',
+                    reasonCode: 'generation_runtime_error',
+                    startedAtMs: reviewStartedAt,
+                    finishedAtMs: reviewFinishedAt,
+                    model: reviewUsage.model,
+                    usage: reviewResult.usage,
+                    estimatedCost: reviewUsage.estimatedCost,
+                    parentStepId: draftParentStepId,
+                    attempt: iteration,
+                });
                 terminationReason = 'executor_error_fail_open';
                 workflowStatus = 'degraded';
                 shouldStop = true;
                 break;
             }
 
+            const assessSignals: AssessStepSignals = {
+                reviewDecision: decision.decision,
+                reviewReason: decision.reason,
+            };
+            const reviewStepId = captureStep({
+                stepKind: 'assess',
+                status: 'executed',
+                summary:
+                    'Assessment step evaluated draft quality and emitted bounded review decision.',
+                startedAtMs: reviewStartedAt,
+                finishedAtMs: reviewFinishedAt,
+                model: reviewUsage.model,
+                usage: reviewResult.usage,
+                estimatedCost: reviewUsage.estimatedCost,
+                parentStepId: draftParentStepId,
+                attempt: iteration,
+                signals: assessSignals,
+            });
             latestReviewReason = decision.reason;
             if (decision.decision === 'finalize') {
                 terminationReason = 'goal_satisfied';

--- a/packages/backend/test/chatService.test.ts
+++ b/packages/backend/test/chatService.test.ts
@@ -905,6 +905,14 @@ test('runChatMessages executes bounded review loop and forwards workflow lineage
     assert.equal(capturedWorkflow?.terminationReason, 'goal_satisfied');
     assert.equal(capturedWorkflow?.status, 'completed');
     assert.ok((capturedWorkflow?.steps.length ?? 0) >= 2);
+    const assessStep = capturedWorkflow?.steps.find(
+        (step) => step.stepKind === 'assess'
+    );
+    assert.equal(assessStep?.outcome.signals?.reviewDecision, 'finalize');
+    assert.equal(
+        assessStep?.outcome.signals?.reviewReason,
+        'Draft is complete and clear.'
+    );
 });
 
 test('runChatMessages fails open when review output is invalid', async () => {

--- a/packages/backend/test/workflowEngine.test.ts
+++ b/packages/backend/test/workflowEngine.test.ts
@@ -533,9 +533,9 @@ test('runBoundedReviewWorkflow persists assess machine decision and reason in li
         },
         captureUsage: (generationResult, requestedModel) => ({
             model: requestedModel ?? generationResult.model ?? 'gpt-5-mini',
-            promptTokens: generationResult.usage.promptTokens ?? 0,
-            completionTokens: generationResult.usage.completionTokens ?? 0,
-            totalTokens: generationResult.usage.totalTokens ?? 0,
+            promptTokens: generationResult.usage?.promptTokens ?? 0,
+            completionTokens: generationResult.usage?.completionTokens ?? 0,
+            totalTokens: generationResult.usage?.totalTokens ?? 0,
             estimatedCost: {
                 inputCostUsd: 0,
                 outputCostUsd: 0,

--- a/packages/backend/test/workflowEngine.test.ts
+++ b/packages/backend/test/workflowEngine.test.ts
@@ -157,7 +157,8 @@ test('applyStepExecutionToState sanitizes invalid deltas and increments stepCoun
 test('isWithinExecutionLimits reports each exhausted limit key', () => {
     const limits = createLimits();
     const startedAtMs = 500;
-    const nowMs = 1500;
+    const withinDurationNowMs = 1200;
+    const exhaustedDurationNowMs = 1500;
 
     const exhaustedBySteps = isWithinExecutionLimits(
         {
@@ -171,7 +172,7 @@ test('isWithinExecutionLimits reports each exhausted limit key', () => {
             totalTokens: 0,
         },
         limits,
-        nowMs
+        withinDurationNowMs
     );
     assert.equal(exhaustedBySteps.withinLimits, false);
     assert.equal(exhaustedBySteps.exhaustedBy, 'maxWorkflowSteps');
@@ -188,7 +189,8 @@ test('isWithinExecutionLimits reports each exhausted limit key', () => {
             totalTokens: 0,
         },
         limits,
-        nowMs
+        withinDurationNowMs,
+        'tool'
     );
     assert.equal(exhaustedByTools.withinLimits, false);
     assert.equal(exhaustedByTools.exhaustedBy, 'maxToolCalls');
@@ -205,7 +207,8 @@ test('isWithinExecutionLimits reports each exhausted limit key', () => {
             totalTokens: 0,
         },
         limits,
-        nowMs
+        withinDurationNowMs,
+        'assess'
     );
     assert.equal(exhaustedByDeliberation.withinLimits, false);
     assert.equal(exhaustedByDeliberation.exhaustedBy, 'maxDeliberationCalls');
@@ -222,7 +225,7 @@ test('isWithinExecutionLimits reports each exhausted limit key', () => {
             totalTokens: 100,
         },
         limits,
-        nowMs
+        withinDurationNowMs
     );
     assert.equal(exhaustedByTokens.withinLimits, false);
     assert.equal(exhaustedByTokens.exhaustedBy, 'maxTokensTotal');
@@ -239,7 +242,7 @@ test('isWithinExecutionLimits reports each exhausted limit key', () => {
             totalTokens: 0,
         },
         limits,
-        nowMs
+        exhaustedDurationNowMs
     );
     assert.equal(exhaustedByDuration.withinLimits, false);
     assert.equal(exhaustedByDuration.exhaustedBy, 'maxDurationMs');
@@ -466,5 +469,91 @@ test('runBoundedReviewWorkflow classifies initial generate runtime failure as no
     assert.equal(
         result.workflowLineage.steps[0].reasonCode,
         'generation_runtime_error'
+    );
+});
+
+test('runBoundedReviewWorkflow persists assess machine decision and reason in lineage signals', async () => {
+    let generationCalls = 0;
+    const generationRuntime: GenerationRuntime = {
+        kind: 'test-runtime',
+        async generate() {
+            generationCalls += 1;
+            if (generationCalls === 1) {
+                return {
+                    text: 'initial draft',
+                    model: 'gpt-5-mini',
+                    usage: {
+                        promptTokens: 20,
+                        completionTokens: 10,
+                        totalTokens: 30,
+                    },
+                    provenance: 'Inferred',
+                    citations: [],
+                };
+            }
+
+            if (generationCalls === 2) {
+                return {
+                    text: '{"decision":"finalize","reason":"Draft is complete and clear."}',
+                    model: 'gpt-5-mini',
+                    usage: {
+                        promptTokens: 8,
+                        completionTokens: 6,
+                        totalTokens: 14,
+                    },
+                    provenance: 'Inferred',
+                    citations: [],
+                };
+            }
+
+            throw new Error(`Unexpected generation call ${generationCalls}`);
+        },
+    };
+
+    const result = await runBoundedReviewWorkflow({
+        generationRuntime,
+        generationRequest: {
+            model: 'gpt-5-mini',
+            messages: [{ role: 'user', content: 'Summarize this.' }],
+        },
+        messagesWithHints: [{ role: 'user', content: 'Summarize this.' }],
+        generationStartedAtMs: Date.now(),
+        workflowConfig: {
+            workflowName: 'message_with_review_loop',
+            maxIterations: 2,
+            maxDurationMs: 15000,
+        },
+        workflowPolicy: {
+            enablePlanning: false,
+            enableToolUse: false,
+            enableReplanning: false,
+            enableGeneration: true,
+            enableAssessment: true,
+            enableRevision: true,
+        },
+        captureUsage: (generationResult, requestedModel) => ({
+            model: requestedModel ?? generationResult.model ?? 'gpt-5-mini',
+            promptTokens: generationResult.usage.promptTokens ?? 0,
+            completionTokens: generationResult.usage.completionTokens ?? 0,
+            totalTokens: generationResult.usage.totalTokens ?? 0,
+            estimatedCost: {
+                inputCostUsd: 0,
+                outputCostUsd: 0,
+                totalCostUsd: 0,
+            },
+        }),
+    });
+
+    assert.equal(result.outcome, 'generated');
+    assert.equal(result.workflowLineage.terminationReason, 'goal_satisfied');
+    const assessStep = result.workflowLineage.steps.find(
+        (step) => step.stepKind === 'assess'
+    );
+    assert.ok(assessStep);
+    assert.equal(assessStep.outcome.status, 'executed');
+    assert.equal(assessStep.outcome.signals?.reviewDecision, 'finalize');
+    assert.equal(
+        assessStep.outcome.signals?.reviewReason,
+        'Draft is complete and clear.'
     );
 });

--- a/packages/backend/test/workflowEngine.test.ts
+++ b/packages/backend/test/workflowEngine.test.ts
@@ -556,4 +556,5 @@ test('runBoundedReviewWorkflow persists assess machine decision and reason in li
         assessStep.outcome.signals?.reviewReason,
         'Draft is complete and clear.'
     );
+    assert.equal(generationCalls, 2);
 });

--- a/packages/contracts/src/ethics-core/index.ts
+++ b/packages/contracts/src/ethics-core/index.ts
@@ -43,6 +43,8 @@ export type {
     WorkflowStepStatus,
     WorkflowStepKind,
     WorkflowTerminationReason,
+    BoundedReviewAssessDecision,
+    BoundedReviewAssessSignals,
     StepOutcome,
     StepRecord,
     WorkflowRecord,
@@ -72,6 +74,7 @@ export {
     WORKFLOW_STEP_STATUSES,
     WORKFLOW_STEP_KINDS,
     WORKFLOW_TERMINATION_REASONS,
+    BOUNDED_REVIEW_ASSESS_DECISIONS,
 } from './types.js';
 export { formatExecutionTimelineSummary } from './executionFormatting.js';
 export {

--- a/packages/contracts/src/ethics-core/types.ts
+++ b/packages/contracts/src/ethics-core/types.ts
@@ -395,10 +395,36 @@ export const WORKFLOW_TERMINATION_REASONS = [
 export type WorkflowTerminationReason =
     (typeof WORKFLOW_TERMINATION_REASONS)[number];
 
+/**
+ * Canonical assess-step decisions emitted by bounded review profiles.
+ * These are advisory outputs used by workflow transitions, not policy authority.
+ */
+export const BOUNDED_REVIEW_ASSESS_DECISIONS = ['finalize', 'revise'] as const;
+
+export type BoundedReviewAssessDecision =
+    (typeof BOUNDED_REVIEW_ASSESS_DECISIONS)[number];
+
+/**
+ * Canonical machine-readable assess output for bounded review profiles.
+ *
+ * Keep this intentionally narrow so review output remains inspectable and does
+ * not become a generic policy bag.
+ */
+export type BoundedReviewAssessSignals = {
+    reviewDecision: BoundedReviewAssessDecision;
+    reviewReason: string;
+};
+
 export type StepOutcome = {
     status: WorkflowStepStatus;
     summary: string;
     artifacts?: string[];
+    /**
+     * Machine-readable per-step outputs.
+     *
+     * For `stepKind === "assess"` in the bounded-review profile, emit
+     * `reviewDecision` + `reviewReason` as the canonical decision seam.
+     */
     signals?: Record<string, string | number | boolean | null>;
     recommendations?: string[];
 };

--- a/packages/contracts/src/web/schemas.ts
+++ b/packages/contracts/src/web/schemas.ts
@@ -8,6 +8,7 @@
 
 import { z } from 'zod';
 import {
+    BOUNDED_REVIEW_ASSESS_DECISIONS,
     WORKFLOW_STEP_KINDS,
     WORKFLOW_STEP_STATUSES,
     WORKFLOW_TERMINATION_REASONS,
@@ -390,6 +391,50 @@ const StepRecordSchema = z
             .strict()
             .optional(),
         outcome: StepOutcomeSchema,
+    })
+    .superRefine((value, context) => {
+        if (
+            value.stepKind !== 'assess' ||
+            value.outcome.status !== 'executed'
+        ) {
+            return;
+        }
+
+        const assessSignals = value.outcome.signals;
+        const reviewDecision =
+            assessSignals !== undefined
+                ? assessSignals.reviewDecision
+                : undefined;
+        const reviewReason =
+            assessSignals !== undefined
+                ? assessSignals.reviewReason
+                : undefined;
+
+        if (
+            typeof reviewDecision !== 'string' ||
+            !BOUNDED_REVIEW_ASSESS_DECISIONS.includes(
+                reviewDecision as (typeof BOUNDED_REVIEW_ASSESS_DECISIONS)[number]
+            )
+        ) {
+            context.addIssue({
+                code: z.ZodIssueCode.custom,
+                path: ['outcome', 'signals', 'reviewDecision'],
+                message:
+                    'executed assess steps must include reviewDecision: "finalize" | "revise".',
+            });
+        }
+
+        if (
+            typeof reviewReason !== 'string' ||
+            reviewReason.trim().length === 0
+        ) {
+            context.addIssue({
+                code: z.ZodIssueCode.custom,
+                path: ['outcome', 'signals', 'reviewReason'],
+                message:
+                    'executed assess steps must include non-empty reviewReason.',
+            });
+        }
     })
     .strict();
 

--- a/packages/contracts/test/webSchemas.test.ts
+++ b/packages/contracts/test/webSchemas.test.ts
@@ -343,7 +343,9 @@ const createValidWorkflowMetadataPayload = (now: string) => ({
                     status: 'executed',
                     summary: 'Assessment step evaluated draft quality.',
                     signals: {
-                        goalMet: true,
+                        reviewDecision: 'finalize',
+                        reviewReason:
+                            'Draft answers the request with sufficient clarity.',
                     },
                 },
             },
@@ -506,6 +508,21 @@ test('ResponseMetadataSchema rejects workflow lineage with invalid termination r
             ],
         },
     });
+
+    assert.equal(parsed.success, false);
+});
+
+test('ResponseMetadataSchema rejects executed assess step without canonical decision signals', () => {
+    const now = new Date().toISOString();
+    const payload = createValidWorkflowMetadataPayload(now);
+    payload.workflow.steps[1].outcome = {
+        status: 'executed',
+        summary: 'Assessment step evaluated draft quality.',
+        signals: {
+            goalMet: true,
+        },
+    };
+    const parsed = ResponseMetadataSchema.safeParse(payload);
 
     assert.equal(parsed.success, false);
 });

--- a/packages/contracts/test/webSchemas.test.ts
+++ b/packages/contracts/test/webSchemas.test.ts
@@ -515,13 +515,11 @@ test('ResponseMetadataSchema rejects workflow lineage with invalid termination r
 test('ResponseMetadataSchema rejects executed assess step without canonical decision signals', () => {
     const now = new Date().toISOString();
     const payload = createValidWorkflowMetadataPayload(now);
-    payload.workflow.steps[1].outcome = {
-        status: 'executed',
-        summary: 'Assessment step evaluated draft quality.',
-        signals: {
-            goalMet: true,
-        },
-    };
+    const assessSignals = payload.workflow.steps[1].outcome.signals as Record<
+        string,
+        unknown
+    >;
+    delete assessSignals.reviewDecision;
     const parsed = ResponseMetadataSchema.safeParse(payload);
 
     assert.equal(parsed.success, false);

--- a/packages/contracts/test/webSchemas.test.ts
+++ b/packages/contracts/test/webSchemas.test.ts
@@ -525,6 +525,27 @@ test('ResponseMetadataSchema rejects executed assess step without canonical deci
     assert.equal(parsed.success, false);
 });
 
+test('ResponseMetadataSchema rejects executed assess step without reviewReason', () => {
+    const now = new Date().toISOString();
+    const payloadMissingReason = createValidWorkflowMetadataPayload(now);
+    const missingReasonSignals = payloadMissingReason.workflow.steps[1].outcome
+        .signals as Record<string, unknown>;
+    delete missingReasonSignals.reviewReason;
+    const missingReasonParsed =
+        ResponseMetadataSchema.safeParse(payloadMissingReason);
+
+    assert.equal(missingReasonParsed.success, false);
+
+    const payloadBlankReason = createValidWorkflowMetadataPayload(now);
+    const blankReasonSignals = payloadBlankReason.workflow.steps[1].outcome
+        .signals as Record<string, unknown>;
+    blankReasonSignals.reviewReason = '';
+    const blankReasonParsed =
+        ResponseMetadataSchema.safeParse(payloadBlankReason);
+
+    assert.equal(blankReasonParsed.success, false);
+});
+
 test('ResponseMetadataSchema rejects non-canonical safety decision rule tuples', () => {
     const parsed = ResponseMetadataSchema.safeParse({
         ...baseMetadata,


### PR DESCRIPTION
## Summary
This PR formalizes bounded review assess outputs so workflow lineage captures a clear machine decision and reason, instead of leaving that decision mostly transient.

## What Changed
- Updated bounded review execution to persist assess outputs as canonical machine-readable lineage signals:
  - `reviewDecision` (`finalize` or `revise`)
  - `reviewReason` (non-empty rationale)
- Tightened assess-step handling in workflow execution so invalid assess output is recorded as a failed assess step and still follows fail-open termination semantics.
- Added shared contracts for assess decision vocabulary and signal shape:
  - `BOUNDED_REVIEW_ASSESS_DECISIONS`
  - `BoundedReviewAssessDecision`
  - `BoundedReviewAssessSignals`
- Added schema validation rules requiring canonical decision signals for executed `assess` steps.
- Expanded tests across backend and contracts to verify:
  - assess decision/reason are durable in lineage
  - schema rejects executed assess steps missing canonical decision signals
- Updated architecture/status docs to describe assess outputs as the canonical workflow seam.

## Why These Changes Were Made
The workflow already has a real bounded loop (`generate -> assess -> maybe revise`). The current gap was output structure durability: assess decisions were affecting behavior at runtime but were not represented strongly enough as inspectable lineage outputs.

This PR closes that gap first, so later bounded extensions (such as retrieval reconsideration) can be introduced through the same workflow seam without creating hidden side channels or a second orchestrator.

## Important Implementation Details
- The assess decision/reason contract is now explicit and validated.
- The decision remains advisory to workflow transitions and does not become policy authority.
- No standalone reconsideration engine was introduced.
- Existing ownership boundaries remain intact:
  - Execution Contract governs
  - workflow owns sequencing
  - planner remains bounded and non-authoritative for runtime policy
  - provenance/TRACE/workflow profile semantics remain distinct.
- Follow-up test-readiness fixes were included so `pnpm review` and deploy compose builds pass cleanly for this branch.

This PR was written using [Vibe Kanban](https://vibekanban.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified canonical machine-readable decision outputs for bounded-review assess steps.

* **New Features**
  * Standardized assessment signals: reviewDecision and reviewReason for assess-step handoff.
  * Validation added to enforce these signals in workflow records.

* **Behavior Changes**
  * Workflows now surface parsing failures for invalid assess outputs and mark the run as degraded.

* **Tests**
  * Added tests asserting capture and enforcement of the canonical decision signals.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->