### PR TITLE
Docs: Add Footnote agentic patterns crosswalk (Vibe Kanban)

### DIFF
--- a/docs/architecture/footnote-and-common-agentic-patterns.md
+++ b/docs/architecture/footnote-and-common-agentic-patterns.md
@@ -7,9 +7,9 @@ without erasing Footnote's own semantics.
 
 Use it like this:
 
-- start with the Footnote term,
-- use the common pattern as orientation,
-- keep Footnote's constraints as the real rule.
+- Start with the Footnote term.
+- Use the common pattern only as orientation.
+- Footnote's constraints are the real rule.
 
 ## Quick Crosswalk
 
@@ -25,8 +25,7 @@ Use it like this:
 **What common pattern it resembles**
 
 Routing in other systems usually means deciding which execution path to take.
-That may mean picking a fast path, a tool path, or a more careful multi-step
-path.
+That may mean a fast path, a tool path, or a reviewed path.
 
 **What Footnote calls it**
 
@@ -43,8 +42,7 @@ Current examples:
 - Routing stays inside Execution Contract guardrails.
 - Mode and profile are related, but they are not the same thing.
 - Backend owns the final routing decision.
-- Fail-open fallback still applies when requested routing input is missing or
-  unknown.
+- Missing or unknown routing input falls back fail-open.
 
 **What it is not**
 
@@ -56,8 +54,7 @@ Current examples:
 
 **What common pattern it resembles**
 
-Planning resembles the common "planner" step that decides what kind of action
-should happen next before execution continues.
+Planning resembles the common planner step that decides the next action shape.
 
 **What Footnote calls it**
 
@@ -70,8 +67,7 @@ not the owner of orchestration.
 - Planner output can be adjusted or rejected by policy.
 - Planner metadata is recorded as execution/provenance data.
 - Planning must stay serializable and inspectable.
-- Planning should align with steerability, provenance, and backend-owned
-  control logic.
+- Planning does not override backend control logic.
 
 **What it is not**
 
@@ -84,7 +80,7 @@ not the owner of orchestration.
 **What common pattern it resembles**
 
 This resembles reflection, critique, or reviewer passes used in other agent
-systems to assess and possibly improve a draft.
+systems.
 
 **What Footnote calls it**
 
@@ -96,7 +92,7 @@ Footnote control.
 
 - Review is optional and policy-gated.
 - Review decisions are bounded: finalize or revise.
-- Revision stays inside grounding and provenance boundaries.
+- Revision cannot loosen grounding or provenance rules.
 - TRACE remains Footnote-specific response temperament metadata, not a generic
   self-improvement score.
 - Backend remains the authority for when review can happen and when it stops.
@@ -111,8 +107,8 @@ Footnote control.
 
 **What common pattern it resembles**
 
-This resembles standard agent tool calling: a model or planner requests an
-external capability, and runtime executes it if allowed.
+This resembles standard tool calling: request a capability, then execute it if
+allowed.
 
 **What Footnote calls it**
 
@@ -138,21 +134,21 @@ intent, eligibility, outcome state, and reason codes.
 
 **What common pattern it resembles**
 
-This resembles agent memory: storing useful information across steps or across
-requests.
+This resembles agent memory, but this part is mostly planned rather than
+current.
 
 **What Footnote calls it**
 
-Memory is still planned work in Footnote. The near-term idea is bounded memory,
-not open-ended agent identity or autonomous long-horizon recall.
+Memory is planned work in Footnote. Near-term direction is bounded memory, not
+open-ended agent identity or autonomous long-horizon recall.
 
 **What constraints Footnote adds**
 
 - Memory must fit provenance and governance requirements.
 - Memory should stay behind Footnote's backend boundary.
-- Public contract behavior must remain serializable and inspectable.
-- Memory only helps if it improves user-visible transparency and steerability,
-  not just runtime cleverness.
+- Any public memory-facing behavior must stay serializable and inspectable.
+- Memory only belongs if it improves user-visible transparency or
+  steerability.
 
 **What it is not**
 
@@ -164,8 +160,8 @@ not open-ended agent identity or autonomous long-horizon recall.
 
 **What common pattern it resembles**
 
