### PR TITLE
Isolate backend transport-sensitive boundaries (Vibe Kanban)

### DIFF
--- a/packages/backend/src/handlers/internalImage.ts
+++ b/packages/backend/src/handlers/internalImage.ts
@@ -186,6 +186,8 @@ export const createInternalImageHandler = ({
                 });
                 if (imageRequest.stream) {
                     streamStarted = true;
+                    // NDJSON streaming is a transport contract for trusted image callers.
+                    // Keep this path isolated from buffering middleware so partial events flush immediately.
                     res.statusCode = 200;
                     res.setHeader(
                         'Content-Type',

--- a/packages/backend/src/handlers/internalVoiceRealtime.ts
+++ b/packages/backend/src/handlers/internalVoiceRealtime.ts
@@ -385,6 +385,7 @@ export const createInternalVoiceRealtimeHandler = ({
         socket: Duplex,
         head: Buffer
     ): void => {
+        // Upgrade flow is intentionally explicit; generic HTTP middleware should not intercept this path.
         if (req.method !== 'GET') {
             rejectUpgrade(socket, 405, { error: 'Method not allowed' });
             return;

--- a/packages/backend/src/handlers/webhook.ts
+++ b/packages/backend/src/handlers/webhook.ts
@@ -77,6 +77,8 @@ const createWebhookHandler =
             }
 
             // --- Body capture (raw bytes for signature) ---
+            // This path is transport-sensitive by design: signature verification must use unparsed bytes.
+            // Keep generic JSON middleware away from this route so byte-level signature checks stay correct.
             const chunks: Buffer[] = [];
             let bodyBytes = 0;
             let bodyTooLarge = false;

--- a/packages/backend/src/http/assets.ts
+++ b/packages/backend/src/http/assets.ts
@@ -87,6 +87,7 @@ const createAssetResolver = (distDir: string) => {
         }
 
         // SPA fallback for client-side routes.
+        // This fallback is transport-sensitive and should stay explicit so API and middleware changes do not shadow it.
         const fallbackPath = path.join(distDir, 'index.html');
         const fallbackContent = await tryReadFile(fallbackPath);
         if (fallbackContent) {

--- a/packages/backend/src/http/routeDispatch.ts
+++ b/packages/backend/src/http/routeDispatch.ts
@@ -6,6 +6,7 @@
  * @footnote-ethics: medium - Dispatch order controls which trust/auth checks run first.
  */
 import type http from 'node:http';
+import { wantsTraceJsonResponse } from './traceAccept.js';
 
 // --- Route path helpers ---
 const INCIDENT_STATUS_PATH_PATTERN = /^\/api\/incidents\/[^/]+\/status$/;
@@ -20,28 +21,6 @@ const normalizePathname = (pathname: string): string =>
     pathname.length > 1 && pathname.endsWith('/')
         ? pathname.slice(0, -1)
         : pathname;
-
-// Decide whether /api/traces/:responseId should return JSON or the SPA HTML shell.
-// We default to JSON unless the Accept header clearly asks for HTML.
-// This keeps API clients working even when they send a generic "*/*" Accept header.
-const wantsJsonResponse = (req: http.IncomingMessage): boolean => {
-    const headerValue = req.headers.accept;
-    const acceptHeader = Array.isArray(headerValue)
-        ? headerValue.join(',')
-        : headerValue || '';
-    const normalized = acceptHeader.toLowerCase();
-    const wantsHtml =
-        normalized.includes('text/html') ||
-        normalized.includes('application/xhtml+xml');
-    const wantsJson =
-        normalized.includes('application/json') || normalized.includes('+json');
-
-    if (wantsHtml && !wantsJson) {
-        return false;
-    }
-
-    return true;
-};
 
 type RequestHandler = (
     req: http.IncomingMessage,
@@ -111,7 +90,8 @@ const createRouteDispatcher = ({
         parsedUrl: URL;
         normalizedPathname: string;
     }): Promise<DispatchOutcome> => {
-        // --- Special routes (keep at top; auth/signature-sensitive) ---
+        // --- Special routes (keep at top; raw-body/signature-sensitive) ---
+        // Keep webhook dispatch ahead of any future generic body middleware. Signature checks require exact raw bytes.
         if (normalizedPathname === '/api/webhook/github') {
             await handlers.handleWebhookRequest(req, res);
             return 'handled';
@@ -215,7 +195,7 @@ const createRouteDispatcher = ({
         if (normalizedPathname.startsWith('/api/traces/')) {
             // Tell caches to keep JSON and HTML variants separate.
             res.setHeader('Vary', 'Accept');
-            if (wantsJsonResponse(req)) {
+            if (wantsTraceJsonResponse(req)) {
                 onTraceRouteMatched(normalizedPathname);
                 await handlers.handleTraceRequest(req, res, parsedUrl);
                 return 'handled';

--- a/packages/backend/src/http/staticTransport.ts
+++ b/packages/backend/src/http/staticTransport.ts
@@ -1,0 +1,135 @@
+/**
+ * @description: Serves static assets, SPA fallback content, and HTML-specific CSP headers.
+ * @footnote-scope: interface
+ * @footnote-module: StaticTransport
+ * @footnote-risk: high - Incorrect static transport can break frontend delivery or CSP enforcement.
+ * @footnote-ethics: medium - CSP coverage protects users from script injection on trusted pages.
+ */
+import type http from 'node:http';
+import path from 'node:path';
+
+type ResolvedAsset = {
+    content: Buffer;
+    absolutePath: string;
+};
+
+type ResolveAsset = (requestPath: string) => Promise<ResolvedAsset | undefined>;
+
+type LogRequest = (
+    req: http.IncomingMessage,
+    res: http.ServerResponse,
+    extra?: string
+) => void;
+
+type StaticTransportDeps = {
+    req: http.IncomingMessage;
+    res: http.ServerResponse;
+    parsedUrl: URL;
+    resolveAsset: ResolveAsset;
+    mimeMap: ReadonlyMap<string, string>;
+    frameAncestors: readonly string[];
+    logRequest: LogRequest;
+};
+
+const trimTrailingSlashes = (value: string): string => {
+    let end = value.length;
+    while (end > 0 && value[end - 1] === '/') {
+        end -= 1;
+    }
+    return value.slice(0, end);
+};
+
+const maybeApplyHtmlCsp = ({
+    req,
+    res,
+    parsedUrl,
+    contentType,
+    frameAncestors,
+}: {
+    req: http.IncomingMessage;
+    res: http.ServerResponse;
+    parsedUrl: URL;
+    contentType: string;
+    frameAncestors: readonly string[];
+}): void => {
+    // Keep CSP attached only to HTML responses. Non-HTML assets must remain cacheable and unmodified.
+    const isHtml =
+        contentType.includes('text/html') ||
+        parsedUrl.pathname === '/' ||
+        parsedUrl.pathname.endsWith('.html') ||
+        parsedUrl.pathname.startsWith('/embed');
+
+    if (!isHtml) {
+        return;
+    }
+
+    const forwardedProto =
+        typeof req.headers['x-forwarded-proto'] === 'string'
+            ? req.headers['x-forwarded-proto']
+            : undefined;
+    const scheme = forwardedProto?.split(',')[0].trim() || 'http';
+    const hostHeader =
+        typeof req.headers.host === 'string' ? req.headers.host.trim() : '';
+    const requestOrigin = hostHeader ? `${scheme}://${hostHeader}` : '';
+
+    // Keep self + current host explicit so embed behavior is stable across proxy/front-door setups.
+    const mergedFrameAncestors = [
+        "'self'",
+        ...(requestOrigin ? [requestOrigin] : []),
+        ...frameAncestors,
+    ];
+    const normalizedFrameAncestors = [
+        ...new Set(mergedFrameAncestors.map(trimTrailingSlashes)),
+    ];
+
+    const csp = [
+        `frame-ancestors ${normalizedFrameAncestors.join(' ')}`,
+        "default-src 'self'",
+        "script-src 'self' 'unsafe-inline' 'unsafe-eval' data: blob: https://challenges.cloudflare.com",
+        "style-src 'self' 'unsafe-inline' data:",
+        "img-src 'self' data: blob:",
+        "font-src 'self' data:",
+        "frame-src 'self' https://challenges.cloudflare.com",
+        "connect-src 'self' https://challenges.cloudflare.com https://api.openai.com",
+    ].join('; ');
+    res.setHeader('Content-Security-Policy', csp);
+};
+
+const handleStaticTransportRequest = async ({
+    req,
+    res,
+    parsedUrl,
+    resolveAsset,
+    mimeMap,
+    frameAncestors,
+    logRequest,
+}: StaticTransportDeps): Promise<void> => {
+    // resolveAsset also owns SPA fallback behavior; keep that fallback path centralized.
+    const asset = await resolveAsset(req.url ?? parsedUrl.pathname);
+    if (!asset) {
+        res.statusCode = 404;
+        res.end('Not Found');
+        logRequest(req, res, '(missing asset, index.html unavailable)');
+        return;
+    }
+
+    const extension = path.extname(asset.absolutePath).toLowerCase();
+    const contentType = mimeMap.get(extension) || 'application/octet-stream';
+
+    res.statusCode = 200;
+    res.setHeader('Content-Type', contentType);
+    res.setHeader('Cache-Control', 'public, max-age=600');
+
+    maybeApplyHtmlCsp({
+        req,
+        res,
+        parsedUrl,
+        contentType,
+        frameAncestors,
+    });
+
+    res.end(asset.content);
+    logRequest(req, res);
+};
+
+export { handleStaticTransportRequest };

--- a/packages/backend/src/http/traceAccept.ts
+++ b/packages/backend/src/http/traceAccept.ts
@@ -1,0 +1,37 @@
+/**
+ * @description: Encapsulates Accept negotiation for dual-use trace transport paths.
+ * @footnote-scope: utility
+ * @footnote-module: TraceAccept
+ * @footnote-risk: medium - Negotiation drift can break API clients or SPA trace-page routing.
+ * @footnote-ethics: medium - Incorrect negotiation can hide provenance data from users.
+ */
+import type http from 'node:http';
+
+/**
+ * /api/traces/:responseId is dual-use:
+ * - API clients need JSON metadata.
+ * - Browsers can request the SPA shell for the trace page.
+ *
+ * Keep this logic isolated so generic middleware changes do not alter transport semantics.
+ */
+const wantsTraceJsonResponse = (req: http.IncomingMessage): boolean => {
+    const headerValue = req.headers.accept;
+    const acceptHeader = Array.isArray(headerValue)
+        ? headerValue.join(',')
+        : headerValue || '';
+    const normalized = acceptHeader.toLowerCase();
+    const wantsHtml =
+        normalized.includes('text/html') ||
+        normalized.includes('application/xhtml+xml');
+    const wantsJson =
+        normalized.includes('application/json') || normalized.includes('+json');
+
+    if (wantsHtml && !wantsJson) {
+        return false;
+    }
+
+    // Fail-open toward JSON for clients that send generic or missing Accept headers.
+    return true;
+};
+
+export { wantsTraceJsonResponse };

--- a/packages/backend/src/http/upgradeBoundary.ts
+++ b/packages/backend/src/http/upgradeBoundary.ts
@@ -1,0 +1,72 @@
+/**
+ * @description: Handles websocket upgrade boundary routing for transport-sensitive paths.
+ * @footnote-scope: interface
+ * @footnote-module: UpgradeBoundary
+ * @footnote-risk: high - Upgrade routing mistakes can break realtime sessions or leave sockets hanging.
+ * @footnote-ethics: high - Realtime voice transport carries sensitive data and must keep strict boundaries.
+ */
+import type http from 'node:http';
+import type { Duplex } from 'node:stream';
+
+type DispatchUpgradeRoute = (args: {
+    req: http.IncomingMessage;
+    socket: Duplex;
+    head: Buffer;
+    normalizedPathname: string;
+    handleInternalVoiceRealtimeUpgrade: (
+        req: http.IncomingMessage,
+        socket: Duplex,
+        head: Buffer
+    ) => void;
+}) => boolean;
+
+type UpgradeDeps = {
+    req: http.IncomingMessage;
+    socket: Duplex;
+    head: Buffer;
+    normalizePathname: (pathname: string) => string;
+    dispatchUpgradeRoute: DispatchUpgradeRoute;
+    handleInternalVoiceRealtimeUpgrade: (
+        req: http.IncomingMessage,
+        socket: Duplex,
+        head: Buffer
+    ) => void;
+    logUpgradeError: (error: unknown) => void;
+};
+
+const handleUpgradeBoundary = ({
+    req,
+    socket,
+    head,
+    normalizePathname,
+    dispatchUpgradeRoute,
+    handleInternalVoiceRealtimeUpgrade,
+    logUpgradeError,
+}: UpgradeDeps): void => {
+    if (!req.url) {
+        socket.destroy();
+        return;
+    }
+
+    try {
+        const parsedUrl = new URL(req.url, 'http://localhost');
+        const normalizedPathname = normalizePathname(parsedUrl.pathname);
+        const isUpgradeHandled = dispatchUpgradeRoute({
+            req,
+            socket,
+            head,
+            normalizedPathname,
+            handleInternalVoiceRealtimeUpgrade,
+        });
+        if (isUpgradeHandled) {
+            return;
+        }
+    } catch (error) {
+        logUpgradeError(error);
+    }
+
+    // Unknown upgrade paths are always destroyed to avoid implicit websocket behavior.
+    socket.destroy();
+};
+
+export { handleUpgradeBoundary };

--- a/packages/backend/src/server.ts
+++ b/packages/backend/src/server.ts
@@ -32,6 +32,8 @@ import {
     createRouteDispatcher,
     normalizePathname,
 } from './http/routeDispatch.js';
+import { handleStaticTransportRequest } from './http/staticTransport.js';
+import { handleUpgradeBoundary } from './http/upgradeBoundary.js';
 import { verifyGitHubSignature } from './utils/github.js';
 import { logRequest } from './utils/requestLogger.js';
 import { logger } from './utils/logger.js';
@@ -539,82 +541,15 @@ const server = http.createServer(async (req, res) => {
             return;
         }
 
-        // --- Static assets ---
-        const asset = await resolveAsset(req.url);
-
-        if (!asset) {
-            res.statusCode = 404;
-            res.end('Not Found');
-            logRequest(req, res, '(missing asset, index.html unavailable)');
-            return;
-        }
-
-        const extension = path.extname(asset.absolutePath).toLowerCase();
-        const contentType =
-            mimeMap.get(extension) || 'application/octet-stream';
-
-        // --- Static response headers ---
-        res.statusCode = 200;
-        res.setHeader('Content-Type', contentType);
-        res.setHeader('Cache-Control', 'public, max-age=600');
-
-        // --- Content Security Policy ---
-        // Apply CSP only for HTML responses and embed routes.
-        const isHtml =
-            contentType.includes('text/html') ||
-            parsedUrl.pathname === '/' ||
-            parsedUrl.pathname.endsWith('.html') ||
-            parsedUrl.pathname.startsWith('/embed');
-
-        if (isHtml) {
-            const forwardedProto =
-                typeof req.headers['x-forwarded-proto'] === 'string'
-                    ? req.headers['x-forwarded-proto']
-                    : undefined;
-            const scheme = forwardedProto?.split(',')[0].trim() || 'http';
-            const hostHeader =
-                typeof req.headers.host === 'string'
-                    ? req.headers.host.trim()
-                    : '';
-            const requestOrigin = hostHeader ? `${scheme}://${hostHeader}` : '';
-
-            // Always allow self + current host, then merge configured frame ancestors.
-            const mergedFrameAncestors = [
-                "'self'",
-                ...(requestOrigin ? [requestOrigin] : []),
-                ...runtimeConfig.csp.frameAncestors,
-            ];
-            const trimTrailingSlashes = (value: string): string => {
-                let end = value.length;
-                while (end > 0 && value[end - 1] === '/') {
-                    end -= 1;
-                }
-                return value.slice(0, end);
-            };
-
-            const normalizedFrameAncestors = [
-                ...new Set(
-                    mergedFrameAncestors.map((domain) =>
-                        trimTrailingSlashes(domain)
-                    )
-                ),
-            ];
-
-            const csp = [
-                `frame-ancestors ${normalizedFrameAncestors.join(' ')}`,
-                "default-src 'self'",
-                "script-src 'self' 'unsafe-inline' 'unsafe-eval' data: blob: https://challenges.cloudflare.com",
-                "style-src 'self' 'unsafe-inline' data:",
-                "img-src 'self' data: blob:",
-                "font-src 'self' data:",
-                "frame-src 'self' https://challenges.cloudflare.com",
-                "connect-src 'self' https://challenges.cloudflare.com https://api.openai.com",
-            ].join('; ');
-            res.setHeader('Content-Security-Policy', csp);
-        }
-
-        res.end(asset.content);
-        logRequest(req, res);
+        await handleStaticTransportRequest({
+            req,
+            res,
+            parsedUrl,
+            resolveAsset,
+            mimeMap,
+            frameAncestors: runtimeConfig.csp.frameAncestors,
+            logRequest,
+        });
     } catch (error) {
         res.statusCode = 500;
         res.end('Internal Server Error');
@@ -627,33 +562,21 @@ const server = http.createServer(async (req, res) => {
 });
 
 server.on('upgrade', (req, socket, head) => {
-    if (!req.url) {
-        socket.destroy();
-        return;
-    }
-
-    try {
-        const parsedUrl = new URL(req.url, 'http://localhost');
-        const normalizedPathname = normalizePathname(parsedUrl.pathname);
-        const isUpgradeHandled = dispatchUpgradeRoute({
-            req,
-            socket,
-            head,
-            normalizedPathname,
-            handleInternalVoiceRealtimeUpgrade,
-        });
-        if (isUpgradeHandled) {
-            return;
-        }
-    } catch (error) {
-        logger.error(
-            `Failed to process websocket upgrade: ${
-                error instanceof Error ? error.message : String(error)
-            }`
-        );
-    }
-
-    socket.destroy();
+    handleUpgradeBoundary({
+        req,
+        socket,
+        head,
+        normalizePathname,
+        dispatchUpgradeRoute,
+        handleInternalVoiceRealtimeUpgrade,
+        logUpgradeError: (error) => {
+            logger.error(
+                `Failed to process websocket upgrade: ${
+                    error instanceof Error ? error.message : String(error)
+                }`
+            );
+        },
+    });
 });
 
 let isShuttingDown = false;


### PR DESCRIPTION
## Summary

Isolate backend transport-sensitive paths into explicit boundary modules before middleware-heavy routing is introduced.

## What Changed

- Extracted trace Accept negotiation into `packages/backend/src/http/traceAccept.ts` and wired route dispatch to use it.
- Extracted static/SPA/CSP transport handling into `packages/backend/src/http/staticTransport.ts` and wired `server.ts` through it.
- Extracted websocket upgrade boundary handling into `packages/backend/src/http/upgradeBoundary.ts` and wired `server.ts` upgrade flow through it.
- Kept route dispatch ordering explicit for transport-sensitive paths, including webhook placement and trace `Vary: Accept` behavior.
- Added boundary comments for:
  - webhook raw-body/signature validation path
  - NDJSON streaming path for internal image generation
  - realtime websocket upgrade path
  - SPA fallback path in asset resolution

## Why

This branch isolates unusual transport behavior so future generic middleware does not accidentally change buffering, raw-body verification, Accept negotiation, streaming flush behavior, or websocket upgrade handling. The goal is to keep these semantics explicit and easy to reason about before introducing a middleware-heavy Express shell.

## Important Implementation Details

- Behavior was preserved; this is a structural isolation/refactor.
- `traceAccept.ts` keeps fail-open JSON behavior for generic/missing `Accept` headers and only falls through to SPA HTML when HTML is explicitly preferred.
- `staticTransport.ts` keeps existing cache headers, MIME selection, SPA fallback serving, and HTML-only CSP injection behavior.
- `upgradeBoundary.ts` keeps explicit URL parsing + route matching for upgrades and destroys unmatched sockets to avoid implicit behavior.
- Route dispatch keeps webhook handling early to preserve raw-byte signature verification safety.

## Validation

- `pnpm exec tsx --test packages/backend/test/serverContract.test.ts`
- `pnpm exec tsx --test packages/backend/test/internalImageHandler.test.ts`
- `pnpm exec tsx --test packages/backend/test/internalVoiceRealtimeHandler.test.ts`
- `pnpm lint`
- `pnpm review`
- `pnpm validate-footnote-tags`

This PR was written using [Vibe Kanban](https://vibekanban.com)
