### PR TITLE
docs: consolidate workflow/planner docs for first-read clarity (Vibe Kanban)

### DIFF
--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -13,8 +13,8 @@ the best starting point.
    current workflow and planner model, including mode, profile, review/revise,
    and planner boundaries.
 3. [Workflow Engine And Provenance](./workflow-engine-and-provenance.md):
-   use this after the routing doc for the current engine surface and lineage
-   record shape.
+   use this after the routing doc for the current engine flow and workflow
+   metadata.
 4. [How to Read Provenance-Related Metadata](./provenance-label-taxonomy.md):
    use this before interpreting TRACE, provenance, mode, or planner fields in
    responses.
@@ -34,8 +34,8 @@ the best starting point.
 
 ## Historical Workflow Notes
 
-These are useful after you understand the current docs above.
-They are not the best first read for the current workflow/planner shape.
+Read these after the docs above if you need rollout history or older design
+notes. They are not the best first read for the workflow/planner model today.
 
 - [Workflow Profiles V1 RFC: Engine Core vs Profile Semantics](./workflow-profiles-v1-engine-vs-profile-semantics.md):
   design notes and ownership reasoning from the workflow-engine rollout.

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -9,28 +9,38 @@ the best starting point.
 
 1. [Execution Contract Authority Map](./execution-contract-authority-map.md):
    start here for system authority and ownership boundaries.
-2. [Workflow Profile Contract](./workflow-profile-contract.md): read this next
-   for the contract that profiles must satisfy.
-3. [Workflow Mode Routing](./workflow-mode-routing.md): explains how runtime
-   routing decisions relate to user-facing posture and execution.
-4. [Workflow Engine And Provenance](./workflow-engine-and-provenance.md):
-   explains the workflow shape and provenance model.
-5. [How to Read Provenance-Related Metadata](./provenance-label-taxonomy.md):
+2. [Workflow Mode Routing](./workflow-mode-routing.md): read this next for the
+   current workflow and planner model, including mode, profile, review/revise,
+   and planner boundaries.
+3. [Workflow Engine And Provenance](./workflow-engine-and-provenance.md):
+   use this after the routing doc for the current engine surface and lineage
+   record shape.
+4. [How to Read Provenance-Related Metadata](./provenance-label-taxonomy.md):
    use this before interpreting TRACE, provenance, mode, or planner fields in
    responses.
 
 ## Important Adjacent Docs
 
+- [Workflow Profile Contract](./workflow-profile-contract.md): contract details
+  for executable workflow profiles, limits, and no-generation handling.
 - [Prompt Resolution Order](./prompt-resolution.md): how prompt layers and
   overrides resolve at runtime.
 - [Bounded User Control Mapping](./bounded-user-control-mapping.md): what users
   can steer directly and what stays backend-owned.
-- [Workflow Profiles V1 RFC: Engine Core vs Profile Semantics](./workflow-profiles-v1-engine-vs-profile-semantics.md):
-  a deeper explanation of engine/profile boundaries and invariants.
 - [Execution Contract TrustGraph Architecture](./execution_contract_trustgraph/architecture.md):
   TrustGraph-specific architecture and rollout constraints.
 - [Steerability Foundation (Internal Controls v1)](./2026-04-steerability-foundation.md):
   the control-plane foundation behind bounded user control and runtime posture.
+
+## Historical Workflow Notes
+
+These are useful after you understand the current docs above.
+They are not the best first read for the current workflow/planner shape.
+
+- [Workflow Profiles V1 RFC: Engine Core vs Profile Semantics](./workflow-profiles-v1-engine-vs-profile-semantics.md):
+  design notes and ownership reasoning from the workflow-engine rollout.
+- [Workflow Engine Rollout Status](../status/2026-04-workflow-engine-rollout-status.md):
+  rollout tracking and landing history for workflow-engine work.
 
 ## Incident And Safety
 

--- a/docs/architecture/execution-contract-authority-map.md
+++ b/docs/architecture/execution-contract-authority-map.md
@@ -22,16 +22,16 @@ That module is the Execution Contract authority surface.
 
 ## Authority Map
 
-| Concern                           | Governing Authority                                                       | Runtime Executor                                       | Notes                                                                             |
-| --------------------------------- | ------------------------------------------------------------------------- | ------------------------------------------------------ | --------------------------------------------------------------------------------- |
-| Execution rules and legal shape   | Execution Contract (`packages/backend/src/services/executionContract.ts`) | `chatOrchestrator` + workflow runtime                  | Runtime must satisfy contract fields; runtime does not redefine ontology.         |
-| Request execution coordination    | Execution Contract (policy bounds)                                        | `packages/backend/src/services/chatOrchestrator.ts`    | Orchestrator selects/coordinates steps inside contract limits.                    |
-| Planner step invocation           | Workflow-owned step policy under Execution Contract bounds                | `chatPlanner` invoked from workflow context only       | Planner is a bounded `plan` step with named purpose; planner output is advisory.  |
-| Workflow/profile semantics        | Execution Contract response/limit constraints + workflow profile contract | `workflowProfileRegistry` + `workflowEngine`           | Profiles are named execution shapes, not competing policy authorities.            |
-| Model/provider/tool selection     | Execution Contract routing intent and limits                              | orchestrator + resolver/services + runtime adapters    | Selection details are execution assembly under contract constraints.              |
-| Trace and provenance recording    | Execution Contract requirement to track provenance                        | `chatService`, trace store, response metadata emitters | Provenance records what happened; it does not set policy.                         |
-| TrustGraph evidence intake        | Execution Contract boundary rules                                         | `executionContractTrustGraph` seam modules             | Advisory evidence can influence bounded views, never control execution authority. |
-| Breaker/safety action application | Deterministic safety contract + backend policy boundary                   | orchestrator/service enforcement path                  | Planner hints are advisory only.                                                  |
+| Concern                           | Governing Authority                                                       | Runtime Executor                                       | Notes                                                                                                |
+| --------------------------------- | ------------------------------------------------------------------------- | ------------------------------------------------------ | ---------------------------------------------------------------------------------------------------- |
+| Execution rules and legal shape   | Execution Contract (`packages/backend/src/services/executionContract.ts`) | `chatOrchestrator` + workflow runtime                  | Runtime must satisfy contract fields; runtime does not redefine ontology.                            |
+| Request execution coordination    | Execution Contract (policy bounds)                                        | `packages/backend/src/services/chatOrchestrator.ts`    | Orchestrator selects/coordinates steps inside contract limits.                                       |
+| Planner step invocation           | Workflow-owned planner boundary under Execution Contract bounds           | `chatPlanner` invoked by `chatOrchestrator` today      | Planner output is advisory. Planner-as-workflow-step is future direction, not current runtime shape. |
+| Workflow/profile semantics        | Execution Contract response/limit constraints + workflow profile contract | `workflowProfileRegistry` + `workflowEngine`           | Profiles are named execution shapes, not competing policy authorities.                               |
+| Model/provider/tool selection     | Execution Contract routing intent and limits                              | orchestrator + resolver/services + runtime adapters    | Selection details are execution assembly under contract constraints.                                 |
+| Trace and provenance recording    | Execution Contract requirement to track provenance                        | `chatService`, trace store, response metadata emitters | Provenance records what happened; it does not set policy.                                            |
+| TrustGraph evidence intake        | Execution Contract boundary rules                                         | `executionContractTrustGraph` seam modules             | Advisory evidence can influence bounded views, never control execution authority.                    |
+| Breaker/safety action application | Deterministic safety contract + backend policy boundary                   | orchestrator/service enforcement path                  | Planner hints are advisory only.                                                                     |
 
 ## Explicit Non-Goals
 
@@ -44,7 +44,7 @@ That module is the Execution Contract authority surface.
 
 - The Execution Contract is the single governing contract for execution shape.
 - The orchestrator is the request-time execution coordinator.
-- Planner is a bounded workflow step, not a second orchestrator.
+- Planner is a bounded helper with workflow-owned boundaries, not a second orchestrator.
 - Planner outputs are advisory and cannot directly override Execution Contract authority.
 - Workflow profiles remain named shapes selected under the contract.
 - External evidence systems (including TrustGraph) never become routing or terminal authorities.

--- a/docs/architecture/execution-contract-authority-map.md
+++ b/docs/architecture/execution-contract-authority-map.md
@@ -4,21 +4,21 @@
 
 Define one stable authority model for chat execution in Footnote.
 
-Target statement:
-
-`The contract governs. The orchestrator executes.`
+The short version is simple: the contract governs and the orchestrator
+executes.
 
 ## Canonical Terms
 
-- `Execution Contract`: the governing backend contract for allowed execution shape, limits, verification expectations, and fail-open semantics.
-- `chatOrchestrator`: the runtime coordinator that carries out one request under the contract.
-- `planner`: a bounded workflow step owned by workflow logic; it can propose action details but cannot mutate hard execution authority.
-- `workflow profile`: a named workflow shape selected under the contract.
-- `trace/provenance`: evidence of what happened relative to contract-governed execution.
+`Execution Contract` is the backend contract for allowed execution behavior,
+limits, verification expectations, and fail-open semantics.
+`chatOrchestrator` carries out one request under that contract.
+`planner` can propose action details, but it cannot change the rules.
+`workflow profile` is the named step pattern selected under the contract.
+`trace/provenance` records what happened.
 
 Implementation note:
 Current code still uses `ExecutionContract` naming for the main contract module.
-That module is the Execution Contract authority surface.
+That module is still the main Execution Contract module.
 
 ## Ownership
 
