### PR TITLE
Add bounded user control mapping docs (Vibe Kanban)

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -15,6 +15,7 @@ Footnote keeps docs in three buckets:
 - [Safety Evaluation And Breakers](./architecture/risk-evaluation-and-breakers.md): Defines the target deterministic safety layer and enforcement point.
 - [Deterministic Breaker Evaluator V1 (Draft)](./architecture/deterministic-breaker-evaluator-v1.md): Proposes the concrete evaluator contract, rule model, action mapping, and validation gates for issue #75.
 - [Prompt Resolution](./architecture/prompt-resolution.md): Defines how prompt layers and overrides resolve at runtime.
+- [Bounded User Control Mapping](./architecture/bounded-user-control-mapping.md): Defines the small user-facing posture set and the internal controls that stay backend-owned.
 - [Workflow Profile Contract](./architecture/workflow-profile-contract.md): Defines required profile hooks/fields and blocked/no-generation behavior + provenance expectations.
 - [Workflow Engine And Provenance](./architecture/workflow-engine-and-provenance.md): Defines the workflow engine direction, step model, and provenance record shape.
 - [How to Read Provenance-Related Metadata](./architecture/provenance-label-taxonomy.md): Explains how to read mode, TRACE, planner, steerability, and provenance fields without mixing their meanings together.

--- a/docs/architecture/bounded-user-control-mapping.md
+++ b/docs/architecture/bounded-user-control-mapping.md
@@ -1,65 +1,52 @@
 # Bounded User Control Mapping
 
-## Purpose
-
-Define a small user-facing control surface for chat posture without exposing
-internal authority knobs too early.
-
-This doc is intentionally narrow. It says which choices users should see, what
-those choices roughly mean, and which controls stay backend-owned.
+This doc defines the small user-facing control surface for chat.
 
 ## User-Facing Allowlist
 
-The bounded user-facing set is:
+For now, users get three choices only:
 
 - `fast`
 - `balanced`
 - `grounded`
 
-These are the only user-facing choices in this design.
-
 Do not add aliases, advanced toggles, or secondary sub-controls in this phase.
 
-## Plain-Language Meaning
+## What These Choices Mean
 
-- `fast`: Prefer a quick answer path with lighter checking and minimal evidence
-  work.
-- `balanced`: Prefer a reviewed default path with a moderate evidence and review
-  posture.
-- `grounded`: Prefer the most careful path in this bounded set, with stricter
-  evidence and review expectations.
+- `fast`: quickest path, with lighter checking and minimal evidence work
+- `balanced`: standard reviewed path, with moderate evidence and review
+- `grounded`: most careful path in this set, with stricter evidence and review
+  expectations
 
-These labels are meant to be humane. A user should be able to pick one without
-needing to understand workflow internals, provider routing, or policy terms.
+These labels should be easy to understand. A user should not need to know
+workflow internals, provider routing, or policy terms to pick one.
 
-## Grounded Default Direction
+## Default Direction
 
-`grounded` should be treated as the explicit default direction for the user
-surface.
+`grounded` should be the default.
 
 This is a product choice, not an accidental fallback. Footnote's stance is that
 careful, reviewable, evidence-aware behavior should be the default posture
 unless a different bounded user choice is made.
 
-## High-Level Mapping
+## How This Maps Internally
 
-User choices map to intent and broad backend behavior, not to direct ownership
-of internal control knobs.
+These choices map to broad backend behavior, not direct control of internal
+knobs.
 
 - If the user chooses `fast`, the system should prefer a quicker execution path
   with lighter review and evidence expectations.
-- If the user chooses `balanced`, the system should prefer the standard reviewed
-  path with moderate evidence and review expectations.
+- If the user chooses `balanced`, the system should prefer the standard
+  reviewed path.
 - If the user chooses `grounded`, the system should prefer a stricter reviewed
   path with stronger evidence expectations.
 
-In all three cases, backend-owned controls still decide the exact runtime shape,
-limits, and conflict handling.
+The backend still owns the exact runtime shape, limits, and conflict handling.
 
-The user is choosing a bounded posture, not issuing low-level authority
-commands.
+The user is picking a simple posture, not issuing low-level policy commands.
 
-## Internal-Only Controls
+## What Stays Internal
 
 The following controls stay internal-only in this phase:
 
@@ -75,14 +62,14 @@ The following controls stay internal-only in this phase:
 The rule is simple: if a control is easy to misread as "the real policy knob,"
 it should stay internal until Footnote has a stronger public control model.
 
-## Contributor Examples
+## Examples
 
 - If a user picks `grounded`, expose that choice as a stricter answer posture.
   Do not expose separate review-pass or evidence-threshold controls next to it.
 - If a user picks `fast`, do not also surface provider or tool-routing choices
   as if they are equal policy controls. Those remain backend-owned.
 
