### PR TITLE
Refactor backend node:http dispatch into ordered route module (Vibe Kanban)

### DIFF
--- a/packages/backend/src/http/routeDispatch.ts
+++ b/packages/backend/src/http/routeDispatch.ts
@@ -1,0 +1,266 @@
+/**
+ * @description: Centralizes ordered HTTP route dispatch for the backend node:http server.
+ * @footnote-scope: core
+ * @footnote-module: RouteDispatch
+ * @footnote-risk: high - Route order mistakes can silently change endpoint behavior.
+ * @footnote-ethics: medium - Dispatch order controls which trust/auth checks run first.
+ */
+import type http from 'node:http';
+
+// --- Route path helpers ---
+const INCIDENT_STATUS_PATH_PATTERN = /^\/api\/incidents\/[^/]+\/status$/;
+const INCIDENT_NOTES_PATH_PATTERN = /^\/api\/incidents\/[^/]+\/notes$/;
+const INCIDENT_REMEDIATION_PATH_PATTERN =
+    /^\/api\/incidents\/[^/]+\/remediation$/;
+const INCIDENT_DETAIL_PATH_PATTERN = /^\/api\/incidents\/[^/]+$/;
+const TRACE_CARD_ASSET_PATH_PATTERN =
+    /^\/api\/traces\/[^/]+\/assets\/trace-card\.svg$/;
+
+const normalizePathname = (pathname: string): string =>
+    pathname.length > 1 && pathname.endsWith('/')
+        ? pathname.slice(0, -1)
+        : pathname;
+
+// Decide whether /api/traces/:responseId should return JSON or the SPA HTML shell.
+// We default to JSON unless the Accept header clearly asks for HTML.
+// This keeps API clients working even when they send a generic "*/*" Accept header.
+const wantsJsonResponse = (req: http.IncomingMessage): boolean => {
+    const headerValue = req.headers.accept;
+    const acceptHeader = Array.isArray(headerValue)
+        ? headerValue.join(',')
+        : headerValue || '';
+    const normalized = acceptHeader.toLowerCase();
+    const wantsHtml =
+        normalized.includes('text/html') ||
+        normalized.includes('application/xhtml+xml');
+    const wantsJson =
+        normalized.includes('application/json') || normalized.includes('+json');
+
+    if (wantsHtml && !wantsJson) {
+        return false;
+    }
+
+    return true;
+};
+
+type RequestHandler = (
+    req: http.IncomingMessage,
+    res: http.ServerResponse
+) => Promise<void>;
+type ParsedUrlHandler = (
+    req: http.IncomingMessage,
+    res: http.ServerResponse,
+    parsedUrl: URL
+) => Promise<void>;
+type BlogPostHandler = (
+    req: http.IncomingMessage,
+    res: http.ServerResponse,
+    postId: string
+) => Promise<void>;
+type TraceRouteMatchedLogger = (pathname: string) => void;
+type UpgradeHandler = (
+    req: http.IncomingMessage,
+    socket: import('node:stream').Duplex,
+    head: Buffer
+) => void;
+
+type DispatchOutcome = 'handled' | 'fallthrough';
+
+type RouteDispatchHandlers = {
+    handleWebhookRequest: RequestHandler;
+    handleRuntimeConfigRequest: RequestHandler;
+    handleIncidentListRequest: ParsedUrlHandler;
+    handleIncidentReportRequest: RequestHandler;
+    handleInternalTextRequest: RequestHandler;
+    handleInternalImageRequest: RequestHandler;
+    handleInternalVoiceTtsRequest: RequestHandler;
+    handleIncidentStatusRequest: ParsedUrlHandler;
+    handleIncidentNotesRequest: ParsedUrlHandler;
+    handleIncidentRemediationRequest: ParsedUrlHandler;
+    handleIncidentDetailRequest: ParsedUrlHandler;
+    handleBlogIndexRequest: RequestHandler;
+    handleBlogPostRequest: BlogPostHandler;
+    handleTraceUpsertRequest: RequestHandler;
+    handleTraceCardCreateRequest: RequestHandler;
+    handleTraceCardFromTraceRequest: RequestHandler;
+    handleTraceCardAssetRequest: ParsedUrlHandler;
+    handleTraceRequest: ParsedUrlHandler;
+    handleChatRequest: RequestHandler;
+    handleChatProfilesRequest: RequestHandler;
+};
+
+/**
+ * Keeps route matching rules explicit and ordered.
+ * Order is behavior: first match wins and later checks never run.
+ */
+const createRouteDispatcher = ({
+    handlers,
+    onTraceRouteMatched,
+}: {
+    handlers: RouteDispatchHandlers;
+    onTraceRouteMatched: TraceRouteMatchedLogger;
+}) => {
+    const dispatchHttpRoute = async ({
+        req,
+        res,
+        parsedUrl,
+        normalizedPathname,
+    }: {
+        req: http.IncomingMessage;
+        res: http.ServerResponse;
+        parsedUrl: URL;
+        normalizedPathname: string;
+    }): Promise<DispatchOutcome> => {
+        // --- Special routes (keep at top; auth/signature-sensitive) ---
+        if (normalizedPathname === '/api/webhook/github') {
+            await handlers.handleWebhookRequest(req, res);
+            return 'handled';
+        }
+
+        // --- Runtime config route ---
+        if (normalizedPathname === '/config.json') {
+            await handlers.handleRuntimeConfigRequest(req, res);
+            return 'handled';
+        }
+
+        // --- Incident routes ---
+        if (normalizedPathname === '/api/incidents') {
+            await handlers.handleIncidentListRequest(req, res, parsedUrl);
+            return 'handled';
+        }
+
+        // Keep explicit report route before generic /api/incidents/:incidentId.
+        if (normalizedPathname === '/api/incidents/report') {
+            await handlers.handleIncidentReportRequest(req, res);
+            return 'handled';
+        }
+
+        // --- Trusted internal routes ---
+        if (normalizedPathname === '/api/internal/text') {
+            await handlers.handleInternalTextRequest(req, res);
+            return 'handled';
+        }
+
+        if (normalizedPathname === '/api/internal/image') {
+            await handlers.handleInternalImageRequest(req, res);
+            return 'handled';
+        }
+
+        if (normalizedPathname === '/api/internal/voice/tts') {
+            await handlers.handleInternalVoiceTtsRequest(req, res);
+            return 'handled';
+        }
+
+        // --- Incident detail sub-routes ---
+        if (INCIDENT_STATUS_PATH_PATTERN.test(normalizedPathname)) {
+            await handlers.handleIncidentStatusRequest(req, res, parsedUrl);
+            return 'handled';
+        }
+
+        if (INCIDENT_NOTES_PATH_PATTERN.test(normalizedPathname)) {
+            await handlers.handleIncidentNotesRequest(req, res, parsedUrl);
+            return 'handled';
+        }
+
+        if (INCIDENT_REMEDIATION_PATH_PATTERN.test(normalizedPathname)) {
+            await handlers.handleIncidentRemediationRequest(
+                req,
+                res,
+                parsedUrl
+            );
+            return 'handled';
+        }
+
+        if (INCIDENT_DETAIL_PATH_PATTERN.test(normalizedPathname)) {
+            await handlers.handleIncidentDetailRequest(req, res, parsedUrl);
+            return 'handled';
+        }
+
+        // --- Blog routes ---
+        if (normalizedPathname === '/api/blog-posts') {
+            await handlers.handleBlogIndexRequest(req, res);
+            return 'handled';
+        }
+
+        if (normalizedPathname.startsWith('/api/blog-posts/')) {
+            const postId = normalizedPathname.split('/').pop() || '';
+            await handlers.handleBlogPostRequest(req, res, postId);
+            return 'handled';
+        }
+
+        // --- Trace write/asset routes ---
+        if (normalizedPathname === '/api/traces') {
+            await handlers.handleTraceUpsertRequest(req, res);
+            return 'handled';
+        }
+
+        if (normalizedPathname === '/api/trace-cards') {
+            await handlers.handleTraceCardCreateRequest(req, res);
+            return 'handled';
+        }
+
+        if (normalizedPathname === '/api/trace-cards/from-trace') {
+            await handlers.handleTraceCardFromTraceRequest(req, res);
+            return 'handled';
+        }
+
+        if (TRACE_CARD_ASSET_PATH_PATTERN.test(normalizedPathname)) {
+            await handlers.handleTraceCardAssetRequest(req, res, parsedUrl);
+            return 'handled';
+        }
+
+        // --- Special dual-use trace route ---
+        // This path also doubles as a browser route for the trace page.
+        // Keep JSON-vs-HTML behavior exactly as-is.
+        if (normalizedPathname.startsWith('/api/traces/')) {
+            // Tell caches to keep JSON and HTML variants separate.
+            res.setHeader('Vary', 'Accept');
+            if (wantsJsonResponse(req)) {
+                onTraceRouteMatched(normalizedPathname);
+                await handlers.handleTraceRequest(req, res, parsedUrl);
+                return 'handled';
+            }
+            // Fall through to static resolver for SPA HTML.
+            return 'fallthrough';
+        }
+
+        // --- Chat routes ---
+        if (normalizedPathname === '/api/chat') {
+            await handlers.handleChatRequest(req, res);
+            return 'handled';
+        }
+
+        if (normalizedPathname === '/api/chat/profiles') {
+            await handlers.handleChatProfilesRequest(req, res);
+            return 'handled';
+        }
+
+        return 'fallthrough';
+    };
+
+    const dispatchUpgradeRoute = ({
+        req,
+        socket,
+        head,
+        normalizedPathname,
+        handleInternalVoiceRealtimeUpgrade,
+    }: {
+        req: http.IncomingMessage;
+        socket: import('node:stream').Duplex;
+        head: Buffer;
+        normalizedPathname: string;
+        handleInternalVoiceRealtimeUpgrade: UpgradeHandler;
+    }): boolean => {
+        // Special websocket route for realtime voice.
+        if (normalizedPathname === '/api/internal/voice/realtime') {
+            handleInternalVoiceRealtimeUpgrade(req, socket, head);
+            return true;
+        }
+
+        return false;
+    };
+
+    return { dispatchHttpRoute, dispatchUpgradeRoute };
+};
+
+export { createRouteDispatcher, normalizePathname };