@@ -35,13 +35,12 @@ That module is the Execution Contract authority surface.
 
 ## Boundaries
 
-- The Execution Contract is the single governing contract for execution shape.
-- The orchestrator is the request-time execution coordinator.
-- Planner is a bounded helper with workflow-owned boundaries, not a second orchestrator.
-- Planner outputs are advisory and cannot directly override Execution Contract authority.
-- Workflow profiles remain named shapes selected under the contract.
-- External evidence systems (including TrustGraph) never become routing or terminal authorities.
-- Provenance explains decisions after execution; it does not become a second decision engine.
+The Execution Contract is the governing contract for execution behavior. The
+orchestrator coordinates the request at runtime. Planner is a bounded helper,
+not a second orchestrator, and its output is advisory. Workflow profiles stay
+inside the contract. External evidence systems such as TrustGraph can inform
+execution, but they do not become routing or terminal authorities. Provenance
+records decisions after execution; it does not become a second decision engine.
 
 ## Non-Goals
 

--- a/docs/architecture/execution-contract-authority-map.md
+++ b/docs/architecture/execution-contract-authority-map.md
@@ -20,7 +20,7 @@ Implementation note:
 Current code still uses `ExecutionContract` naming for the main contract module.
 That module is the Execution Contract authority surface.
 
-## Authority Map
+## Ownership
 
 | Concern                           | Governing Authority                                                       | Runtime Executor                                       | Notes                                                                                                |
 | --------------------------------- | ------------------------------------------------------------------------- | ------------------------------------------------------ | ---------------------------------------------------------------------------------------------------- |
@@ -33,14 +33,7 @@ That module is the Execution Contract authority surface.
 | TrustGraph evidence intake        | Execution Contract boundary rules                                         | `executionContractTrustGraph` seam modules             | Advisory evidence can influence bounded views, never control execution authority.                    |
 | Breaker/safety action application | Deterministic safety contract + backend policy boundary                   | orchestrator/service enforcement path                  | Planner hints are advisory only.                                                                     |
 
-## Explicit Non-Goals
-
-- Turn the Execution Contract into a general runtime engine.
-- Replace orchestrator control flow with a contract interpreter.
-- Introduce user-defined workflow programming in this phase.
-- Treat provider abstraction as solved by this authority-map document.
-
-## Invariants To Keep Stable
+## Boundaries
 
 - The Execution Contract is the single governing contract for execution shape.
 - The orchestrator is the request-time execution coordinator.
@@ -49,6 +42,13 @@ That module is the Execution Contract authority surface.
 - Workflow profiles remain named shapes selected under the contract.
 - External evidence systems (including TrustGraph) never become routing or terminal authorities.
 - Provenance explains decisions after execution; it does not become a second decision engine.
+
+## Non-Goals
+
+- Turn the Execution Contract into a general runtime engine.
+- Replace orchestrator control flow with a contract interpreter.
+- Introduce user-defined workflow programming in this phase.
+- Treat provider abstraction as solved by this authority-map document.
 
 ## Extension Checklist
 

--- a/docs/architecture/execution-contract-authority-map.md
+++ b/docs/architecture/execution-contract-authority-map.md
@@ -2,12 +2,12 @@
 
 ## Purpose
 
-Define one stable authority model for chat execution in Footnote.
+Explain which part owns each decision in chat execution.
 
 The short version is simple: the contract governs and the orchestrator
 executes.
 
-## Canonical Terms
+## Terms
 
 `Execution Contract` is the backend contract for allowed execution behavior,
 limits, verification expectations, and fail-open semantics.
@@ -49,7 +49,7 @@ records decisions after execution; it does not become a second decision engine.
 - Introduce user-defined workflow programming in this phase.
 - Treat provider abstraction as solved by this authority-map document.
 
-## Extension Checklist
+## Changes
 
 When adding execution behavior:
 

--- a/docs/architecture/workflow-engine-and-provenance.md
+++ b/docs/architecture/workflow-engine-and-provenance.md
@@ -2,7 +2,7 @@
 
 ## Purpose
 
-Explain the current workflow-engine surface and the provenance record it emits.
+Explain the current workflow engine and the metadata it emits.
 
 This doc is about what is implemented now, not the full target direction.
 Read [Workflow Mode Routing](./workflow-mode-routing.md) first if you need the
@@ -27,7 +27,7 @@ big picture.
 - `WorkflowRecord`: Curated structured artifact for provenance and operators.
 - `StepRecord`: One step entry inside the workflow record.
 
-## Current Engine Scope
+## Engine Scope
 
 Today the engine mainly powers the reviewed chat path in
 `packages/backend/src/services/workflowEngine.ts`.
@@ -41,7 +41,8 @@ What is active now:
 - fail-open handling for generation/review/revise failures,
 - `WorkflowRecord` and `StepRecord` lineage output.
 
-What is vocabulary now but not the main current chat path:
+Terms that exist in the shared workflow vocabulary but are not part of the
+main current chat path:
 
 - `plan`
 - `tool`
@@ -64,7 +65,7 @@ That choice is controlled by `WorkflowPolicy` and `ExecutionLimits`.
 Model-backed deliberation is treated as an optional capability of certain steps,
 not a top-level orchestration authority.
 
-## Current Review Loop
+## Review Loop
 
 The reviewed profile uses one bounded pattern:
 
@@ -76,7 +77,7 @@ The reviewed profile uses one bounded pattern:
 This is the current runtime path behind review and revise behavior.
 It is not just a target design note.
 
-## Outcome Shape
+## Step Records
 
 Each `StepRecord` includes an `outcome` with minimal typed fields:
 
@@ -86,19 +87,19 @@ Each `StepRecord` includes an `outcome` with minimal typed fields:
 - `signals`
 - `recommendations` (optional)
 
-This keeps handoff data explicit without a separate top-level handoff type.
+This keeps step output explicit without a separate top-level handoff type.
 `signals` means machine-readable control indicators used by transition logic
 (for example `goalMet`, `needsMoreEvidence`, `toolResultQuality`), not generic telemetry.
 For bounded review `assess` steps, use `reviewDecision` (`finalize` or `revise`)
 plus `reviewReason` as the canonical machine output seam.
 `recommendations` is advisory only and never overrides backend legality checks.
 
-## Transition And Limit Ownership
+## Limits
 
-`WorkflowPolicy` defines legal next steps from current state.
-`WorkflowPolicy` also owns capability toggles (for example plan/revise/tool enablement).
+`WorkflowPolicy` defines legal next steps from the current state.
+It also owns capability toggles such as plan/revise/tool enablement.
 Model outputs can recommend transitions only where policy allows.
-Final transition legality remains backend-owned.
+Final transition checks remain backend-owned.
 
 `ExecutionLimits` owns the hard caps:
 
@@ -110,9 +111,9 @@ Final transition legality remains backend-owned.
 
 These are backend-enforced stops, not model suggestions.
 
-## Termination Reasons
+## Failure Behavior
 
-Initial reasons:
+The current workflow can end for these reasons:
 
 - `goal_satisfied`
 - `budget_exhausted_steps`
@@ -123,10 +124,11 @@ Initial reasons:
 - `max_deliberation_calls_reached`
 - `executor_error_fail_open`
 
-## Provenance Shape
+## Workflow Metadata
 
 `WorkflowRecord` is the primary orchestration provenance artifact.
-`WorkflowRecord` is the provenance-facing curated record.
+`WorkflowRecord` is the main workflow record returned for operators and
+response metadata.
 Deeper runtime/debug execution detail can remain in internal logs keyed by
 `workflowId` and `stepId`.
 
@@ -134,10 +136,10 @@ In current chat responses:
 
 - planner metadata still lives alongside workflow lineage,
 - workflow lineage covers the reviewed generation path,
-- the two should be read together without confusing planner influence for
-  workflow authority.
+- read planner metadata and workflow metadata together, but do not confuse
+  planner influence with workflow authority.
 
-## Future Direction
+## Future Work
 
 Future work may extend the same engine shape to planner and tool steps.
 That is not the current first-read explanation.

--- a/docs/architecture/workflow-engine-and-provenance.md
+++ b/docs/architecture/workflow-engine-and-provenance.md
@@ -4,7 +4,7 @@
 
 Explain the current workflow engine and the metadata it emits.
 
-This doc is about what is implemented now, not the full target direction.
+This doc covers what is implemented now, not the full plan.
 Read [Workflow Mode Routing](./workflow-mode-routing.md) first if you need the
 big picture.
 
@@ -19,45 +19,29 @@ big picture.
 
 ## Terms
 
-- `WorkflowEngine`: Runs one bounded workflow loop from start to termination.
-- `WorkflowPolicy`: Declares legal transitions and capability toggles.
-- `ExecutionLimits`: Declares hard caps (steps, calls, tokens, time).
-- `WorkflowState`: In-memory state used while a workflow is running.
-- `StepExecutor`: Executes one step.
-- `WorkflowRecord`: Curated structured artifact for provenance and operators.
-- `StepRecord`: One step entry inside the workflow record.
+`WorkflowEngine` runs one bounded workflow loop from start to termination.
+`WorkflowPolicy` defines legal transitions and capability toggles.
+`ExecutionLimits` defines hard caps for steps, calls, tokens, and time.
+`WorkflowState` is the in-memory state for a running workflow.
+`StepExecutor` runs one step.
+`WorkflowRecord` and `StepRecord` are the workflow metadata records.
 
 ## Engine Scope
 
 Today the engine mainly powers the reviewed chat path in
