### PR TITLE
Introduce backend Express transport shell without route migration (Vibe Kanban)

### DIFF
--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -14,17 +14,19 @@
         "@resvg/resvg-js": "catalog:",
         "better-sqlite3": "catalog:",
         "dotenv": "catalog:",
+        "express": "catalog:",
         "js-yaml": "catalog:",
         "nodemailer": "catalog:",
-        "ws": "catalog:",
+        "winston": "catalog:",
         "winston-daily-rotate-file": "catalog:",
-        "zod": "catalog:",
-        "winston": "catalog:"
+        "ws": "catalog:",
+        "zod": "catalog:"
     },
     "devDependencies": {
         "@types/better-sqlite3": "catalog:",
-        "@types/nodemailer": "catalog:",
+        "@types/express": "catalog:",
         "@types/node": "catalog:",
+        "@types/nodemailer": "catalog:",
         "typescript": "catalog:"
     }
 }

--- a/packages/backend/src/http/expressApp.ts
+++ b/packages/backend/src/http/expressApp.ts
@@ -1,0 +1,168 @@
+/**
+ * @description: Builds the Express composition shell for standard HTTP route dispatch.
+ * Keeps special transport behavior explicit by delegating to existing route/static handlers without global body parsing.
+ * @footnote-scope: interface
+ * @footnote-module: ExpressAppShell
+ * @footnote-risk: medium - Middleware ordering mistakes can change route fallthrough behavior.
+ * @footnote-ethics: low - Transport composition changes do not alter policy decisions or user data handling.
+ */
+import type http from 'node:http';
+import express from 'express';
+
+type DispatchOutcome = 'handled' | 'fallthrough';
+
+type DispatchHttpRoute = (args: {
+    req: http.IncomingMessage;
+    res: http.ServerResponse;
+    parsedUrl: URL;
+    normalizedPathname: string;
+}) => Promise<DispatchOutcome>;
+
+type ResolveAsset = (
+    requestPath: string
+) => Promise<{ content: Buffer; absolutePath: string } | undefined>;
+
+type LogRequest = (
+    req: http.IncomingMessage,
+    res: http.ServerResponse,
+    extra?: string
+) => void;
+
+type HandleStaticTransportRequest = (args: {
+    req: http.IncomingMessage;
+    res: http.ServerResponse;
+    parsedUrl: URL;
+    resolveAsset: ResolveAsset;
+    mimeMap: ReadonlyMap<string, string>;
+    frameAncestors: readonly string[];
+    logRequest: LogRequest;
+}) => Promise<void>;
+
+type CreateExpressAppDeps = {
+    dispatchHttpRoute: DispatchHttpRoute;
+    normalizePathname: (pathname: string) => string;
+    handleStaticTransportRequest: HandleStaticTransportRequest;
+    resolveAsset: ResolveAsset;
+    mimeMap: ReadonlyMap<string, string>;
+    frameAncestors: readonly string[];
+    logRequest: LogRequest;
+};
+
+const getRequestUrl = (req: http.IncomingMessage): string | undefined => {
+    const requestWithOriginalUrl = req as http.IncomingMessage & {
+        originalUrl?: unknown;
+    };
+    if (
+        typeof requestWithOriginalUrl.originalUrl === 'string' &&
+        requestWithOriginalUrl.originalUrl.length > 0
+    ) {
+        return requestWithOriginalUrl.originalUrl;
+    }
+    return (typeof req.url === 'string' && req.url) || undefined;
+};
+
+const createExpressApp = ({
+    dispatchHttpRoute,
+    normalizePathname,
+    handleStaticTransportRequest,
+    resolveAsset,
+    mimeMap,
+    frameAncestors,
+    logRequest,
+}: CreateExpressAppDeps): express.Express => {
+    const app = express();
+
+    // Normal HTTP API routes should be composed here with route-scoped middleware.
+    // Keep request body parsing opt-in per route so signature/raw-body paths stay safe.
+    app.use('/api', async (req, res, next) => {
+        const requestUrl = getRequestUrl(req);
+        if (!requestUrl) {
+            res.status(400).end('Bad Request');
+            return;
+        }
+
+        try {
+            const parsedUrl = new URL(requestUrl, 'http://localhost');
+            const normalizedPathname = normalizePathname(parsedUrl.pathname);
+            const routeOutcome = await dispatchHttpRoute({
+                req,
+                res,
+                parsedUrl,
+                normalizedPathname,
+            });
+            if (routeOutcome === 'handled') {
+                return;
+            }
+            next();
+        } catch (error) {
+            res.status(500).end('Internal Server Error');
+            logRequest(
+                req,
+                res,
+                error instanceof Error ? error.message : 'unknown error'
+            );
+        }
+    });
+
+    app.all('/config.json', async (req, res, next) => {
+        const requestUrl = getRequestUrl(req);
+        if (!requestUrl) {
+            res.status(400).end('Bad Request');
+            return;
+        }
+
+        try {
+            const parsedUrl = new URL(requestUrl, 'http://localhost');
+            const normalizedPathname = normalizePathname(parsedUrl.pathname);
+            const routeOutcome = await dispatchHttpRoute({
+                req,
+                res,
+                parsedUrl,
+                normalizedPathname,
+            });
+            if (routeOutcome === 'fallthrough') {
+                next();
+            }
+        } catch (error) {
+            res.status(500).end('Internal Server Error');
+            logRequest(
+                req,
+                res,
+                error instanceof Error ? error.message : 'unknown error'
+            );
+        }
+    });
+
+    // Static assets and SPA fallback remain the terminal normal-HTTP transport stage.
+    app.use(async (req, res) => {
+        const requestUrl = getRequestUrl(req);
+        if (!requestUrl) {
+            res.status(400).end('Bad Request');
+            return;
+        }
+
+        try {
+            const parsedUrl = new URL(requestUrl, 'http://localhost');
+            await handleStaticTransportRequest({
+                req,
+                res,
+                parsedUrl,
+                resolveAsset,
+                mimeMap,
+                frameAncestors,
+                logRequest,
+            });
+        } catch (error) {
+            res.status(500).end('Internal Server Error');
+            logRequest(
+                req,
+                res,
+                error instanceof Error ? error.message : 'unknown error'
+            );
+        }
+    });
+
+    return app;
+};
+
+export { createExpressApp };