--- a/packages/backend/src/server.ts
+++ b/packages/backend/src/server.ts
@@ -28,6 +28,10 @@ import { createTraceStore, storeTrace } from './services/traceStore.js';
 import { createBlogStore } from './storage/blogStore.js';
 import { getDefaultIncidentStore } from './storage/incidents/incidentStore.js';
 import { createAssetResolver } from './http/assets.js';
+import {
+    createRouteDispatcher,
+    normalizePathname,
+} from './http/routeDispatch.js';
 import { verifyGitHubSignature } from './utils/github.js';
 import { logRequest } from './utils/requestLogger.js';
 import { logger } from './utils/logger.js';
@@ -465,27 +469,6 @@ const { handleUpgrade: handleInternalVoiceRealtimeUpgrade } =
             }),
         buildInstructions: buildRealtimeInstructions,
     });
-// Decide whether /api/traces/:responseId should return JSON or the SPA HTML shell.
-// We default to JSON unless the Accept header clearly asks for HTML.
-// This keeps API clients working even when they send a generic "*/*" Accept header.
-const wantsJsonResponse = (req: http.IncomingMessage): boolean => {
-    const headerValue = req.headers.accept;
-    const acceptHeader = Array.isArray(headerValue)
-        ? headerValue.join(',')
-        : headerValue || '';
-    const normalized = acceptHeader.toLowerCase();
-    const wantsHtml =
-        normalized.includes('text/html') ||
-        normalized.includes('application/xhtml+xml');
-    const wantsJson =
-        normalized.includes('application/json') || normalized.includes('+json');
-
-    if (wantsHtml && !wantsJson) {
-        return false;
-    }
-
-    return true;
-};
 // Chat is the backend-standardized conversation interface (adapter-facing, Turnstile + rate-limited for public web calls).
 const executionContractTrustGraphRuntimeOptions =
     resolveExecutionContractTrustGraphRuntimeOptions(
@@ -505,6 +488,33 @@ const handleChatRequest = createChatHandler({
     maxChatBodyBytes: runtimeConfig.reflect.maxBodyBytes,
     executionContractTrustGraph: executionContractTrustGraphRuntimeOptions,
 });
+const { dispatchHttpRoute, dispatchUpgradeRoute } = createRouteDispatcher({
+    handlers: {
+        handleWebhookRequest,
+        handleRuntimeConfigRequest,
+        handleIncidentListRequest,
+        handleIncidentReportRequest,
+        handleInternalTextRequest,
+        handleInternalImageRequest,
+        handleInternalVoiceTtsRequest,
+        handleIncidentStatusRequest,
+        handleIncidentNotesRequest,
+        handleIncidentRemediationRequest,
+        handleIncidentDetailRequest,
+        handleBlogIndexRequest,
+        handleBlogPostRequest,
+        handleTraceUpsertRequest,
+        handleTraceCardCreateRequest,
+        handleTraceCardFromTraceRequest,
+        handleTraceCardAssetRequest,
+        handleTraceRequest,
+        handleChatRequest,
+        handleChatProfilesRequest,
+    },
+    onTraceRouteMatched: (pathname) => {
+        logger.debug(`Trace route matched: ${pathname}`);
+    },
+});
 
 // --- HTTP server ---
 const server = http.createServer(async (req, res) => {
@@ -518,124 +528,14 @@ const server = http.createServer(async (req, res) => {
     try {
         // --- URL parsing ---
         const parsedUrl = new URL(req.url, 'http://localhost');
-        const normalizedPathname =
-            parsedUrl.pathname.length > 1 && parsedUrl.pathname.endsWith('/')
-                ? parsedUrl.pathname.slice(0, -1)
-                : parsedUrl.pathname;
-
-        // --- API routes ---
-        if (normalizedPathname === '/api/webhook/github') {
-            await handleWebhookRequest(req, res);
-            return;
-        }
-
-        if (normalizedPathname === '/config.json') {
-            await handleRuntimeConfigRequest(req, res);
-            return;
-        }
-
-        if (normalizedPathname === '/api/incidents') {
-            await handleIncidentListRequest(req, res, parsedUrl);
-            return;
-        }
-
-        if (normalizedPathname === '/api/incidents/report') {
-            await handleIncidentReportRequest(req, res);
-            return;
-        }
-
-        if (normalizedPathname === '/api/internal/text') {
-            await handleInternalTextRequest(req, res);
-            return;
-        }
-
-        if (normalizedPathname === '/api/internal/image') {
-            await handleInternalImageRequest(req, res);
-            return;
-        }
-
-        if (normalizedPathname === '/api/internal/voice/tts') {
-            await handleInternalVoiceTtsRequest(req, res);
-            return;
-        }
-
-        if (/^\/api\/incidents\/[^/]+\/status$/.test(normalizedPathname)) {
-            await handleIncidentStatusRequest(req, res, parsedUrl);
-            return;
-        }
-
-        if (/^\/api\/incidents\/[^/]+\/notes$/.test(normalizedPathname)) {
-            await handleIncidentNotesRequest(req, res, parsedUrl);
-            return;
-        }
-
-        if (/^\/api\/incidents\/[^/]+\/remediation$/.test(normalizedPathname)) {
-            await handleIncidentRemediationRequest(req, res, parsedUrl);
-            return;
-        }
-
-        if (/^\/api\/incidents\/[^/]+$/.test(normalizedPathname)) {
-            await handleIncidentDetailRequest(req, res, parsedUrl);
-            return;
-        }
-
-        if (normalizedPathname === '/api/blog-posts') {
-            await handleBlogIndexRequest(req, res);
-            return;
-        }
-
-        if (normalizedPathname.startsWith('/api/blog-posts/')) {
-            const postId = normalizedPathname.split('/').pop() || '';
-            await handleBlogPostRequest(req, res, postId);
-            return;
-        }
-
-        if (normalizedPathname === '/api/traces') {
-            await handleTraceUpsertRequest(req, res);
-            return;
-        }
-
-        if (normalizedPathname === '/api/trace-cards') {
-            await handleTraceCardCreateRequest(req, res);
-            return;
-        }
-
-        if (normalizedPathname === '/api/trace-cards/from-trace') {
-            await handleTraceCardFromTraceRequest(req, res);
-            return;
-        }
-
-        if (
-            /^\/api\/traces\/[^/]+\/assets\/trace-card\.svg$/.test(
-                normalizedPathname
-            )
-        ) {
-            await handleTraceCardAssetRequest(req, res, parsedUrl);
-            return;
-        }
-
-        // --- Trace retrieval route (JSON only) ---
-        // This path also doubles as a browser route for the trace page.
-        // We only return JSON when the caller explicitly asks for JSON.
-        if (normalizedPathname.startsWith('/api/traces/')) {
-            // This endpoint can return HTML or JSON depending on the Accept header.
-            // Tell caches to keep those two versions separate (so a JSON request never gets a cached HTML page and vice versa).
-            res.setHeader('Vary', 'Accept');
-            if (wantsJsonResponse(req)) {
-                logger.debug(`Trace route matched: ${normalizedPathname}`);
-                await handleTraceRequest(req, res, parsedUrl);
-                return;
-            }
-            // Fall through to the static asset resolver for the SPA.
-        }
-
-        if (normalizedPathname === '/api/chat') {
-            await handleChatRequest(req, res);
-            return;
-        }
-
-        if (normalizedPathname === '/api/chat/profiles') {
-            await handleChatProfilesRequest(req, res);
+        const normalizedPathname = normalizePathname(parsedUrl.pathname);
+        const routeOutcome = await dispatchHttpRoute({
+            req,
+            res,
+            parsedUrl,
+            normalizedPathname,
+        });
+        if (routeOutcome === 'handled') {
             return;
         }
 
@@ -734,13 +634,15 @@ server.on('upgrade', (req, socket, head) => {
 
     try {
         const parsedUrl = new URL(req.url, 'http://localhost');
-        const normalizedPathname =
-            parsedUrl.pathname.length > 1 && parsedUrl.pathname.endsWith('/')
-                ? parsedUrl.pathname.slice(0, -1)
-                : parsedUrl.pathname;
-
-        if (normalizedPathname === '/api/internal/voice/realtime') {
-            handleInternalVoiceRealtimeUpgrade(req, socket, head);
+        const normalizedPathname = normalizePathname(parsedUrl.pathname);
+        const isUpgradeHandled = dispatchUpgradeRoute({
+            req,
+            socket,
+            head,
+            normalizedPathname,
+            handleInternalVoiceRealtimeUpgrade,
+        });
+        if (isUpgradeHandled) {
             return;
         }
     } catch (error) {


### PR DESCRIPTION
## Summary

Extract backend `node:http` route dispatch into a dedicated module to improve readability while preserving existing behavior and route precedence.

## What changed

- Added `packages/backend/src/http/routeDispatch.ts` to centralize route matching and dispatch.
- Moved ordered HTTP route checks from `server.ts` into `createRouteDispatcher()`.
- Kept route order explicit and grouped (special routes, incidents, internal routes, blog, traces, chat) with focused comments/JSDoc.
- Kept trace dual-use behavior intact (`/api/traces/:id` JSON vs SPA fallback) including `Vary: Accept` handling.
- Added shared pathname normalization helper and reused it for both HTTP request dispatch and websocket upgrade dispatch.
- Updated `server.ts` to delegate route decisions to the dispatcher while keeping startup, static asset serving, CSP, and shutdown concerns in place.

## Why

`server.ts` previously mixed startup/wiring concerns with a long, manual chain of route checks where ordering is critical. This refactor makes dispatch flow easier for newcomers to scan, keeps special-case routes visibly marked, and surfaces natural route groupings to reduce migration risk for later Express work.

## Important implementation details

- Route semantics are preserved: first-match-wins ordering is intentionally unchanged.
- No endpoint behavior rewrites were introduced; handlers remain the same and are invoked through typed dispatch contracts.
- Websocket upgrade handling for `/api/internal/voice/realtime` now goes through the same normalization/dispatch helper pattern for consistency.
- The change avoids endpoint-per-file fragmentation and keeps this as a structural extraction step only.

This PR was written using [Vibe Kanban](https://vibekanban.com)