-`packages/backend/src/services/workflowEngine.ts`.
+`packages/backend/src/services/workflowEngine.ts`. It handles transition
+checks, hard limits, the bounded `generate -> assess -> revise` flow,
+termination reasons, fail-open handling for generation/review/revise failures,
+and `WorkflowRecord` plus `StepRecord` output.
 
-What is active now:
-
-- legal transition checks,
-- hard execution limits,
-- bounded `generate -> assess -> revise` execution,
-- canonical termination reasons,
-- fail-open handling for generation/review/revise failures,
-- `WorkflowRecord` and `StepRecord` lineage output.
-
-Terms that exist in the shared workflow vocabulary but are not part of the
-main current chat path:
-
-- `plan`
-- `tool`
-- replanning/tool-call budgets beyond current reviewed generation flow
+The shared workflow vocabulary also includes `plan`, `tool`, and replanning or
+tool-call budgets. Those terms exist in the engine, but they are not part of
+the main chat path yet.
 
 ## Step Model
 
-Step kinds:
-
-- `plan`
-- `tool`
-- `generate`
-- `assess`
-- `revise`
-- `finalize`
+Step kinds are `plan`, `tool`, `generate`, `assess`, `revise`, and
+`finalize`.
 
 Some steps may be deterministic.
 Some may invoke model deliberation.
@@ -67,82 +51,56 @@ not a top-level orchestration authority.
 
 ## Review Loop
 
-The reviewed profile uses one bounded pattern:
-
-1. `generate` produces the current draft.
-2. `assess` returns `reviewDecision` and `reviewReason`.
-3. If the decision is `revise`, `revise` produces the next draft.
-4. The loop stops when it reaches `finalize`, hits a limit, or fails open.
-
-This is the current runtime path behind review and revise behavior.
-It is not just a target design note.
+The reviewed profile uses one bounded pattern. `generate` produces the current
+draft. `assess` returns `reviewDecision` and `reviewReason`. If the decision is
+`revise`, `revise` produces the next draft. The loop stops when it reaches
+`finalize`, hits a limit, or fails open.
 
 ## Step Records
 
-Each `StepRecord` includes an `outcome` with minimal typed fields:
-
-- `status`
-- `summary`
-- `artifacts`
-- `signals`
-- `recommendations` (optional)
-
-This keeps step output explicit without a separate top-level handoff type.
+Each `StepRecord` includes an `outcome` with `status`, `summary`, `artifacts`,
+`signals`, and optional `recommendations`. This keeps step output explicit
+without a separate handoff type.
 `signals` means machine-readable control indicators used by transition logic
 (for example `goalMet`, `needsMoreEvidence`, `toolResultQuality`), not generic telemetry.
-For bounded review `assess` steps, use `reviewDecision` (`finalize` or `revise`)
-plus `reviewReason` as the canonical machine output seam.
+For bounded review `assess` steps, use `reviewDecision` (`finalize` or
+`revise`) plus `reviewReason` as the machine-readable output.
 `recommendations` is advisory only and never overrides backend legality checks.
 
 ## Limits
 
-`WorkflowPolicy` defines legal next steps from the current state.
-It also owns capability toggles such as plan/revise/tool enablement.
-Model outputs can recommend transitions only where policy allows.
-Final transition checks remain backend-owned.
+`WorkflowPolicy` defines legal next steps from the current state. It also owns
+capability toggles such as plan, revise, and tool enablement. Model outputs
+can recommend transitions only where policy allows.
 
-`ExecutionLimits` owns the hard caps:
-
-- `maxWorkflowSteps`
-- `maxToolCalls`
-- `maxDeliberationCalls`
-- `maxTokensTotal`
-- `maxDurationMs`
-
-These are backend-enforced stops, not model suggestions.
+`ExecutionLimits` sets the hard caps: `maxWorkflowSteps`, `maxToolCalls`,
+`maxDeliberationCalls`, `maxTokensTotal`, and `maxDurationMs`. These are
+backend-enforced stops, not model suggestions.
 
 ## Failure Behavior
 
-The current workflow can end for these reasons:
-
-- `goal_satisfied`
-- `budget_exhausted_steps`
-- `budget_exhausted_tokens`
-- `budget_exhausted_time`
-- `transition_blocked_by_policy`
-- `max_tool_calls_reached`
-- `max_deliberation_calls_reached`
-- `executor_error_fail_open`
+The current workflow can end with `goal_satisfied`,
+`budget_exhausted_steps`, `budget_exhausted_tokens`,
+`budget_exhausted_time`, `transition_blocked_by_policy`,
+`max_tool_calls_reached`, `max_deliberation_calls_reached`, or
+`executor_error_fail_open`.
 
 ## Workflow Metadata
 
-`WorkflowRecord` is the primary orchestration provenance artifact.
 `WorkflowRecord` is the main workflow record returned for operators and
 response metadata.
 Deeper runtime/debug execution detail can remain in internal logs keyed by
 `workflowId` and `stepId`.
 
-In current chat responses:
-
-- planner metadata still lives alongside workflow lineage,
-- workflow lineage covers the reviewed generation path,
-- read planner metadata and workflow metadata together, but do not confuse
-  planner influence with workflow authority.
+In current chat responses, planner metadata still sits alongside workflow
+lineage, and workflow lineage covers the reviewed generation path. Read those
+records together, but do not confuse planner influence with workflow
+authority.
 
 ## Future Work
 
-Future work may extend the same engine shape to planner and tool steps.
-That is not the current first-read explanation.
+Future work may extend the same engine flow to planner and tool steps. That is
+not the current first-read explanation.
 Use rollout or RFC docs only when you need historical sequencing or design
 tradeoffs.
 

--- a/docs/architecture/workflow-engine-and-provenance.md
+++ b/docs/architecture/workflow-engine-and-provenance.md
@@ -2,30 +2,11 @@
 
 ## Purpose
 
-Define the next orchestration shape for chat generation in Footnote.
+Explain the current workflow-engine surface and the provenance record it emits.
 
-This document is high-level and natural language.
-It is intended to align architecture direction before deeper implementation details.
-
-## Why This Exists
-
-The current bounded review loop was a useful stepping stone.
-It proved three important things:
-
-- we can run bounded multi-step execution safely,
-- we can keep fail-open behavior where policy allows,
-- we can emit lineage-bearing workflow metadata.
-
-It is not the final form.
-Its current shape is still specialized around a draft/review/revise path.
-
-Footnote now needs a general workflow engine that can support:
-
-- optional planning,
-- optional tool usage with bounded retries,
-- optional model-assisted assessment,
-- optional revision,
-- deterministic termination under hard limits.
+This doc is about what is implemented now, not the full target direction.
+Read [Workflow Mode Routing](./workflow-mode-routing.md) first if you need the
+big picture.
 
 ## Core Principles
 
@@ -38,7 +19,7 @@ Footnote now needs a general workflow engine that can support:
 
 ## Terms
 
-- `WorkflowEngine`: Runs one workflow loop from start to termination.
+- `WorkflowEngine`: Runs one bounded workflow loop from start to termination.
 - `WorkflowPolicy`: Declares legal transitions and capability toggles.
 - `ExecutionLimits`: Declares hard caps (steps, calls, tokens, time).
 - `WorkflowState`: In-memory state used while a workflow is running.
@@ -46,14 +27,25 @@ Footnote now needs a general workflow engine that can support:
 - `WorkflowRecord`: Curated structured artifact for provenance and operators.
 - `StepRecord`: One step entry inside the workflow record.
 
-## Control And Work Separation
+## Current Engine Scope
 
-Footnote separates:
+Today the engine mainly powers the reviewed chat path in
+`packages/backend/src/services/workflowEngine.ts`.
 
-- decision/control logic (what can run next),
-- execution logic (run tool calls, generation, checks).
+What is active now:
 
-This is a responsibility split, not a 2D axis model.
+- legal transition checks,
+- hard execution limits,
+- bounded `generate -> assess -> revise` execution,
+- canonical termination reasons,
+- fail-open handling for generation/review/revise failures,
+- `WorkflowRecord` and `StepRecord` lineage output.
+
+What is vocabulary now but not the main current chat path:
+
+- `plan`
+- `tool`
+- replanning/tool-call budgets beyond current reviewed generation flow
 
 ## Step Model
 
@@ -72,21 +64,17 @@ That choice is controlled by `WorkflowPolicy` and `ExecutionLimits`.
 Model-backed deliberation is treated as an optional capability of certain steps,
 not a top-level orchestration authority.
 
-## Tool Step Boundary
+## Current Review Loop
 
-The `tool` step is intentionally simple:
+The reviewed profile uses one bounded pattern:
 
-- it accepts `calls[]`,
-- it declares `execution: sequential | parallel`,
-- it returns one normalized step outcome.
+1. `generate` produces the current draft.
+2. `assess` returns `reviewDecision` and `reviewReason`.
+3. If the decision is `revise`, `revise` produces the next draft.
+4. The loop stops when it reaches `finalize`, hits a limit, or fails open.
 
-Boundary rules:
-
-- `calls[]` must stay short and bounded.
-- no internal branching mini-language inside one `tool` step.
-- complex routing becomes multiple workflow steps.
-
-Even with one `tool` step type, each concrete tool call attempt is still recorded internally for retries, costs, and provenance.
+This is the current runtime path behind review and revise behavior.
+It is not just a target design note.
 
 ## Outcome Shape
 
@@ -105,18 +93,14 @@ For bounded review `assess` steps, use `reviewDecision` (`finalize` or `revise`)
 plus `reviewReason` as the canonical machine output seam.
 `recommendations` is advisory only and never overrides backend legality checks.
 