-MCP resembles a standard protocol layer for exposing tools or resources to a
-runtime in a more uniform way.
+MCP resembles a protocol layer for exposing tools or resources in a more
+uniform way.
 
 **What Footnote calls it**
 
@@ -190,10 +186,10 @@ capability access.
 
 ## Bottom Line
 
-Footnote does use some patterns that people will recognize from wider agent
-systems.
+Footnote uses some patterns people will recognize from agent systems.
 
-But Footnote is not trying to become a generic vocabulary demo.
+But those patterns only help if they are translated into Footnote's own terms
+and constraints.
 
 The semantic center stays the same:
 

--- a/docs/architecture/footnote-and-common-agentic-patterns.md
+++ b/docs/architecture/footnote-and-common-agentic-patterns.md
@@ -1,0 +1,203 @@
+# Footnote and Common Agentic Patterns
+
+This page is a translation guide.
+
+It helps contributors map common agent vocabulary onto Footnote's architecture
+without erasing Footnote's own semantics.
+
+Use it like this:
+
+- start with the Footnote term,
+- use the common pattern as orientation,
+- keep Footnote's constraints as the real rule.
+
+## Quick Crosswalk
+
+- Routing -> `workflow mode` selection and `workflow profile` resolution
+- Planning -> bounded planner step
+- Reflection -> review / revise path, plus future bounded TRACE refinement
+- Tool use -> Execution Contract-limited tool execution
+- Memory -> planned, bounded by provenance and governance
+- MCP -> protocol boundary for capability access, not policy authority
+
+## Routing
+
+**What common pattern it resembles**
+
+Routing in other systems usually means deciding which execution path to take.
+That may mean picking a fast path, a tool path, or a more careful multi-step
+path.
+
+**What Footnote calls it**
+
+Footnote uses `workflow mode` for the high-level run choice and `workflow profile`
+for the concrete executable shape.
+
+Current examples:
+
+- `workflow mode`: `fast`, `balanced`, `grounded`
+- `workflow profile`: `generate-only`, `bounded-review`
+
+**What constraints Footnote adds**
+
+- Routing stays inside Execution Contract guardrails.
+- Mode and profile are related, but they are not the same thing.
+- Backend owns the final routing decision.
+- Fail-open fallback still applies when requested routing input is missing or
+  unknown.
+
+**What it is not**
+
+- not a free-form runtime graph builder
+- not per-request workflow scripting
+- not a license for callers or adapters to invent new authority semantics
+
+## Planning
+
+**What common pattern it resembles**
+
+Planning resembles the common "planner" step that decides what kind of action
+should happen next before execution continues.
+
+**What Footnote calls it**
+
+Footnote treats planning as a bounded planner step. It is part of orchestration,
+not the owner of orchestration.
+
+**What constraints Footnote adds**
+
+- Planning is bounded in purpose and shape.
+- Planner output can be adjusted or rejected by policy.
+- Planner metadata is recorded as execution/provenance data.
+- Planning must stay serializable and inspectable.
+- Planning should align with steerability, provenance, and backend-owned
+  control logic.
+
+**What it is not**
+
+- not unbounded planning loops
+- not a self-directed agent deciding its own authority
+- not a replacement for Execution Contract policy
+
+## Reflection / Review
+
+**What common pattern it resembles**
+
+This resembles reflection, critique, or reviewer passes used in other agent
+systems to assess and possibly improve a draft.
+
+**What Footnote calls it**
+
+Today Footnote has a review / revise path in bounded-review workflows.
+Future TRACE refinement may add another bounded refinement seam, but still under
+Footnote control.
+
+**What constraints Footnote adds**
+
+- Review is optional and policy-gated.
+- Review decisions are bounded: finalize or revise.
+- Revision stays inside grounding and provenance boundaries.
+- TRACE remains Footnote-specific response temperament metadata, not a generic
+  self-improvement score.
+- Backend remains the authority for when review can happen and when it stops.
+
+**What it is not**
+
+- not uncontrolled self-critique
+- not an endless improve-until-perfect loop
+- not permission to rewrite provenance or blur sourced versus inferred content
+
+## Tool Use
+
+**What common pattern it resembles**
+
+This resembles standard agent tool calling: a model or planner requests an
+external capability, and runtime executes it if allowed.
+
+**What Footnote calls it**
+
+Footnote treats this as Execution Contract-limited tool execution with explicit
+intent, eligibility, outcome state, and reason codes.
+
+**What constraints Footnote adds**
+
+- Tool use is governed by backend policy, not by tool adapters.
+- Tool outcomes are normalized as `executed`, `skipped`, or `failed`.
+- Non-executed outcomes need explicit reason codes.
+- Provenance, reviewability, and cost accounting stay Footnote-owned.
+- Fail-open behavior remains the default unless an explicit policy says
+  otherwise.
+
+**What it is not**
+
+- not tools deciding policy
+- not silent tool-intent dropping
+- not a hidden side channel around provenance or review semantics
+
+## Memory
+
+**What common pattern it resembles**
+
+This resembles agent memory: storing useful information across steps or across
+requests.
+
+**What Footnote calls it**
+
+Memory is still planned work in Footnote. The near-term idea is bounded memory,
+not open-ended agent identity or autonomous long-horizon recall.
+
+**What constraints Footnote adds**
+
+- Memory must fit provenance and governance requirements.
+- Memory should stay behind Footnote's backend boundary.
+- Public contract behavior must remain serializable and inspectable.
+- Memory only helps if it improves user-visible transparency and steerability,
+  not just runtime cleverness.
+
+**What it is not**
+
+- not a commitment to broad long-term memory now
+- not hidden persistence that weakens user understanding
+- not a reason to bypass provenance, review, or authority boundaries
+
+## MCP as a Protocol Boundary
+
+**What common pattern it resembles**
+
+MCP resembles a standard protocol layer for exposing tools or resources to a
+runtime in a more uniform way.
+
+**What Footnote calls it**
+
+For this pass, MCP is best understood as a possible protocol boundary for
+capability access.
+
+**What constraints Footnote adds**
+
+- MCP is useful if it reduces coupling at the tool/resource boundary.
+- MCP is not useful if it only adds protocol ceremony or just renames existing
+  registry concepts.
+- MCP does not replace backend policy, provenance, review, or governance
+  authority.
+- Local MCP exploration is valid, but this page does not commit Footnote to an
+  MCP migration.
+
+**What it is not**
+
+- not a default replacement for the current tool architecture
+- not policy authority
+- not a replacement for Footnote's authority boundaries
+
+## Bottom Line
+
+Footnote does use some patterns that people will recognize from wider agent
+systems.
+
+But Footnote is not trying to become a generic vocabulary demo.
+
+The semantic center stays the same:
+
+- Execution Contract governs authority
+- `workflow mode` and `workflow profile` govern run shape
+- TRACE, provenance, and steerability stay Footnote-native
+- backend remains the control-plane boundary