--- a/packages/backend/src/server.ts
+++ b/packages/backend/src/server.ts
@@ -28,6 +28,7 @@ import { createTraceStore, storeTrace } from './services/traceStore.js';
 import { createBlogStore } from './storage/blogStore.js';
 import { getDefaultIncidentStore } from './storage/incidents/incidentStore.js';
 import { createAssetResolver } from './http/assets.js';
+import { createExpressApp } from './http/expressApp.js';
 import {
     createRouteDispatcher,
     normalizePathname,
@@ -517,49 +518,18 @@ const { dispatchHttpRoute, dispatchUpgradeRoute } = createRouteDispatcher({
         logger.debug(`Trace route matched: ${pathname}`);
     },
 });
+const app = createExpressApp({
+    dispatchHttpRoute,
+    normalizePathname,
+    handleStaticTransportRequest,
+    resolveAsset,
+    mimeMap,
+    frameAncestors: runtimeConfig.csp.frameAncestors,
+    logRequest,
+});
 
 // --- HTTP server ---
-const server = http.createServer(async (req, res) => {
-    // --- Early request guard ---
-    if (!req.url) {
-        res.statusCode = 400;
-        res.end('Bad Request');
-        return;
-    }
-
-    try {
-        // --- URL parsing ---
-        const parsedUrl = new URL(req.url, 'http://localhost');
-        const normalizedPathname = normalizePathname(parsedUrl.pathname);
-        const routeOutcome = await dispatchHttpRoute({
-            req,
-            res,
-            parsedUrl,
-            normalizedPathname,
-        });
-        if (routeOutcome === 'handled') {
-            return;
-        }
-
-        await handleStaticTransportRequest({
-            req,
-            res,
-            parsedUrl,
-            resolveAsset,
-            mimeMap,
-            frameAncestors: runtimeConfig.csp.frameAncestors,
-            logRequest,
-        });
-    } catch (error) {
-        res.statusCode = 500;
-        res.end('Internal Server Error');
-        logRequest(
-            req,
-            res,
-            error instanceof Error ? error.message : 'unknown error'
-        );
-    }
-});
+const server = http.createServer(app);
 
 server.on('upgrade', (req, socket, head) => {
     handleUpgradeBoundary({

--- a/packages/backend/test/expressApp.test.ts
+++ b/packages/backend/test/expressApp.test.ts
@@ -1,0 +1,108 @@
+/**
+ * @description: Verifies the Express shell keeps route dispatch and static fallthrough boundaries explicit.
+ * Confirms normal HTTP handling behavior remains composition-only with no implicit parsing side effects.
+ * @footnote-scope: test
+ * @footnote-module: ExpressAppTests
+ * @footnote-risk: medium - Missing shell tests can hide regressions in route dispatch order and fallthrough.
+ * @footnote-ethics: low - Tests validate transport composition and do not process sensitive user data.
+ */
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import http from 'node:http';
+
+import { createExpressApp } from '../src/http/expressApp.js';
+
+const TEST_HOST = '127.0.0.1';
+
+const createTestServer = (
+    app: ReturnType<typeof createExpressApp>
+): Promise<{
+    baseUrl: string;
+    stop: () => Promise<void>;
+}> =>
+    new Promise((resolve, reject) => {
+        const server = http.createServer(app);
+        server.on('error', reject);
+        server.listen(0, TEST_HOST, () => {
+            const address = server.address();
+            if (!address || typeof address === 'string') {
+                reject(new Error('Failed to resolve test server address.'));
+                return;
+            }
+            resolve({
+                baseUrl: `http://${TEST_HOST}:${address.port}`,
+                stop: async () => {
+                    await new Promise<void>((resolveClose, rejectClose) => {
+                        server.close((error) => {
+                            if (error) {
+                                rejectClose(error);
+                                return;
+                            }
+                            resolveClose();
+                        });
+                    });
+                },
+            });
+        });
+    });
+
+test('express shell returns handled API dispatch without entering static fallback', async (t) => {
+    let staticCalls = 0;
+    const app = createExpressApp({
+        dispatchHttpRoute: async ({ normalizedPathname, res }) => {
+            if (normalizedPathname === '/api/health') {
+                res.statusCode = 200;
+                res.end('ok');
+                return 'handled';
+            }
+            return 'fallthrough';
+        },
+        normalizePathname: (pathname) => pathname,
+        handleStaticTransportRequest: async ({ res }) => {
+            staticCalls += 1;
+            res.statusCode = 200;
+            res.end('static');
+        },
+        resolveAsset: async () => undefined,
+        mimeMap: new Map<string, string>(),
+        frameAncestors: [],
+        logRequest: () => undefined,
+    });
+
+    const server = await createTestServer(app);
+    t.after(async () => {
+        await server.stop();
+    });
+
+    const response = await fetch(`${server.baseUrl}/api/health`);
+    assert.equal(response.status, 200);
+    assert.equal(await response.text(), 'ok');
+    assert.equal(staticCalls, 0);
+});
+
+test('express shell falls through API dispatch and serves static transport', async (t) => {
+    let staticCalls = 0;
+    const app = createExpressApp({
+        dispatchHttpRoute: async () => 'fallthrough',
+        normalizePathname: (pathname) => pathname,
+        handleStaticTransportRequest: async ({ res }) => {
+            staticCalls += 1;
+            res.statusCode = 200;
+            res.end('static-fallback');
+        },
+        resolveAsset: async () => undefined,
+        mimeMap: new Map<string, string>(),
+        frameAncestors: [],
+        logRequest: () => undefined,
+    });
+
+    const server = await createTestServer(app);
+    t.after(async () => {
+        await server.stop();
+    });
+
+    const response = await fetch(`${server.baseUrl}/api/traces/example`);
+    assert.equal(response.status, 200);
+    assert.equal(await response.text(), 'static-fallback');
+    assert.equal(staticCalls, 1);
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -330,6 +330,9 @@ importers:
             dotenv:
                 specifier: 'catalog:'
                 version: 17.3.1
+            express:
+                specifier: 'catalog:'
+                version: 5.2.1
             js-yaml:
                 specifier: 'catalog:'
                 version: 4.1.1
@@ -352,6 +355,9 @@ importers:
             '@types/better-sqlite3':
                 specifier: 'catalog:'
                 version: 7.6.13
+            '@types/express':
+                specifier: 'catalog:'
+                version: 5.0.6
             '@types/node':
                 specifier: 'catalog:'
                 version: 25.5.0


### PR DESCRIPTION
## What Changed

- Added an Express composition shell for normal backend HTTP routes via `createExpressApp()`.
- Kept existing route behavior by reusing the current `createRouteDispatcher()` and `handleStaticTransportRequest()` logic.
- Updated server wiring from inline `http.createServer(async (req, res) => ...)` handling to `http.createServer(app)`.
- Preserved the explicit server-owned websocket upgrade boundary (`server.on('upgrade', ...)`) and existing `upgradeBoundary` flow.
- Added focused shell tests for:
  - handled `/api` dispatch paths
  - `/api` fallthrough into static transport
- Added backend dependencies for `express` and `@types/express`, with lockfile updates.

## Why This Was Done

This PR introduces the Express transport shell as a low-risk composition step, without broad route migration. The goal is to improve middleware and route composition ergonomics while proving that behavior remains unchanged. It directly supports the task context to keep special transport boundaries explicit and protected (upgrade handling, Accept negotiation, NDJSON/raw-body-sensitive paths).

## Important Implementation Details

- No global body parser was introduced (no blanket `express.json()` middleware).
- Middleware boundaries are explicit and route-scoped:
  - `/api` routes dispatch through existing backend handlers.
  - `/config.json` remains explicitly routed.
  - static/SPA resolution remains the terminal fallback path.
- Trace Accept negotiation behavior remains in the existing dispatcher (`Vary: Accept`, JSON vs SPA fallthrough).
- Websocket upgrade routing remains outside Express in the raw Node server boundary.
- The shell uses request URL normalization with `originalUrl` support to preserve mounted-route behavior.

## Validation

- `pnpm lint:fix`
- `pnpm exec tsx --test packages/backend/test/expressApp.test.ts`
- `pnpm exec tsx --test packages/backend/test/serverContract.test.ts`
- `pnpm lint`
- `pnpm review`
- `docker compose -f deploy/compose.yml build`
- `pnpm validate-footnote-tags`

This PR was written using [Vibe Kanban](https://vibekanban.com)