-## Transition Legality
+## Transition And Limit Ownership
 
 `WorkflowPolicy` defines legal next steps from current state.
 `WorkflowPolicy` also owns capability toggles (for example plan/revise/tool enablement).
 Model outputs can recommend transitions only where policy allows.
 Final transition legality remains backend-owned.
 
-## Limits And Budgeting
-
-`ExecutionLimits` is separate from `WorkflowPolicy`.
-`ExecutionLimits` owns hard quantitative caps only.
-Examples:
+`ExecutionLimits` owns the hard caps:
 
 - `maxWorkflowSteps`
 - `maxToolCalls`
@@ -124,7 +108,7 @@ Examples:
 - `maxTokensTotal`
 - `maxDurationMs`
 
-These limits are hard stops enforced by backend code.
+These are backend-enforced stops, not model suggestions.
 
 ## Termination Reasons
 
@@ -139,30 +123,26 @@ Initial reasons:
 - `max_deliberation_calls_reached`
 - `executor_error_fail_open`
 
-## Provenance Direction
+## Provenance Shape
 
 `WorkflowRecord` is the primary orchestration provenance artifact.
-Execution metadata should progressively align around it.
 `WorkflowRecord` is the provenance-facing curated record.
 Deeper runtime/debug execution detail can remain in internal logs keyed by
 `workflowId` and `stepId`.
 
-Legacy fields may exist temporarily during migration, but they are not the target model.
+In current chat responses:
 
-## Non-Goals
+- planner metadata still lives alongside workflow lineage,
+- workflow lineage covers the reviewed generation path,
+- the two should be read together without confusing planner influence for
+  workflow authority.
 
-- full generalized graph language,
-- unlimited nested orchestration,
-- cross-request memory planning framework,
-- broad rollout to every route before chat stabilization.
+## Future Direction
 
-## Rollout Strategy
+Future work may extend the same engine shape to planner and tool steps.
+That is not the current first-read explanation.
+Use rollout or RFC docs only when you need historical sequencing or design
+tradeoffs.
 
-- Phase 1: lock names, boundaries, and minimal record contract.
-- Phase 2: build engine skeleton with current behavior parity.
-- Phase 3: migrate current specialized loop to step-based execution.
-- Phase 4: enable optional planning/assessment/revision modes via policy toggles.
-- Phase 5: expand tool execution patterns (parallel where safe).
-
-Status and implementation tracking lives in:
+Historical rollout tracking lives in
 `docs/status/2026-04-workflow-engine-rollout-status.md`.

--- a/docs/architecture/workflow-engine-and-provenance.md
+++ b/docs/architecture/workflow-engine-and-provenance.md
@@ -38,7 +38,7 @@ The shared workflow vocabulary also includes `plan`, `tool`, and replanning or
 tool-call budgets. Those terms exist in the engine, but they are not part of
 the main chat path yet.
 
-## Step Model
+## Steps
 
 Step kinds are `plan`, `tool`, `generate`, `assess`, `revise`, and
 `finalize`.
@@ -85,7 +85,7 @@ The current workflow can end with `goal_satisfied`,
 `max_tool_calls_reached`, `max_deliberation_calls_reached`, or
 `executor_error_fail_open`.
 
-## Workflow Metadata
+## Metadata
 
 `WorkflowRecord` is the main workflow record returned for operators and
 response metadata.
@@ -104,5 +104,5 @@ not the current first-read explanation.
 Use rollout or RFC docs only when you need historical sequencing or design
 tradeoffs.
 
-Historical rollout tracking lives in
+For rollout history, see
 `docs/status/2026-04-workflow-engine-rollout-status.md`.

--- a/docs/architecture/workflow-mode-routing.md
+++ b/docs/architecture/workflow-mode-routing.md
@@ -7,20 +7,33 @@ A workflow mode is the routing choice for one chat request.
 This is the main doc for workflow and planner behavior today.
 Read this before the profile contract, rollout notes, or RFC material.
 
-The Execution Contract sets the limits. Workflow mode picks the kind of run.
-Workflow profile picks the step pattern. Planner can suggest how to carry out
-the run, but it cannot change the rules. Workflow lineage records what
-happened.
+When a chat request comes in, Footnote has to decide how careful the run
+should be before it starts generating. Some requests can take the fast path.
+Others should use the reviewed path, with stricter evidence and revision rules.
+
+This doc explains that routing layer.
+
+The split is simple. The Execution Contract sets the limits for the run.
+Workflow mode chooses the run type. Workflow profile chooses the step pattern.
+Planner can suggest action details inside those limits. Workflow lineage shows
+what actually happened.
 
 ## Runtime Flow
 
-The backend resolves an Execution Contract preset first. Then it resolves a
-workflow mode, maps that mode to a workflow profile and runtime limits, and
-runs planner once in `chatOrchestrator` before message generation. Planner
-output still goes through surface policy, capability policy, and tool policy.
-`chatService` then runs either direct generation or the bounded review loop.
-Response metadata records `workflowMode`, planner execution details, and
-workflow lineage.
+The normal chat path starts with the Execution Contract. That contract decides
+the allowed behavior and limits for the request.
+
+After that, the backend resolves a workflow mode: `fast`, `balanced`, or
+`grounded`. The mode maps to a workflow profile, which is the step pattern the
+runtime will use. For example, `fast` maps to `generate-only`, while
+`balanced` and `grounded` both use `bounded-review`.
+
+Planner runs once in `chatOrchestrator` before generation. Its output still
+goes through surface policy, capability policy, and tool policy. Then
+`chatService` runs either direct generation or the bounded review loop.
+
+Response metadata records the selected mode, planner influence, and workflow
+lineage.
 
 Planner affects execution today, but it is not yet a first-class workflow step
 in workflow metadata.
@@ -51,7 +64,9 @@ mode escalation.
 ## Review Loop
 
 `generate-only` runs one `generate` step and stops. `bounded-review` runs
-`generate -> assess -> revise` in a bounded loop.
+`generate -> assess -> revise` in a bounded loop. That is why the reviewed
+path matters here: it gives the runtime one bounded chance to assess the draft
+and revise it before stopping.
 
 The assess step emits two machine-readable fields: `reviewDecision`
 (`finalize` or `revise`) and `reviewReason`. A review result can request a
@@ -59,11 +74,12 @@ revision, but it does not bypass workflow policy or engine limits.
 
 ## Planner Boundary
 
-Planner can choose an action shape for the request, suggest search or tool
-details, suggest a capability profile, and affect execution metadata when its
-output materially mattered. It cannot change the Execution Contract, grant
-itself extra tools or steps, bypass policy, or become the final authority on
-mode, profile, safety, or provenance.
+Planner helps decide how to carry out the request. It can suggest search or
+tool details, choose an action shape, and recommend a capability profile.
+
+Those suggestions stay inside backend policy. Planner cannot change the
+Execution Contract, grant extra tools or steps, bypass policy, or become the
+final authority on mode, profile, safety, or provenance.
 
 Today, planner runs in `chatOrchestrator` before `chatService` starts the
 review loop.
@@ -95,13 +111,15 @@ Rules for this seam:
 
 ## Metadata
 
-`workflowMode` in response metadata records `modeId`, `selectedBy`,
-`selectionReason`, `initial_mode`, optional `escalated_mode`, optional
-`escalation_reason`, optional `requestedModeId`, optional
-`executionContractResponseMode`, and `behavior`.
+The response metadata keeps these concepts separate so readers can see why the
+request ran the way it did.
 
-Use the nearby metadata fields for different jobs.
 `metadata.workflowMode.*` explains the routing choice.
 `metadata.execution[]` planner entries explain planner influence.
 `metadata.workflow` records workflow lineage.
 TRACE fields describe answer behavior, not workflow routing.
+
+The `workflowMode` object includes `modeId`, `selectedBy`,
+`selectionReason`, `initial_mode`, optional `escalated_mode`, optional
+`escalation_reason`, optional `requestedModeId`, optional
+`executionContractResponseMode`, and `behavior`.

--- a/docs/architecture/workflow-mode-routing.md
+++ b/docs/architecture/workflow-mode-routing.md
@@ -2,44 +2,57 @@
 
 ## Purpose
 
-A workflow mode is the explicit high-level routing decision for chat execution.
+A workflow mode is the high-level routing choice for one chat request.
 
-Each part has a different job. The Execution Contract sets the allowed posture.
-The chat orchestrator runs within that contract. Workflow mode is the
-high-level choice, and workflow profile is the concrete step pattern. TRACE is
-about answer temperament (`trace_target` and `trace_final`), while provenance
-and evidence metadata are about what actually happened.
+This is the main current-shape doc for workflow and planner behavior.
+Read this before the profile contract, rollout notes, or RFC material.
 
-In short:
+The short version:
 
-- mode chooses the kind of run,
-- profile chooses the executable workflow shape.
+- the Execution Contract governs allowed posture and limits,
+- workflow mode chooses the kind of run,
+- workflow profile chooses the executable step pattern,
+- planner can suggest execution details but does not gain policy authority,
+- workflow lineage records what actually happened.
 
-Keep contract posture and workflow mechanics separate. The Execution Contract
-preset answers "what kind of run should govern this request?" The workflow
-profile id answers "what step pattern should execute this run?" Mixing them
-into one label makes naming and reasoning harder.
-Today, planner dispatch still happens in orchestration before workflow
-execution. The target shape is for planner behavior to be represented as
-bounded workflow step types so workflow remains the owner of when and why
-planning runs.
+Keep those jobs separate.
+The Execution Contract answers "what kind of run is allowed?"
+Workflow mode answers "which current posture did we choose?"
+Workflow profile answers "which step pattern executes that posture?"
+Planner answers "what action details should this run try?"
+Those are related, but they are not the same thing.
 