-## Boundaries
+## Not In Scope
 
 This doc does not define:
 

--- a/docs/architecture/bounded-user-control-mapping.md
+++ b/docs/architecture/bounded-user-control-mapping.md
@@ -1,0 +1,93 @@
+# Bounded User Control Mapping
+
+## Purpose
+
+Define a small user-facing control surface for chat posture without exposing
+internal authority knobs too early.
+
+This doc is intentionally narrow. It says which choices users should see, what
+those choices roughly mean, and which controls stay backend-owned.
+
+## User-Facing Allowlist
+
+The bounded user-facing set is:
+
+- `fast`
+- `balanced`
+- `grounded`
+
+These are the only user-facing choices in this design.
+
+Do not add aliases, advanced toggles, or secondary sub-controls in this phase.
+
+## Plain-Language Meaning
+
+- `fast`: Prefer a quick answer path with lighter checking and minimal evidence
+  work.
+- `balanced`: Prefer a reviewed default path with a moderate evidence and review
+  posture.
+- `grounded`: Prefer the most careful path in this bounded set, with stricter
+  evidence and review expectations.
+
+These labels are meant to be humane. A user should be able to pick one without
+needing to understand workflow internals, provider routing, or policy terms.
+
+## Grounded Default Direction
+
+`grounded` should be treated as the explicit default direction for the user
+surface.
+
+This is a product choice, not an accidental fallback. Footnote's stance is that
+careful, reviewable, evidence-aware behavior should be the default posture
+unless a different bounded user choice is made.
+
+## High-Level Mapping
+
+User choices map to intent and broad backend behavior, not to direct ownership
+of internal control knobs.
+
+- If the user chooses `fast`, the system should prefer a quicker execution path
+  with lighter review and evidence expectations.
+- If the user chooses `balanced`, the system should prefer the standard reviewed
+  path with moderate evidence and review expectations.
+- If the user chooses `grounded`, the system should prefer a stricter reviewed
+  path with stronger evidence expectations.
+
+In all three cases, backend-owned controls still decide the exact runtime shape,
+limits, and conflict handling.
+
+The user is choosing a bounded posture, not issuing low-level authority
+commands.
+
+## Internal-Only Controls
+
+The following controls stay internal-only in this phase:
+
+- `provider_preference`: Too easy to mistake for policy authority when it should
+  remain advisory or backend-resolved.
+- `persona_tone_overlay`: Presentation styling should not look like execution
+  authority.
+- detailed tool controls: Tool eligibility and routing are too low-level for an
+  early humane surface.
+- detailed review and evidence knobs: Exposing sub-knobs too early makes users
+  guess which setting is the real authority.
+
+The rule is simple: if a control is easy to misread as "the real policy knob,"
+it should stay internal until Footnote has a stronger public control model.
+
+## Contributor Examples
+
+- If a user picks `grounded`, expose that choice as a stricter answer posture.
+  Do not expose separate review-pass or evidence-threshold controls next to it.
+- If a user picks `fast`, do not also surface provider or tool-routing choices
+  as if they are equal policy controls. Those remain backend-owned.
+
+## Boundaries
+
+This doc does not define:
+
+- UI rollout details
+- API rollout details
+- a final global override policy
+- compatibility aliases
+- speculative advanced control sets


### PR DESCRIPTION
## Summary
This PR adds a small, bounded user-control mapping doc for steerability and makes it discoverable from the architecture docs index.

## What Changed
- Added `docs/architecture/bounded-user-control-mapping.md`.
- Added a link to the new doc in `docs/README.md` under Architecture.

The new doc explicitly defines a bounded user-facing allowlist:
- `fast`
- `balanced`
- `grounded`

It also defines plain-language meaning for each mode, states `grounded` as an explicit default direction, provides high-level mapping from user choice to backend behavior, and lists internal-only controls with rationale.

## Why
The task context for this branch was to prevent an early failure mode: exposing too many control knobs too soon and confusing users about which controls are true policy authority.

This change keeps the user surface intentionally small and understandable while preserving backend authority boundaries. It also makes the grounded-default intent explicit as a product choice rather than accidental fallback drift.

## Important Implementation Details
- Scope is documentation-only (no UI/API/runtime behavior changes).
- Mapping is intentionally high-level; it does not expose or normalize low-level internal control ownership to end users.
- Internal-only controls are called out as non-user-facing to avoid authority confusion (for example provider preference, persona tone overlay, and detailed tool/review/evidence knobs).
- Non-goals are explicit: no rollout plan, no compatibility aliases, and no advanced control set expansion in this phase.

This PR was written using [Vibe Kanban](https://vibekanban.com)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added new architecture documentation defining the user-facing control surface, including three selectable options (`fast`, `balanced`, `grounded`) with their respective interpretations.
  * Documented the mapping between user controls and backend behavior, along with constraints on future UI/API exposure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->