### PR TITLE
Harden AGENTS.md guardrails for scope, validation, and boundary docs (Vibe Kanban)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -83,7 +83,7 @@ Conditional (must explain if skipped):
 - Prefer small, focused diffs.
 - Edit only files needed for the task.
 - If the task starts touching multiple concepts, packages, or behavior surfaces, stop, report the scope expansion, and wait for confirmation before continuing.
-- Follow the current project shape over the literal prompt when they conflict. Preserve Footnote terms and boundaries unless the user explicitly asks to change them.
+- Follow the user’s requested change, but preserve existing project boundaries unless the prompt explicitly asks to change them. If the prompt appears to conflict with core Footnote semantics, stop and ask before rewriting those semantics.
 - Use repo code/docs as primary context; use MCP/external tools only to verify third-party APIs, UI behavior, secrets, or issue state.
 - For non-trivial structural refactors, include 1-2 example evidence links using `pnpm refactor:lookup`.
 - Do not invent runtime facts, command output, or test results.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -71,17 +71,20 @@ Before final handoff:
 
 - `pnpm lint`
 
-When relevant:
+Conditional (must explain if skipped):
 
 - `pnpm validate-footnote-tags`
 - `pnpm validate-openapi-links` (API boundary changes)
-- `pnpm review` (cross-cutting or review-ready changes)
-- `docker compose -f deploy/compose.yml build` (deploy/runtime packaging impact)
+- `pnpm review` (required for review-ready code changes; explain if skipped)
+- `docker compose -f deploy/compose.yml build` (required for startup, provider, env, deploy, or runtime packaging impact; explain if skipped)
 
 ## Working Style
 
 - Prefer small, focused diffs.
 - Edit only files needed for the task.
+- If the task starts touching multiple concepts, packages, or behavior surfaces, stop, report the scope expansion, and wait for confirmation before continuing.
+- Follow the current project shape over the literal prompt when they conflict. Preserve Footnote terms and boundaries unless the user explicitly asks to change them.
+- Use repo code/docs as primary context; use MCP/external tools only to verify third-party APIs, UI behavior, secrets, or issue state.
 - For non-trivial structural refactors, include 1-2 example evidence links using `pnpm refactor:lookup`.
 - Do not invent runtime facts, command output, or test results.
 - If a check was not run, say that clearly.
@@ -93,4 +96,5 @@ Write for a junior contributor:
 - Plain language first.
 - Short sentences.
 - Concrete action words.
-- Comments should explain purpose, trigger, and consequence.
+- Add JSDoc or comments for exported boundary functions, workflow/orchestrator/provider/provenance logic, fail-open behavior, and authority decisions.
+- Do not add comments that only restate obvious code.


### PR DESCRIPTION
## Summary
This PR improves `AGENTS.md` with focused instruction hardening aimed at recurring agent failure modes (scope creep, optional validation skips, and uneven boundary-level documentation quality).

## What changed
- Tightened conditional validation language:
  - `pnpm review` is now required for review-ready code changes (with explicit skip explanation).
  - `docker compose -f deploy/compose.yml build` is now required for startup/provider/env/deploy/runtime packaging impact (with explicit skip explanation).
  - Renamed the section label from "When relevant" to "Conditional (must explain if skipped)" to reduce ambiguity.
- Added a scope-stop rule in Working Style:
  - If work expands across multiple concepts/packages/surfaces, stop, report scope expansion, and wait for confirmation before continuing.
- Added prompt-vs-boundary guardrail:
  - Implement the requested change while preserving existing project boundaries unless explicitly asked to change them.
  - If a request appears to conflict with core Footnote semantics, stop and ask before rewriting those semantics.
- Added concise context-use guidance:
  - Use repo code/docs as primary context; use MCP/external tools for third-party APIs, UI behavior, secrets, or issue-state verification.
- Strengthened communication guidance:
  - Require JSDoc/comments for exported boundary logic (workflow/orchestrator/provider/provenance/fail-open/authority decisions).
  - Explicitly discourage comments that restate obvious code.

## Why these changes were made
The update keeps `AGENTS.md` short while making a few passive rules operational, based on observed behavior:
- Agents touching too many files/concepts in one pass.
- Agents skipping heavier validation because "relevance" was interpreted too loosely.
- Inconsistent boundary-level explanation quality (too little in critical paths, too much obvious commentary elsewhere).
- Risk of overcorrecting prompt-following by ignoring explicit user requests.

These edits are intentionally surgical so agents get clearer behavioral constraints without adding prompt bloat.

## Implementation details
- File changed: `AGENTS.md` only.
- Commit sequence:
  - `docs(agents): tighten scope, validation, and boundary-comment rules`
  - `docs(agents): clarify prompt precedence with boundary safeguards`
- Net diff: 1 file, 8 insertions, 4 deletions.

This PR was written using [Vibe Kanban](https://vibekanban.com)