-The chosen mode is emitted as `workflowMode` in response metadata.
-Each mode resolves to a concrete execution shape. The table below shows that
-mapping in runtime terms.
+## Current Runtime Shape
+
+Today the request path looks like this:
+
+1. The backend resolves an Execution Contract preset.
+2. Workflow mode is resolved as `fast`, `balanced`, or `grounded`.
+3. That mode maps to a workflow profile and runtime limits.
+4. `chatOrchestrator` invokes planner once, before message generation.
+5. Planner output is filtered through surface policy, capability policy, and
+   tool policy.
+6. `chatService` either runs direct generation or the bounded review workflow.
+7. Response metadata records `workflowMode`, planner execution details, and
+   workflow lineage.
+
+That means planner is execution-relevant today, but it is not yet a
+first-class workflow-engine step in runtime lineage.
 
 ## Mode Set
 
 Canonical mode ids are `fast`, `balanced`, and `grounded`.
 
-| Mode       | Contract preset    | Profile id       | Workflow used | Review | Revise | Evidence | Steps | Deliberation | Notes                                      |
-| ---------- | ------------------ | ---------------- | ------------- | ------ | ------ | -------- | ----- | ------------ | ------------------------------------------ |
-| `fast`     | `fast-direct`      | `generate-only`  | no            | no     | no     | minimal  | 1     | 0            | direct single-pass path                    |
-| `balanced` | `balanced`         | `bounded-review` | yes           | yes    | yes    | balanced | 4     | 2            | reviewed default path                      |
-| `grounded` | `quality-grounded` | `bounded-review` | conditional   | yes    | yes    | strict   | 8     | 4            | same profile as `balanced`, stricter guard |
+| Mode       | Contract preset    | Workflow profile | Current execution shape                   | Review | Revise | Evidence posture | Notes                                      |
+| ---------- | ------------------ | ---------------- | ----------------------------------------- | ------ | ------ | ---------------- | ------------------------------------------ |
+| `fast`     | `fast-direct`      | `generate-only`  | single-pass generation                    | no     | no     | minimal          | no workflow review loop                    |
+| `balanced` | `balanced`         | `bounded-review` | reviewed workflow path                    | yes    | yes    | balanced         | same profile as `grounded`, lighter limits |
+| `grounded` | `quality-grounded` | `bounded-review` | reviewed workflow path with stricter caps | yes    | yes    | strict           | workflow execution is policy-gated         |
 
-`balanced` and `grounded` already show why the split matters: they share one
-workflow profile (`bounded-review`) but differ in posture and limits.
+`balanced` and `grounded` share one profile today.
+That is why mode and profile stay separate.
+Mode carries posture and limits.
+Profile carries executable shape.
 
 ## Selection Order
 
@@ -51,6 +64,66 @@ This keeps the system available while preferring the more careful default
 posture.
 These fallback steps are initial routing fallback only. They are not runtime
 mode escalation.
+
+## Review And Revise Behavior
+
+The current profiles are simple on purpose:
+
+- `generate-only` means one `generate` step and stop.
+- `bounded-review` means `generate -> assess -> revise` in a bounded loop.
+
+The assess step emits the canonical machine-readable review outcome:
+
+- `reviewDecision`: `finalize` or `revise`
+- `reviewReason`: one short explanation
+
+That assess output can request revision, but it still does not bypass engine
+limits or workflow policy.
+The engine decides whether another step is legal.
+
+## Planner Boundary
+
+Planner is intentionally bounded.
+
+Planner can:
+
+- choose an action shape for the request,
+- suggest search/tool usage details,
+- suggest a capability profile,
+- influence execution metadata when its output materially mattered.
+
+Planner cannot:
+
+- change the Execution Contract,
+- grant itself extra tools or extra steps,
+- bypass surface policy or capability policy,
+- become the final authority on mode, profile, safety, or provenance.
+
+Today, planner runs in `chatOrchestrator` before `chatService` begins the
+review workflow.
+Planner execution is recorded in `metadata.execution[]` and in steerability
+metadata, but workflow lineage still starts with the generation/review path.
+
+## Current And Future Line
+
+Current behavior:
+
+- planner is orchestrator-frontloaded,
+- workflow engine is used for the reviewed generation path,
+- `plan` and `tool` are part of the shared workflow vocabulary but are not the
+  main current chat path,
+- review/revise are real runtime behavior today.
+
+Future direction:
+
+- planner-as-workflow-step,
+- tool steps under the same workflow engine,
+- clearer correlation if multiple planner passes or retries ever exist.
+
+Do not read the future direction back into current authority.
+Planner is still advisory.
+Workflow engine does not yet own planner execution timing in the current chat
+path.
 
 ## Escalation Seam
 
@@ -71,3 +144,10 @@ Rules for this seam:
 `escalation_reason`, optional `requestedModeId`, optional
 `executionContractResponseMode`, and `behavior` (the concrete mapped behavior
 tuple).
+
+Use nearby metadata like this:
+
+- `metadata.workflowMode.*` explains the routing choice.
+- `metadata.execution[]` planner entries explain planner influence.
+- `metadata.workflow` explains the executed workflow lineage.
+- TRACE fields explain answer posture, not workflow routing.

--- a/docs/architecture/workflow-mode-routing.md
+++ b/docs/architecture/workflow-mode-routing.md
@@ -4,12 +4,12 @@
 
 A workflow mode is the high-level routing choice for one chat request.
 
-This is the main current-shape doc for workflow and planner behavior.
+This is the main doc for current workflow and planner behavior.
 Read this before the profile contract, rollout notes, or RFC material.
 
 The short version:
 
-- the Execution Contract governs allowed posture and limits,
+- the Execution Contract governs allowed behavior and limits,
 - workflow mode chooses the kind of run,
 - workflow profile chooses the executable step pattern,
 - planner can suggest execution details but does not gain policy authority,
@@ -17,12 +17,12 @@ The short version:
 
 Keep those jobs separate.
 The Execution Contract answers "what kind of run is allowed?"
-Workflow mode answers "which current posture did we choose?"
+Workflow mode answers "which run did we choose?"
 Workflow profile answers "which step pattern executes that posture?"
 Planner answers "what action details should this run try?"
 Those are related, but they are not the same thing.
 
-## Current Runtime Shape
+## Runtime Flow
 
 Today the request path looks like this:
 
@@ -36,10 +36,10 @@ Today the request path looks like this:
 7. Response metadata records `workflowMode`, planner execution details, and
    workflow lineage.
 
-That means planner is execution-relevant today, but it is not yet a
-first-class workflow-engine step in runtime lineage.
+Planner affects execution today, but it is not yet a first-class
+workflow-engine step in workflow metadata.
 
-## Mode Set
+## Modes And Profiles
 
 Canonical mode ids are `fast`, `balanced`, and `grounded`.
 
@@ -51,7 +51,7 @@ Canonical mode ids are `fast`, `balanced`, and `grounded`.
 
 `balanced` and `grounded` share one profile today.
 That is why mode and profile stay separate.
-Mode carries posture and limits.
+Mode carries behavior and limits.
 Profile carries executable shape.
 
 ## Selection Order
@@ -65,7 +65,7 @@ posture.
 These fallback steps are initial routing fallback only. They are not runtime
 mode escalation.
 
-## Review And Revise Behavior
+## Review Loop
 
 The current profiles are simple on purpose:
 
@@ -100,13 +100,13 @@ Planner cannot:
 - become the final authority on mode, profile, safety, or provenance.
 
 Today, planner runs in `chatOrchestrator` before `chatService` begins the
-review workflow.
+review loop.
 Planner execution is recorded in `metadata.execution[]` and in steerability
 metadata, but workflow lineage still starts with the generation/review path.
 
-## Current And Future Line
+## Future Work
 
-Current behavior:
+Today:
 
 - planner is orchestrator-frontloaded,
 - workflow engine is used for the reviewed generation path,
@@ -114,13 +114,13 @@ Current behavior:
   main current chat path,
 - review/revise are real runtime behavior today.
 
-Future direction:
+Future work:
 
 - planner-as-workflow-step,
 - tool steps under the same workflow engine,
 - clearer correlation if multiple planner passes or retries ever exist.
 
-Do not read the future direction back into current authority.
+Do not read future work back into current authority.
 Planner is still advisory.
 Workflow engine does not yet own planner execution timing in the current chat
 path.
@@ -137,7 +137,7 @@ Rules for this seam:
 - Never run recursive or unbounded mode re-evaluation loops.
 - Keep escalation routing centralized in workflow resolver code, not callers.
 
-## Metadata Contract
+## Metadata Output
 
 `workflowMode` in response metadata records `modeId`, `selectedBy`,
 `selectionReason`, `initial_mode`, optional `escalated_mode`, optional
@@ -150,4 +150,4 @@ Use nearby metadata like this:
 - `metadata.workflowMode.*` explains the routing choice.
 - `metadata.execution[]` planner entries explain planner influence.
 - `metadata.workflow` explains the executed workflow lineage.
-- TRACE fields explain answer posture, not workflow routing.
+- TRACE fields explain answer behavior, not workflow routing.

--- a/docs/architecture/workflow-mode-routing.md
+++ b/docs/architecture/workflow-mode-routing.md
@@ -2,7 +2,7 @@
 
 ## Purpose
 