### PR DESCRIPTION
## What Changed
- Added one new architecture page: `docs/architecture/footnote-and-common-agentic-patterns.md`.
- The page introduces a short crosswalk from common agentic terms to Footnote-native concepts.
- It covers six scoped patterns: routing, planning, reflection/review, tool use, memory (planned/bounded), and MCP as a protocol boundary.
- Each pattern follows one consistent orientation structure: what it resembles, what Footnote calls it, Footnote constraints, and what it is not.

## Why
- Contributors regularly encounter external agent vocabulary that can map loosely (or incorrectly) onto Footnote.
- This PR adds a translation guide that preserves Footnote semantics instead of flattening them into generic framework language.
- The explicit "what it is not" sections are included to prevent semantic drift, especially around planning loops, reflection authority, and MCP governance assumptions.

## Important Implementation Details
- Scope is docs-only and intentionally non-refactor; no runtime, API, or contract behavior changed.
- Core Footnote terms remain the semantic center: `Execution Contract`, `workflow mode`, `workflow profile`, `TRACE`, provenance, and steerability.
- MCP is framed as an optional protocol boundary for capability access, not as a default migration target and not as a replacement for Footnote authority boundaries.
- The page was tightened in a follow-up branch commit to reduce repetitive phrasing and make memory explicitly "mostly planned rather than current."

This PR was written using [Vibe Kanban](https://vibekanban.com)