-A workflow mode is the high-level routing choice for one chat request.
+A workflow mode is the routing choice for one chat request.
 
 This is the main doc for workflow and planner behavior today.
 Read this before the profile contract, rollout notes, or RFC material.
@@ -27,7 +27,7 @@ in workflow metadata.
 
 ## Modes And Profiles
 
-Canonical mode ids are `fast`, `balanced`, and `grounded`.
+The mode ids are `fast`, `balanced`, and `grounded`.
 
 | Mode       | Contract preset    | Workflow profile | Flow                     | Review | Revise | Evidence | Notes                                      |
 | ---------- | ------------------ | ---------------- | ------------------------ | ------ | ------ | -------- | ------------------------------------------ |
@@ -38,7 +38,7 @@ Canonical mode ids are `fast`, `balanced`, and `grounded`.
 `balanced` and `grounded` share one profile today. The difference is in the
 contract preset and limits, not in the step pattern.
 
-## Selection Order
+## Selection
 
 1. Use the requested mode when it is recognized.
 2. Otherwise, if the Execution Contract provides a response mode, map it to canonical mode (`quality_grounded` -> `grounded`, `fast_direct` -> `fast`).
@@ -81,9 +81,9 @@ engine, and clearer correlation if planner passes or retries are added later.
 That does not change the current rule: planner is advisory, and the workflow
 engine does not yet own planner timing in the current chat path.
 
-## Escalation Seam
+## Mode Escalation
 
-Workflow mode escalation is attached at one bounded seam in
+Workflow mode escalation is attached at one place in
 `resolveWorkflowRuntimeConfig` (`packages/backend/src/services/workflowProfileRegistry.ts`).
 
 Rules for this seam:
@@ -93,7 +93,7 @@ Rules for this seam:
 - Never run recursive or unbounded mode re-evaluation loops.
 - Keep escalation routing centralized in workflow resolver code, not callers.
 
-## Metadata Output
+## Metadata
 
 `workflowMode` in response metadata records `modeId`, `selectedBy`,
 `selectionReason`, `initial_mode`, optional `escalated_mode`, optional

--- a/docs/architecture/workflow-mode-routing.md
+++ b/docs/architecture/workflow-mode-routing.md
@@ -4,55 +4,39 @@
 
 A workflow mode is the high-level routing choice for one chat request.
 
-This is the main doc for current workflow and planner behavior.
+This is the main doc for workflow and planner behavior today.
 Read this before the profile contract, rollout notes, or RFC material.
 
-The short version:
-
-- the Execution Contract governs allowed behavior and limits,
-- workflow mode chooses the kind of run,
-- workflow profile chooses the executable step pattern,
-- planner can suggest execution details but does not gain policy authority,
-- workflow lineage records what actually happened.
-
-Keep those jobs separate.
-The Execution Contract answers "what kind of run is allowed?"
-Workflow mode answers "which run did we choose?"
-Workflow profile answers "which step pattern executes that posture?"
-Planner answers "what action details should this run try?"
-Those are related, but they are not the same thing.
+The Execution Contract sets the limits. Workflow mode picks the kind of run.
+Workflow profile picks the step pattern. Planner can suggest how to carry out
+the run, but it cannot change the rules. Workflow lineage records what
+happened.
 
 ## Runtime Flow
 
-Today the request path looks like this:
+The backend resolves an Execution Contract preset first. Then it resolves a
+workflow mode, maps that mode to a workflow profile and runtime limits, and
+runs planner once in `chatOrchestrator` before message generation. Planner
+output still goes through surface policy, capability policy, and tool policy.
+`chatService` then runs either direct generation or the bounded review loop.
+Response metadata records `workflowMode`, planner execution details, and
+workflow lineage.
 
-1. The backend resolves an Execution Contract preset.
-2. Workflow mode is resolved as `fast`, `balanced`, or `grounded`.
-3. That mode maps to a workflow profile and runtime limits.
-4. `chatOrchestrator` invokes planner once, before message generation.
-5. Planner output is filtered through surface policy, capability policy, and
-   tool policy.
-6. `chatService` either runs direct generation or the bounded review workflow.
-7. Response metadata records `workflowMode`, planner execution details, and
-   workflow lineage.
-
-Planner affects execution today, but it is not yet a first-class
-workflow-engine step in workflow metadata.
+Planner affects execution today, but it is not yet a first-class workflow step
+in workflow metadata.
 
 ## Modes And Profiles
 
 Canonical mode ids are `fast`, `balanced`, and `grounded`.
 
-| Mode       | Contract preset    | Workflow profile | Current execution shape                   | Review | Revise | Evidence posture | Notes                                      |
-| ---------- | ------------------ | ---------------- | ----------------------------------------- | ------ | ------ | ---------------- | ------------------------------------------ |
-| `fast`     | `fast-direct`      | `generate-only`  | single-pass generation                    | no     | no     | minimal          | no workflow review loop                    |
-| `balanced` | `balanced`         | `bounded-review` | reviewed workflow path                    | yes    | yes    | balanced         | same profile as `grounded`, lighter limits |
-| `grounded` | `quality-grounded` | `bounded-review` | reviewed workflow path with stricter caps | yes    | yes    | strict           | workflow execution is policy-gated         |
+| Mode       | Contract preset    | Workflow profile | Flow                     | Review | Revise | Evidence | Notes                                      |
+| ---------- | ------------------ | ---------------- | ------------------------ | ------ | ------ | -------- | ------------------------------------------ |
+| `fast`     | `fast-direct`      | `generate-only`  | single-pass generation   | no     | no     | minimal  | no workflow review loop                    |
+| `balanced` | `balanced`         | `bounded-review` | reviewed generation path | yes    | yes    | balanced | same profile as `grounded`, lighter limits |
+| `grounded` | `quality-grounded` | `bounded-review` | reviewed generation path | yes    | yes    | strict   | workflow execution is policy-gated         |
 
-`balanced` and `grounded` share one profile today.
-That is why mode and profile stay separate.
-Mode carries behavior and limits.
-Profile carries executable shape.
+`balanced` and `grounded` share one profile today. The difference is in the
+contract preset and limits, not in the step pattern.
 
 ## Selection Order
 
@@ -60,70 +44,42 @@ Profile carries executable shape.
 2. Otherwise, if the Execution Contract provides a response mode, map it to canonical mode (`quality_grounded` -> `grounded`, `fast_direct` -> `fast`).
 3. Otherwise, fall back to `grounded`.
 
-This keeps the system available while preferring the more careful default
-posture.
-These fallback steps are initial routing fallback only. They are not runtime
+This keeps the system available while preferring the more careful default.
+These fallback steps happen only during initial routing. They are not runtime
 mode escalation.
 
 ## Review Loop
 
-The current profiles are simple on purpose:
+`generate-only` runs one `generate` step and stops. `bounded-review` runs
+`generate -> assess -> revise` in a bounded loop.
 
-- `generate-only` means one `generate` step and stop.
-- `bounded-review` means `generate -> assess -> revise` in a bounded loop.
-
-The assess step emits the canonical machine-readable review outcome:
-
-- `reviewDecision`: `finalize` or `revise`
-- `reviewReason`: one short explanation
-
-That assess output can request revision, but it still does not bypass engine
-limits or workflow policy.
-The engine decides whether another step is legal.
+The assess step emits two machine-readable fields: `reviewDecision`
+(`finalize` or `revise`) and `reviewReason`. A review result can request a
+revision, but it does not bypass workflow policy or engine limits.
 
 ## Planner Boundary
 
-Planner is intentionally bounded.
+Planner can choose an action shape for the request, suggest search or tool
+details, suggest a capability profile, and affect execution metadata when its
+output materially mattered. It cannot change the Execution Contract, grant
+itself extra tools or steps, bypass policy, or become the final authority on
+mode, profile, safety, or provenance.
 
-Planner can:
-
-- choose an action shape for the request,
-- suggest search/tool usage details,
-- suggest a capability profile,
-- influence execution metadata when its output materially mattered.
-
-Planner cannot:
-
-- change the Execution Contract,
-- grant itself extra tools or extra steps,
-- bypass surface policy or capability policy,
-- become the final authority on mode, profile, safety, or provenance.
-
-Today, planner runs in `chatOrchestrator` before `chatService` begins the
+Today, planner runs in `chatOrchestrator` before `chatService` starts the
 review loop.
 Planner execution is recorded in `metadata.execution[]` and in steerability
 metadata, but workflow lineage still starts with the generation/review path.
 
 ## Future Work
 
-Today:
+Today, planner is still frontloaded in orchestration. The workflow engine runs
+the reviewed generation path. `plan` and `tool` exist in the shared workflow
+vocabulary, but they are not the main current chat path.
 
-- planner is orchestrator-frontloaded,
-- workflow engine is used for the reviewed generation path,
-- `plan` and `tool` are part of the shared workflow vocabulary but are not the
-  main current chat path,
-- review/revise are real runtime behavior today.
-
-Future work:
-
-- planner-as-workflow-step,
-- tool steps under the same workflow engine,
-- clearer correlation if multiple planner passes or retries ever exist.
-
-Do not read future work back into current authority.
-Planner is still advisory.
-Workflow engine does not yet own planner execution timing in the current chat
-path.
+Future work includes planner as a workflow step, tool steps under the same
+engine, and clearer correlation if planner passes or retries are added later.
+That does not change the current rule: planner is advisory, and the workflow
+engine does not yet own planner timing in the current chat path.
 
 ## Escalation Seam
 
@@ -142,12 +98,10 @@ Rules for this seam:
 `workflowMode` in response metadata records `modeId`, `selectedBy`,
 `selectionReason`, `initial_mode`, optional `escalated_mode`, optional
 `escalation_reason`, optional `requestedModeId`, optional
-`executionContractResponseMode`, and `behavior` (the concrete mapped behavior
-tuple).
+`executionContractResponseMode`, and `behavior`.
 
-Use nearby metadata like this:
-
-- `metadata.workflowMode.*` explains the routing choice.
-- `metadata.execution[]` planner entries explain planner influence.
-- `metadata.workflow` explains the executed workflow lineage.
-- TRACE fields explain answer behavior, not workflow routing.
+Use the nearby metadata fields for different jobs.
+`metadata.workflowMode.*` explains the routing choice.
+`metadata.execution[]` planner entries explain planner influence.
+`metadata.workflow` records workflow lineage.
+TRACE fields describe answer behavior, not workflow routing.

--- a/docs/architecture/workflow-profile-contract.md
+++ b/docs/architecture/workflow-profile-contract.md
@@ -59,7 +59,7 @@ Contract rule:
   disposition, or termination-reason mapping.
 
 Mode chooses the kind of run. Profile chooses the step pattern. The engine
-enforces legality and limits. Adapters wire the profile to runtime calls.
+enforces legality and limits. Adapters connect the profile to runtime calls.
 
 ## No-Generation Behavior
 
@@ -79,13 +79,13 @@ Notes:
 - “Internal termination” means the workflow record always terminates with a
   reason code, even when not surfaced as a dedicated blocked UI state.
 
-## Required No-Generation Reason Mapping
+## Reason Mapping
 
 Reason-code mapping is defined in:
 `WORKFLOW_NO_GENERATION_HANDLING_MAP`
 (`packages/backend/src/services/workflowProfileContract.ts`).
 
-Required mapping:
+The required mapping is:
 `blocked_by_policy_before_generate` -> `transition_blocked_by_policy`,
 `generation_disabled_by_profile` -> `transition_blocked_by_policy`,
 `budget_exhausted_steps_before_generate` -> `budget_exhausted_steps`,
@@ -93,7 +93,7 @@ Required mapping:
 `budget_exhausted_time_before_generate` -> `budget_exhausted_time`,
 and `executor_error_before_generate` -> `executor_error_fail_open`.
 
-Disposition mapping:
+The disposition mapping is:
 policy-blocked, generation-disabled, and executor-error are surfaced.
 Pre-generation budget exhaustion is internal-only.
 

--- a/docs/architecture/workflow-profile-contract.md
+++ b/docs/architecture/workflow-profile-contract.md
@@ -2,9 +2,11 @@
 
 ## Purpose
 
-Define one contract for workflow profiles before multi-profile execution is introduced.
+Define the contract that executable workflow profiles must satisfy.
 
-This removes ambiguity for blocked/no-generation handling and provenance.
+This is a contract doc, not the best first explanation of the current runtime
+shape.
+Read [Workflow Mode Routing](./workflow-mode-routing.md) first if you are new.
 
 ## Scope
 
@@ -21,6 +23,18 @@ Out of scope:
 - profile registry runtime implementation,
 - plan-and-generate or tool-assisted profile implementation,
 - blocked-state UI redesign.
+
+## Current Built-In Profiles
+
+Current chat runtime uses two built-in profiles:
+
+| Profile id       | Current purpose              | Main steps                     |
+| ---------------- | ---------------------------- | ------------------------------ |
+| `generate-only`  | direct single-pass execution | `generate`                     |
+| `bounded-review` | reviewed message generation  | `generate -> assess -> revise` |
+
+Modes choose between these profiles.
+Profiles do not become a second policy authority.
 
 ## Contract Shape
 
@@ -50,6 +64,13 @@ Contract rule:
 
 - optional extensions cannot override required no-generation classification,
   disposition, or termination-reason mapping.
+
+The practical split is:
+
+- mode chooses the run posture,
+- profile chooses the executable shape,
+- engine enforces legality and limits,
+- adapters wire the profile to real runtime calls.
 
 ## Blocked / No-Generation Behavior Matrix
 
@@ -125,9 +146,9 @@ Current `bounded-review` profile:
   `transition_blocked_by_policy` when generation is blocked before first
   draft emission.
 
-Upcoming `generate-only` profile:
+Current `generate-only` profile:
 
-- should implement the same required hooks with
+- already uses the same required hooks with
   `enableAssessment=false`, `enableRevision=false`.
-- should reuse the same no-generation mapping and provenance invariants.
-- should not introduce profile-specific blocked-state semantics.
+- reuses the same no-generation mapping and provenance invariants.
+- does not introduce profile-specific blocked-state semantics.

--- a/docs/architecture/workflow-profile-contract.md
+++ b/docs/architecture/workflow-profile-contract.md
@@ -5,24 +5,17 @@
 Define the contract that executable workflow profiles must satisfy.
 
 This is a contract doc, not the best first explanation of the current runtime
-shape.
+flow.
 Read [Workflow Mode Routing](./workflow-mode-routing.md) first if you are new.
 
 ## Scope
 
-This document defines:
+This document covers the profile contract, no-generation behavior, required
+termination-reason mapping, workflow metadata requirements, and compatibility
+rules for `bounded-review` and `generate-only`.
 
-- profile contract shape,
-- blocked/no-generation behavior matrix,
-- required termination-reason mapping,
-- provenance requirements for blocked-before-generation and no-generation,
-- compatibility notes for `bounded-review` and `generate-only`.
-
-Out of scope:
-
-- profile registry runtime implementation,
-- plan-and-generate or tool-assisted profile implementation,
-- blocked-state UI redesign.
+It does not cover profile registry runtime implementation, plan-and-generate
+or tool-assisted profiles, or blocked-state UI design.
 
 ## Built-In Profiles
 
@@ -33,8 +26,8 @@ Current chat runtime uses two built-in profiles:
 | `generate-only`  | direct single-pass execution | `generate`                     |
 | `bounded-review` | reviewed message generation  | `generate -> assess -> revise` |
 
-Modes choose between these profiles.
-Profiles do not become a second policy authority.
+Modes choose between these profiles. Profiles do not become a second policy
+authority.
 
 ## Contract Shape
 
@@ -65,12 +58,8 @@ Contract rule:
 - optional extensions cannot override required no-generation classification,
   disposition, or termination-reason mapping.
 
-The practical split is:
-
-- mode chooses the run posture,
-- profile chooses the executable shape,
-- engine enforces legality and limits,
-- adapters wire the profile to real runtime calls.
+Mode chooses the kind of run. Profile chooses the step pattern. The engine
+enforces legality and limits. Adapters wire the profile to runtime calls.
 
 ## No-Generation Behavior
 
@@ -97,30 +86,24 @@ Reason-code mapping is defined in:
 (`packages/backend/src/services/workflowProfileContract.ts`).
 
 Required mapping:
-
-- `blocked_by_policy_before_generate` -> `transition_blocked_by_policy`
-- `generation_disabled_by_profile` -> `transition_blocked_by_policy`
-- `budget_exhausted_steps_before_generate` -> `budget_exhausted_steps`
-- `budget_exhausted_tokens_before_generate` -> `budget_exhausted_tokens`
-- `budget_exhausted_time_before_generate` -> `budget_exhausted_time`
-- `executor_error_before_generate` -> `executor_error_fail_open`
+`blocked_by_policy_before_generate` -> `transition_blocked_by_policy`,
+`generation_disabled_by_profile` -> `transition_blocked_by_policy`,
+`budget_exhausted_steps_before_generate` -> `budget_exhausted_steps`,
+`budget_exhausted_tokens_before_generate` -> `budget_exhausted_tokens`,
+`budget_exhausted_time_before_generate` -> `budget_exhausted_time`,
+and `executor_error_before_generate` -> `executor_error_fail_open`.
 
 Disposition mapping:
-
-- surfaced: policy-blocked, generation-disabled, executor-error
-- internal-only: pre-generation budget exhaustion
+policy-blocked, generation-disabled, and executor-error are surfaced.
+Pre-generation budget exhaustion is internal-only.
 
 ## Metadata Requirements
 
 For all profiles, blocked-before-generation and no-generation outcomes must
-produce a valid `WorkflowRecord` with:
-
-- `workflowId`, `workflowName`
-- `status='degraded'` (unless a future profile formally introduces a completed
-  no-output mode with a new reason vocabulary)
-- `terminationReason` from the required map
-- `stepCount` equal to `steps.length`
-- `maxSteps`, `maxDurationMs`
+produce a valid `WorkflowRecord` with `workflowId`, `workflowName`,
+`status='degraded'`, `terminationReason` from the required map, `stepCount`
+equal to `steps.length`, `maxSteps`, and `maxDurationMs`. A future profile may
+introduce a completed no-output mode, but only with a new reason vocabulary.
 
 When generation never occurred:
 
@@ -129,26 +112,18 @@ When generation never occurred:
 - if any step executed before no-generation termination, emitted steps must
   remain chronologically ordered with valid parent references.
 
-Cross-profile invariants:
-
-- no profile may emit ad-hoc termination reason strings.
-- no profile may treat the same reason code as surfaced in one path and
-  internal-only in another path.
-- no profile may omit workflow provenance for no-generation outcomes.
+Across profiles, no profile may emit ad-hoc termination reason strings, treat
+the same reason code as surfaced in one path and internal-only in another, or
+omit workflow provenance for no-generation outcomes.
 
 ## Compatibility Rules
 
-Current `bounded-review` profile:
+Current `bounded-review` profile is compatible with this contract through
+policy, limits, and review/revision extensions. Its current no-generation
+hotspot maps to `transition_blocked_by_policy` when generation is blocked
+before the first draft.
 
-- compatible with this contract through policy/limits + review/revision
-  extensions.
-- current no-generation hotspot maps to
-  `transition_blocked_by_policy` when generation is blocked before first
-  draft emission.
-
-Current `generate-only` profile:
-
-- already uses the same required hooks with
-  `enableAssessment=false`, `enableRevision=false`.
-- reuses the same no-generation mapping and provenance invariants.
-- does not introduce profile-specific blocked-state semantics.
+Current `generate-only` profile uses the same required hooks with
+`enableAssessment=false` and `enableRevision=false`. It reuses the same
+no-generation mapping and metadata rules and does not introduce
+profile-specific blocked-state semantics.

--- a/docs/architecture/workflow-profile-contract.md
+++ b/docs/architecture/workflow-profile-contract.md
@@ -24,7 +24,7 @@ Out of scope:
 - plan-and-generate or tool-assisted profile implementation,
 - blocked-state UI redesign.
 
-## Current Built-In Profiles
+## Built-In Profiles
 
 Current chat runtime uses two built-in profiles:
 
@@ -72,7 +72,7 @@ The practical split is:
 - engine enforces legality and limits,
 - adapters wire the profile to real runtime calls.
 
-## Blocked / No-Generation Behavior Matrix
+## No-Generation Behavior
 
 | Condition                                              | Surface To Caller                               | Internal Termination | Required `terminationReason`   |
 | ------------------------------------------------------ | ----------------------------------------------- | -------------------- | ------------------------------ |
@@ -110,7 +110,7 @@ Disposition mapping:
 - surfaced: policy-blocked, generation-disabled, executor-error
 - internal-only: pre-generation budget exhaustion
 
-## Provenance Requirements For No-Generation Outcomes
+## Metadata Requirements
 
 For all profiles, blocked-before-generation and no-generation outcomes must
 produce a valid `WorkflowRecord` with:
@@ -136,7 +136,7 @@ Cross-profile invariants:
   internal-only in another path.
 - no profile may omit workflow provenance for no-generation outcomes.
 
-## Compatibility Notes
+## Compatibility Rules
 
 Current `bounded-review` profile:
 

--- a/docs/architecture/workflow-profiles-v1-engine-vs-profile-semantics.md
+++ b/docs/architecture/workflow-profiles-v1-engine-vs-profile-semantics.md
@@ -6,6 +6,13 @@
 - Scope: Architecture boundary contract for workflow execution
 - Applies to: `packages/backend/src/services/workflowEngine.ts` and caller adapters
 
+This RFC is historical design context for the workflow-engine rollout.
+For the current first-read explanation, use:
+
+- [Workflow Mode Routing](./workflow-mode-routing.md)
+- [Workflow Engine And Provenance](./workflow-engine-and-provenance.md)
+- [Workflow Profile Contract](./workflow-profile-contract.md)
+
 ## Why This Exists
 
 Workflow logic can spread across several files and layers.

--- a/docs/status/2026-04-workflow-engine-rollout-status.md
+++ b/docs/status/2026-04-workflow-engine-rollout-status.md
@@ -14,10 +14,10 @@
 ## Purpose
 
 Track current rollout state for moving from a specialized bounded review loop
-to a general workflow-engine shape with first-class workflow provenance records.
+to a general workflow engine with first-class workflow provenance records.
 
-Read this after the current architecture docs.
-It is rollout history and tracking, not the main workflow/planner explainer.
+Read this after the current architecture docs. It is a rollout tracker, not
+the main workflow/planner explainer.
 
 Current architecture references:
 
@@ -145,8 +145,8 @@ Goal:
 
 ## Policy And Limits Boundary
 
-- `WorkflowPolicy` owns capability toggles and legal transition rules.
-- `ExecutionLimits` owns hard quantitative caps.
+`WorkflowPolicy` owns capability toggles and legal transition rules.
+`ExecutionLimits` owns hard quantitative caps.
 
 ## Runtime Controls (Current Chat Profile)
 

--- a/docs/status/2026-04-workflow-engine-rollout-status.md
+++ b/docs/status/2026-04-workflow-engine-rollout-status.md
@@ -25,7 +25,7 @@ Current architecture references:
 - `docs/architecture/workflow-engine-and-provenance.md`
 - `docs/architecture/workflow-profile-contract.md`
 
-## Current Snapshot
+## Snapshot
 
 - Workflow metadata is now aligned to `WorkflowRecord` + `StepRecord`.
 - Step outcomes now have explicit machine-readable control signals.
@@ -43,7 +43,7 @@ Current architecture references:
 - Planner still runs in `chatOrchestrator` before workflow execution; planner
   as first-class workflow step remains future work.
 
-## What Is Landed
+## Landed Work
 
 ### 1) Contract Baseline (Core)
 
@@ -103,7 +103,7 @@ Status: `landed`
 - Added termination reason mapping from exhausted limits.
 - Added direct unit tests for engine legality and budget invariants.
 
-## What Is Open
+## Open Work
 
 ### 1) Replace Specialized Loop With Engine-Driven Step Routing
 
@@ -143,7 +143,7 @@ Goal:
 - Move planner from orchestrator-frontloaded execution into first-class
   workflow lineage without giving planner extra policy authority.
 
-## Policy And Limits Boundary
+## Policy And Limits
 
 `WorkflowPolicy` owns capability toggles and legal transition rules.
 `ExecutionLimits` owns hard quantitative caps.

--- a/docs/status/2026-04-workflow-engine-rollout-status.md
+++ b/docs/status/2026-04-workflow-engine-rollout-status.md
@@ -16,8 +16,14 @@
 Track current rollout state for moving from a specialized bounded review loop
 to a general workflow-engine shape with first-class workflow provenance records.
 
-Architecture reference:
-`docs/architecture/workflow-engine-and-provenance.md`
+Read this after the current architecture docs.
+It is rollout history and tracking, not the main workflow/planner explainer.
+
+Current architecture references:
+
+- `docs/architecture/workflow-mode-routing.md`
+- `docs/architecture/workflow-engine-and-provenance.md`
+- `docs/architecture/workflow-profile-contract.md`
 
 ## Current Snapshot
 
@@ -34,6 +40,8 @@ Architecture reference:
   `ExecutionLimits`, transition checks, and state/limit helpers).
 - Chat bounded review loop routing is now delegated through
   `runBoundedReviewWorkflow`, with legality enforced before each bounded step.
+- Planner still runs in `chatOrchestrator` before workflow execution; planner
+  as first-class workflow step remains future work.
 
 ## What Is Landed
 
@@ -125,6 +133,15 @@ Goal:
 
 - Ensure model-backed deliberation is invoked only for allowed step kinds and
   within `maxDeliberationCalls`.
+
+### 4) Planner As Workflow Step
+
+Status: `pending`
+
+Goal:
+
+- Move planner from orchestrator-frontloaded execution into first-class
+  workflow lineage without giving planner extra policy authority.
 
 ## Policy And Limits Boundary
 

--- a/docs/status/README.md
+++ b/docs/status/README.md
@@ -17,7 +17,8 @@ history or migration context.
 - [Weather.gov Tool Pilot Eval](./2026-03-weathergov-pilot-eval.md): pilot
   evaluation notes for the Weather.gov tool path.
 - [Workflow Engine Rollout Status](./2026-04-workflow-engine-rollout-status.md):
-  rollout state for workflow-engine work.
+  rollout state and landing history for workflow-engine work. Read the
+  architecture docs first for the current workflow/planner explanation.
 - [TrustGraph Foundation Consolidation Status](./2026-04-trustgraph-foundation-consolidation.md):
   bounded-scope TrustGraph consolidation and review notes.
 


### PR DESCRIPTION
## What changed
- Reworked the workflow/planner documentation set into a smaller and clearer first-read path.
- Updated these docs:
  - `docs/architecture/README.md`
  - `docs/architecture/workflow-mode-routing.md`
  - `docs/architecture/workflow-engine-and-provenance.md`
  - `docs/architecture/workflow-profile-contract.md`
  - `docs/architecture/execution-contract-authority-map.md`
  - `docs/architecture/workflow-profiles-v1-engine-vs-profile-semantics.md`
  - `docs/status/2026-04-workflow-engine-rollout-status.md`
  - `docs/status/README.md`
- Consolidated wording and structure so current behavior is easier to learn, while rollout/RFC material remains available but lower in the reading path.

## Why
This branch prepares the docs for upcoming planner-as-workflow-step work by making the current model easy to understand first. Previously, useful information was distributed across docs with mixed intent (current behavior, rollout status, and future direction). The update improves onboarding for junior contributors, keeps planner boundaries explicit, and separates current runtime behavior from planned work.

## Important implementation details
- No code, schema, or runtime behavior changes were made.
- Mode/profile semantics remain unchanged:
  - `fast` -> `generate-only`
  - `balanced`/`grounded` -> `bounded-review`
- Current planner boundary remains unchanged: planner is still advisory and orchestrator-frontloaded in current runtime.
- Review/revise behavior and workflow lineage semantics were clarified in prose without changing contract meaning.
- History was preserved: RFC/rollout references were retained and moved to secondary reading positions instead of being removed.

This PR was written using [Vibe Kanban](https://vibekanban.com)
