### PR TITLE
Consolidate response metadata docs (Vibe Kanban)

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,11 +91,10 @@ Representative metadata shape:
 
 TRACE shows five response qualities at a glance: Tightness, Rationale, Attribution, Caution, and Extent.
 
-To understand how TRACE differs from mode, planner influence, steerability
-controls, and provenance, start with
-[How to Read Provenance-Related Metadata](docs/architecture/provenance-label-taxonomy.md).
-For the rationale behind TRACE itself, see the
-[TRACE decision record](docs/decisions/2026-03-compact-provenance-TRACE.md).
+See [How to Read Provenance-Related Metadata](docs/architecture/provenance-label-taxonomy.md)
+for the current metadata model, and the
+[TRACE decision record](docs/decisions/2026-03-compact-provenance-TRACE.md)
+for rationale.
 
 ## Advanced Setup
 

--- a/README.md
+++ b/README.md
@@ -91,7 +91,11 @@ Representative metadata shape:
 
 TRACE shows five response qualities at a glance: Tightness, Rationale, Attribution, Caution, and Extent.
 
-Learn more: [TRACE decision record](docs/decisions/2026-03-compact-provenance-TRACE.md)
+To understand how TRACE differs from mode, planner influence, steerability
+controls, and provenance, start with
+[How to Read Provenance-Related Metadata](docs/architecture/provenance-label-taxonomy.md).
+For the rationale behind TRACE itself, see the
+[TRACE decision record](docs/decisions/2026-03-compact-provenance-TRACE.md).
 
 ## Advanced Setup
 

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ Representative metadata shape:
 
 TRACE shows five response qualities at a glance: Tightness, Rationale, Attribution, Caution, and Extent.
 
-See [How to Read Provenance-Related Metadata](docs/architecture/provenance-label-taxonomy.md)
+See [Response Metadata](docs/architecture/response-metadata.md)
 for the current metadata model, and the
 [TRACE decision record](docs/decisions/2026-03-compact-provenance-TRACE.md)
 for rationale.

--- a/docs/README.md
+++ b/docs/README.md
@@ -26,7 +26,7 @@
 - [Architecture](./architecture/README.md): stable system design, interfaces,
   boundaries, and reading-order guidance.
 - [Status](./status/README.md): active rollout notes and implementation
-  snapshots. `status/archive` is historical rollout context, not the primary
+  state. `status/archive` is historical rollout context, not the primary
   place to learn current architecture.
 - [Decisions](./decisions/): durable technical choices and why they were made.
 - [Proposals](./proposals/): unadopted or exploratory ideas.

--- a/docs/architecture/2026-04-steerability-foundation.md
+++ b/docs/architecture/2026-04-steerability-foundation.md
@@ -4,6 +4,11 @@
 run. The trace uses it to show what actually influenced execution. It is not a
 policy engine, a user control surface, or a workflow scripting layer.
 
+Read this as an internal control-record doc, not as the main explainer for
+response metadata. For the first-pass separation between mode, TRACE, planner
+metadata, steerability controls, and provenance, start with
+[How to Read Provenance-Related Metadata](./provenance-label-taxonomy.md).
+
 Each control record stores a control id, value, source, rationale,
 `mattered`, and impacted targets.
 
@@ -156,6 +161,12 @@ If workflows later support multiple planner invocations or retries, add
 explicit correlation. Do not let planner metadata turn into orchestration
 authority.
 
+This boundary matters for doc cleanup:
+
+- planner metadata is about planner influence in a run
+- steerability controls are bounded internal control records
+- neither one replaces workflow lineage or provenance classification
+
 ## Control Observability Envelope
 
 Every control decision also writes one structured event:
@@ -271,6 +282,8 @@ A few expansion points are already visible, and they need to stay bounded.
   recorded with an explicit `trace_final_reason_code`. `workflowMode` remains
   routing metadata. TRACE remains answer-posture metadata.
   Current runtime does not implement a full TRACE lifecycle/history model yet.
+  Treat that lifecycle/history as future direction, not current runtime
+  behavior.
 
 The trace should show what the runtime actually did, in a form contributors
 can follow.

--- a/docs/architecture/2026-04-steerability-foundation.md
+++ b/docs/architecture/2026-04-steerability-foundation.md
@@ -5,8 +5,7 @@ run. The trace uses it to show what actually influenced execution. It is not a
 policy engine, a user control surface, or a workflow scripting layer.
 
 For the broader metadata map, read
-[How to Read Provenance-Related Metadata](./provenance-label-taxonomy.md)
-first.
+[Response Metadata](./response-metadata.md) first.
 
 Each control record stores a control id, value, source, rationale,
 `mattered`, and impacted targets.

--- a/docs/architecture/2026-04-steerability-foundation.md
+++ b/docs/architecture/2026-04-steerability-foundation.md
@@ -4,10 +4,9 @@
 run. The trace uses it to show what actually influenced execution. It is not a
 policy engine, a user control surface, or a workflow scripting layer.
 
-Read this as an internal control-record doc, not as the main explainer for
-response metadata. For the first-pass separation between mode, TRACE, planner
-metadata, steerability controls, and provenance, start with
-[How to Read Provenance-Related Metadata](./provenance-label-taxonomy.md).
+For the broader metadata map, read
+[How to Read Provenance-Related Metadata](./provenance-label-taxonomy.md)
+first.
 
 Each control record stores a control id, value, source, rationale,
 `mattered`, and impacted targets.
@@ -161,12 +160,6 @@ If workflows later support multiple planner invocations or retries, add
 explicit correlation. Do not let planner metadata turn into orchestration
 authority.
 
-This boundary matters for doc cleanup:
-
-- planner metadata is about planner influence in a run
-- steerability controls are bounded internal control records
-- neither one replaces workflow lineage or provenance classification
-
 ## Control Observability Envelope
 
 Every control decision also writes one structured event:
@@ -282,8 +275,6 @@ A few expansion points are already visible, and they need to stay bounded.
   recorded with an explicit `trace_final_reason_code`. `workflowMode` remains
   routing metadata. TRACE remains answer-posture metadata.
   Current runtime does not implement a full TRACE lifecycle/history model yet.
-  Treat that lifecycle/history as future direction, not current runtime
-  behavior.
 
 The trace should show what the runtime actually did, in a form contributors
 can follow.

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -13,9 +13,8 @@ the best starting point.
    current workflow and planner model, including mode, profile, review/revise,
    and planner boundaries.
 3. [How to Read Provenance-Related Metadata](./provenance-label-taxonomy.md):
-   use this next if your question is "what am I actually seeing in response
-   metadata?" It separates mode, TRACE, planner influence, steerability
-   controls, provenance, and current transitional fields.
+   use this when you need the metadata map for mode, TRACE, planner influence,
+   steerability, and provenance.
 4. [Workflow Engine And Provenance](./workflow-engine-and-provenance.md):
    use this after the metadata guide for the current engine flow and workflow
    lineage records.
@@ -31,8 +30,7 @@ the best starting point.
 - [Execution Contract TrustGraph Architecture](./execution_contract_trustgraph/architecture.md):
   TrustGraph-specific architecture and rollout constraints.
 - [Steerability Foundation (Internal Controls v1)](./2026-04-steerability-foundation.md):
-  internal control-record semantics behind steerability metadata. Read this
-  after the metadata guide, not before.
+  internal control-record semantics behind steerability metadata.
 
 ## Historical Workflow Notes
 

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -12,12 +12,13 @@ the best starting point.
 2. [Workflow Mode Routing](./workflow-mode-routing.md): read this next for the
    current workflow and planner model, including mode, profile, review/revise,
    and planner boundaries.
-3. [Workflow Engine And Provenance](./workflow-engine-and-provenance.md):
-   use this after the routing doc for the current engine flow and workflow
-   metadata.
-4. [How to Read Provenance-Related Metadata](./provenance-label-taxonomy.md):
-   use this before interpreting TRACE, provenance, mode, or planner fields in
-   responses.
+3. [How to Read Provenance-Related Metadata](./provenance-label-taxonomy.md):
+   use this next if your question is "what am I actually seeing in response
+   metadata?" It separates mode, TRACE, planner influence, steerability
+   controls, provenance, and current transitional fields.
+4. [Workflow Engine And Provenance](./workflow-engine-and-provenance.md):
+   use this after the metadata guide for the current engine flow and workflow
+   lineage records.
 
 ## Important Adjacent Docs
 
@@ -30,12 +31,13 @@ the best starting point.
 - [Execution Contract TrustGraph Architecture](./execution_contract_trustgraph/architecture.md):
   TrustGraph-specific architecture and rollout constraints.
 - [Steerability Foundation (Internal Controls v1)](./2026-04-steerability-foundation.md):
-  the control-plane foundation behind bounded user control and runtime posture.
+  internal control-record semantics behind steerability metadata. Read this
+  after the metadata guide, not before.
 
 ## Historical Workflow Notes
 
 Read these after the docs above if you need rollout history or older design
-notes. They are not the best first read for the workflow/planner model today.
+notes. They are rationale or rollout context, not the main current explanation.
 
 - [Workflow Profiles V1 RFC: Engine Core vs Profile Semantics](./workflow-profiles-v1-engine-vs-profile-semantics.md):
   design notes and ownership reasoning from the workflow-engine rollout.

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -12,7 +12,7 @@ the best starting point.
 2. [Workflow Mode Routing](./workflow-mode-routing.md): read this next for the
    current workflow and planner model, including mode, profile, review/revise,
    and planner boundaries.
-3. [How to Read Provenance-Related Metadata](./provenance-label-taxonomy.md):
+3. [Response Metadata](./response-metadata.md):
    use this when you need the metadata map for mode, TRACE, planner influence,
    steerability, and provenance.
 4. [Workflow Engine And Provenance](./workflow-engine-and-provenance.md):

--- a/docs/architecture/provenance-label-taxonomy.md
+++ b/docs/architecture/provenance-label-taxonomy.md
@@ -1,22 +1,14 @@
 # How to Read Provenance-Related Metadata
 
-When you look at response metadata, the first question should be:
+Footnote returns several metadata records next to each other because one
+response can have several different explanations. One field may describe how
+the request was routed. Another may describe the answer posture. Another may
+record what the planner influenced. Another may record what happened during
+execution.
 
-What am I actually seeing?
-
-The short answer is that Footnote returns several related record types side by
-side. They help explain one response, but they do different jobs. Do not treat
-them as one combined "why" field.
-
-Use this reading order:
-
-1. Read **mode** to see how the backend chose to run the request.
-2. Read **TRACE** to see the posture of the delivered answer.
-3. Read **planner metadata** to see whether planner output materially affected
-   the run.
-4. Read **steerability controls** to see which bounded internal controls
-   mattered.
-5. Read **provenance** to see what happened and how Footnote classified it.
+The useful reading order is simple: start with mode, then TRACE, then planner
+or steerability if you need to understand influence, and finish with
+provenance if you need the classified record of what happened.
 
 ## The Quick Map
 
@@ -28,109 +20,49 @@ Use this reading order:
 | Which internal controls materially affected execution or output?     | **Steerability controls** | `metadata.steerabilityControls.controls[]`                                                                                                                         |
 | What happened, and how was it classified?                            | **Provenance**            | `metadata.provenance`, `metadata.provenanceAssessment`, with supporting records in `metadata.execution`, `metadata.workflow`, and `metadata.trustGraph`            |
 
-If one field seems to answer two or three rows at once, the docs or the
-metadata wording are probably getting muddy.
+Mode is the routing choice. It tells you how the backend ran the request:
+which path it took, where that choice came from, and whether workflow-owned
+escalation happened.
 
-## What Each Concept Means
+TRACE is the posture of the answer. It tells you how the answer was shaped,
+not how the request was routed. `trace_target` is the intended posture.
+`trace_final` is the delivered posture. `trace_final_reason_code` explains the
+gap when those differ. The current runtime stops there. TRACE lifecycle/history
+is still future work.
 
-### Mode
+Planner metadata records planner influence inside the run. In practice that
+usually means checking the planner entry in `metadata.execution[]` to see
+whether planner output was applied, adjusted by policy, or not applied.
 
-Mode is about how the system runs.
+Steerability controls are the bounded backend control records for the same run.
+They answer a narrower question than planner metadata: which internal controls
+materially affected execution or output.
 
-This is the routing choice for the request, not a description of answer style.
-It tells you which broad execution path the backend selected and why.
+Provenance is the classified record of what happened. The label and assessment
+fields give the reviewer-facing summary. The supporting execution, workflow,
+and TrustGraph records provide the structural detail behind it.
 
-Read `metadata.workflowMode.*` when you want to answer:
+If you have a trace payload open, a common pattern is:
 
-- Did the backend take the fast path or the reviewed path?
-- Was the mode requested directly, inferred from the contract, or resolved by
-  fallback?
-- Did workflow-owned escalation happen?
-
-Do not use mode fields to explain TRACE posture, planner influence, or
-provenance classification.
-
-### TRACE
-
-TRACE is about the posture of the answer.
-
-It describes visible answer behavior such as tightness, rationale, attribution,
-caution, and extent. It does not describe routing, tool legality, or evidence
-provenance.
-
-`trace_target` is the intended posture. `trace_final` is the delivered posture.
-`trace_final_reason_code` explains why the delivered posture differs when it
-does.
-
-Important current boundary:
-
-- Current runtime does not implement a full TRACE lifecycle or history model.
-- TRACE target/final fields are current runtime metadata.
-- TRACE lifecycle/history is future direction, not current first-read behavior.
-
-### Planner Metadata
-
-Planner metadata is about planner influence in a run.
-
-It lives in planner entries inside `metadata.execution[]`. Read it when you
-want to know whether planner output was applied, adjusted by policy, or not
-applied.
-
-Planner metadata is not workflow authority. It does not prove that planner
-owned mode, policy, provenance, or control resolution. It records observable
-planner influence within backend-owned limits.
-
-### Steerability Controls
-
-Steerability controls are bounded internal control records.
-
-They answer a narrower question than planner metadata: which backend controls
-materially affected execution or output in this run?
-
-These controls are not a user-facing rollout, not a scripting surface, and not
-a replacement for workflow metadata. They are bounded records of control
-influence.
-
-### Provenance
-
-Provenance is about what happened and how it was classified.
-
-The label and assessment fields tell you the reviewer-facing classification.
-The supporting execution, workflow, and TrustGraph records give you the
-structural record behind that classification.
-
-Use provenance when you want to answer questions like:
-
-- What evidence or process shaped this result?
-- What was ignored, dropped, blocked, or classified a certain way?
-- What path would a reviewer inspect next?
-
-Do not collapse provenance into TRACE. TRACE is posture. Provenance is
-historical and classificatory.
+- `workflowMode` tells you the request ran `grounded`
+- the planner event shows a tool suggestion was adjusted by policy
+- `trace_final` shows a more cautious delivered answer
+- provenance fields tell you how the run was classified after the fact
 
 ## Metadata Types
 
-Not all metadata has the same status.
+Some of these fields are structural and some are summary-oriented.
 
-### Structural metadata
-
-Structural metadata describes durable runtime facts and record shapes.
-
-Examples:
+Structural metadata is the durable record of what the runtime did. That mainly
+means fields such as:
 
 - `metadata.workflowMode.*`
 - `metadata.workflow`
 - `metadata.execution`
 - `metadata.trustGraph`
 
-This is the best place to start when you need to reconstruct what the runtime
-actually did.
-
-### Heuristic metadata
-
-Heuristic metadata describes evaluated posture or judgment-oriented summaries.
-
-Examples:
+Heuristic metadata is the runtime's summarized posture or assessment. That
+includes fields such as:
 
 - `metadata.trace_target`
 - `metadata.trace_final`
@@ -138,42 +70,15 @@ Examples:
 - `metadata.freshnessScore`
 - parts of `metadata.provenanceAssessment`
 
-These fields are useful, but they are not orchestration authority.
-
-### Transitional metadata
-
-Transitional metadata exists because the implementation is still evolving.
-
-Examples:
+Some fields are transitional because the implementation is still moving toward
+the longer-term shape. Today that mainly means:
 
 - planner metadata living alongside, rather than inside, first-class workflow
   lineage
 - TRACE target/final fields without a full lifecycle/history model
 - compatibility mirrors or summary fields kept during contract cleanup
 
-Treat these as current runtime surfaces, but do not mistake them for the final
-shape of every future subsystem.
-
-## Current Vs Future
-
-Keep these boundaries explicit when writing or editing docs:
-
-- Current architecture docs explain what the runtime does now.
-- Decision records explain why a durable choice was made.
-- Rollout and status docs explain landing order, migration progress, or open
-  work.
-- Future TRACE lifecycle/history work is not fully implemented current
-  behavior.
-
-If you need the current workflow/planner explanation, start with
+For current workflow behavior, read
 [Workflow Mode Routing](./workflow-mode-routing.md) and
 [Workflow Engine And Provenance](./workflow-engine-and-provenance.md).
-If you need rationale, read the decision records after that.
-
-## Guardrails
-
-- Keep mode, TRACE, planner influence, steerability controls, and provenance
-  separate.
-- Prefer clearer wording and stronger tests over new wrapper fields or
-  duplicated labels.
-- Do not turn decision records into the main current docs.
+For rationale and history, use the decision and status docs after that.

--- a/docs/architecture/provenance-label-taxonomy.md
+++ b/docs/architecture/provenance-label-taxonomy.md
@@ -1,36 +1,179 @@
 # How to Read Provenance-Related Metadata
 
-This is the quick map for reading Footnote metadata without mixing different things together.
+When you look at response metadata, the first question should be:
 
-These categories are related, but they are not interchangeable:
+What am I actually seeing?
 
-- **Mode** = how the backend chose to run the request
-  Field: `metadata.workflowMode.*`
+The short answer is that Footnote returns several related record types side by
+side. They help explain one response, but they do different jobs. Do not treat
+them as one combined "why" field.
 
-- **TRACE** = the posture of the answer
-  Fields: `metadata.trace_target`, `metadata.trace_final`, `metadata.trace_final_reason_code`, plus optional chips like `metadata.evidenceScore` and `metadata.freshnessScore`
+Use this reading order:
 
-- **Planner** = what the planner step influenced during the run
-  Field surface: planner entries in `metadata.execution[]`
+1. Read **mode** to see how the backend chose to run the request.
+2. Read **TRACE** to see the posture of the delivered answer.
+3. Read **planner metadata** to see whether planner output materially affected
+   the run.
+4. Read **steerability controls** to see which bounded internal controls
+   mattered.
+5. Read **provenance** to see what happened and how Footnote classified it.
 
-- **Steerability controls** = which controls materially affected execution or output
-  Field: `metadata.steerabilityControls.controls[]`
+## The Quick Map
 
-- **Provenance** = what happened and how it was classified
-  Provenance label/method fields: `metadata.provenance`, `metadata.provenanceAssessment`
-  Supporting record surfaces (separate from provenance label/method): `metadata.execution`, `metadata.workflow`, and `metadata.trustGraph`
+| Question                                                             | Concept                   | Main fields                                                                                                                                                        |
+| -------------------------------------------------------------------- | ------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| How did the backend choose to run this request?                      | **Mode**                  | `metadata.workflowMode.*`                                                                                                                                          |
+| What posture did the answer aim for, and what posture was delivered? | **TRACE**                 | `metadata.trace_target`, `metadata.trace_final`, `metadata.trace_final_reason_code`, optional chips such as `metadata.evidenceScore` and `metadata.freshnessScore` |
+| Did planner output affect the run?                                   | **Planner metadata**      | planner entries in `metadata.execution[]`                                                                                                                          |
+| Which internal controls materially affected execution or output?     | **Steerability controls** | `metadata.steerabilityControls.controls[]`                                                                                                                         |
+| What happened, and how was it classified?                            | **Provenance**            | `metadata.provenance`, `metadata.provenanceAssessment`, with supporting records in `metadata.execution`, `metadata.workflow`, and `metadata.trustGraph`            |
 
-A simple way to read them:
+If one field seems to answer two or three rows at once, the docs or the
+metadata wording are probably getting muddy.
 
-- “How did the system choose to run?” → **Mode**
-- “How was the answer shaped?” → **TRACE**
-- “What did the planner affect?” → **Planner**
-- “Which controls actually mattered?” → **Steerability controls**
-- “What happened, and how was it classified?” → **Provenance**
+## What Each Concept Means
 
-If one field seems to answer two or three of those at once, something is probably getting muddy.
+### Mode
+
+Mode is about how the system runs.
+
+This is the routing choice for the request, not a description of answer style.
+It tells you which broad execution path the backend selected and why.
+
+Read `metadata.workflowMode.*` when you want to answer:
+
+- Did the backend take the fast path or the reviewed path?
+- Was the mode requested directly, inferred from the contract, or resolved by
+  fallback?
+- Did workflow-owned escalation happen?
+
+Do not use mode fields to explain TRACE posture, planner influence, or
+provenance classification.
+
+### TRACE
+
+TRACE is about the posture of the answer.
+
+It describes visible answer behavior such as tightness, rationale, attribution,
+caution, and extent. It does not describe routing, tool legality, or evidence
+provenance.
+
+`trace_target` is the intended posture. `trace_final` is the delivered posture.
+`trace_final_reason_code` explains why the delivered posture differs when it
+does.
+
+Important current boundary:
+
+- Current runtime does not implement a full TRACE lifecycle or history model.
+- TRACE target/final fields are current runtime metadata.
+- TRACE lifecycle/history is future direction, not current first-read behavior.
+
+### Planner Metadata
+
+Planner metadata is about planner influence in a run.
+
+It lives in planner entries inside `metadata.execution[]`. Read it when you
+want to know whether planner output was applied, adjusted by policy, or not
+applied.
+
+Planner metadata is not workflow authority. It does not prove that planner
+owned mode, policy, provenance, or control resolution. It records observable
+planner influence within backend-owned limits.
+
+### Steerability Controls
+
+Steerability controls are bounded internal control records.
+
+They answer a narrower question than planner metadata: which backend controls
+materially affected execution or output in this run?
+
+These controls are not a user-facing rollout, not a scripting surface, and not
+a replacement for workflow metadata. They are bounded records of control
+influence.
+
+### Provenance
+
+Provenance is about what happened and how it was classified.
+
+The label and assessment fields tell you the reviewer-facing classification.
+The supporting execution, workflow, and TrustGraph records give you the
+structural record behind that classification.
+
+Use provenance when you want to answer questions like:
+
+- What evidence or process shaped this result?
+- What was ignored, dropped, blocked, or classified a certain way?
+- What path would a reviewer inspect next?
+
+Do not collapse provenance into TRACE. TRACE is posture. Provenance is
+historical and classificatory.
+
+## Metadata Types
+
+Not all metadata has the same status.
+
+### Structural metadata
+
+Structural metadata describes durable runtime facts and record shapes.
+
+Examples:
+
+- `metadata.workflowMode.*`
+- `metadata.workflow`
+- `metadata.execution`
+- `metadata.trustGraph`
+
+This is the best place to start when you need to reconstruct what the runtime
+actually did.
+
+### Heuristic metadata
+
+Heuristic metadata describes evaluated posture or judgment-oriented summaries.
+
+Examples:
+
+- `metadata.trace_target`
+- `metadata.trace_final`
+- `metadata.evidenceScore`
+- `metadata.freshnessScore`
+- parts of `metadata.provenanceAssessment`
+
+These fields are useful, but they are not orchestration authority.
+
+### Transitional metadata
+
+Transitional metadata exists because the implementation is still evolving.
+
+Examples:
+
+- planner metadata living alongside, rather than inside, first-class workflow
+  lineage
+- TRACE target/final fields without a full lifecycle/history model
+- compatibility mirrors or summary fields kept during contract cleanup
+
+Treat these as current runtime surfaces, but do not mistake them for the final
+shape of every future subsystem.
+
+## Current Vs Future
+
+Keep these boundaries explicit when writing or editing docs:
+
+- Current architecture docs explain what the runtime does now.
+- Decision records explain why a durable choice was made.
+- Rollout and status docs explain landing order, migration progress, or open
+  work.
+- Future TRACE lifecycle/history work is not fully implemented current
+  behavior.
+
+If you need the current workflow/planner explanation, start with
+[Workflow Mode Routing](./workflow-mode-routing.md) and
+[Workflow Engine And Provenance](./workflow-engine-and-provenance.md).
+If you need rationale, read the decision records after that.
 
 ## Guardrails
 
-- Keep policy, posture, planner influence, control influence, and provenance separate.
-- Prefer clearer wording and stronger tests over new wrapper fields or duplicate labels.
+- Keep mode, TRACE, planner influence, steerability controls, and provenance
+  separate.
+- Prefer clearer wording and stronger tests over new wrapper fields or
+  duplicated labels.
+- Do not turn decision records into the main current docs.

--- a/docs/architecture/response-metadata.md
+++ b/docs/architecture/response-metadata.md
@@ -1,4 +1,4 @@
-# How to Read Provenance-Related Metadata
+# Response Metadata
 
 Footnote returns several metadata records next to each other because one
 response can have several different explanations. One field may describe how

--- a/docs/architecture/workflow-engine-and-provenance.md
+++ b/docs/architecture/workflow-engine-and-provenance.md
@@ -7,6 +7,9 @@ Explain the current workflow engine and the metadata it emits.
 This doc covers what is implemented now, not the full plan.
 Read [Workflow Mode Routing](./workflow-mode-routing.md) first if you need the
 big picture.
+Read [How to Read Provenance-Related Metadata](./provenance-label-taxonomy.md)
+if your main question is how workflow records relate to mode, TRACE, planner
+metadata, or provenance classification.
 
 ## Core Principles
 
@@ -97,12 +100,24 @@ lineage, and workflow lineage covers the reviewed generation path. Read those
 records together, but do not confuse planner influence with workflow
 authority.
 
+The same separation applies to TRACE and provenance:
+
+- workflow lineage records what the workflow did
+- TRACE records answer posture
+- provenance classifies what happened and how it should be read
+
+Those records support each other, but they are not interchangeable.
+
 ## Future Work
 
 Future work may extend the same engine flow to planner and tool steps. That is
 not the current first-read explanation.
 Use rollout or RFC docs only when you need historical sequencing or design
 tradeoffs.
+
+That same rule applies to workflow history language. Branch closeout notes and
+rollout history are useful context, but they are not the main current docs for
+reading response metadata or workflow behavior.
 
 For rollout history, see
 `docs/status/2026-04-workflow-engine-rollout-status.md`.

--- a/docs/architecture/workflow-engine-and-provenance.md
+++ b/docs/architecture/workflow-engine-and-provenance.md
@@ -7,9 +7,6 @@ Explain the current workflow engine and the metadata it emits.
 This doc covers what is implemented now, not the full plan.
 Read [Workflow Mode Routing](./workflow-mode-routing.md) first if you need the
 big picture.
-Read [How to Read Provenance-Related Metadata](./provenance-label-taxonomy.md)
-if your main question is how workflow records relate to mode, TRACE, planner
-metadata, or provenance classification.
 
 ## Core Principles
 
@@ -100,24 +97,12 @@ lineage, and workflow lineage covers the reviewed generation path. Read those
 records together, but do not confuse planner influence with workflow
 authority.
 
-The same separation applies to TRACE and provenance:
-
-- workflow lineage records what the workflow did
-- TRACE records answer posture
-- provenance classifies what happened and how it should be read
-
-Those records support each other, but they are not interchangeable.
-
 ## Future Work
 
 Future work may extend the same engine flow to planner and tool steps. That is
 not the current first-read explanation.
 Use rollout or RFC docs only when you need historical sequencing or design
 tradeoffs.
-
-That same rule applies to workflow history language. Branch closeout notes and
-rollout history are useful context, but they are not the main current docs for
-reading response metadata or workflow behavior.
 
 For rollout history, see
 `docs/status/2026-04-workflow-engine-rollout-status.md`.

--- a/docs/architecture/workflow-mode-routing.md
+++ b/docs/architecture/workflow-mode-routing.md
@@ -18,6 +18,12 @@ Workflow mode chooses the run type. Workflow profile chooses the step pattern.
 Planner can suggest action details inside those limits. Workflow lineage shows
 what actually happened.
 
+If you are reading response metadata, keep one boundary in mind from the start:
+mode is about how the system runs. TRACE is about the posture of the answer.
+Planner metadata is about planner influence in the run, not workflow
+authority. Use [How to Read Provenance-Related Metadata](./provenance-label-taxonomy.md)
+for the field-level map.
+
 ## Runtime Flow
 
 The normal chat path starts with the Execution Contract. That contract decides
@@ -118,6 +124,13 @@ request ran the way it did.
 `metadata.execution[]` planner entries explain planner influence.
 `metadata.workflow` records workflow lineage.
 TRACE fields describe answer behavior, not workflow routing.
+
+Current behavior and future direction are separate here:
+
+- Current runtime records mode, planner influence, and workflow lineage.
+- Planner is not yet a first-class workflow step in main chat metadata.
+- TRACE lifecycle/history is not the current routing model and should not be
+  read into workflow fields.
 
 The `workflowMode` object includes `modeId`, `selectedBy`,
 `selectionReason`, `initial_mode`, optional `escalated_mode`, optional

--- a/docs/architecture/workflow-mode-routing.md
+++ b/docs/architecture/workflow-mode-routing.md
@@ -18,12 +18,6 @@ Workflow mode chooses the run type. Workflow profile chooses the step pattern.
 Planner can suggest action details inside those limits. Workflow lineage shows
 what actually happened.
 
-If you are reading response metadata, keep one boundary in mind from the start:
-mode is about how the system runs. TRACE is about the posture of the answer.
-Planner metadata is about planner influence in the run, not workflow
-authority. Use [How to Read Provenance-Related Metadata](./provenance-label-taxonomy.md)
-for the field-level map.
-
 ## Runtime Flow
 
 The normal chat path starts with the Execution Contract. That contract decides
@@ -117,20 +111,10 @@ Rules for this seam:
 
 ## Metadata
 
-The response metadata keeps these concepts separate so readers can see why the
-request ran the way it did.
-
 `metadata.workflowMode.*` explains the routing choice.
 `metadata.execution[]` planner entries explain planner influence.
 `metadata.workflow` records workflow lineage.
 TRACE fields describe answer behavior, not workflow routing.
-
-Current behavior and future direction are separate here:
-
-- Current runtime records mode, planner influence, and workflow lineage.
-- Planner is not yet a first-class workflow step in main chat metadata.
-- TRACE lifecycle/history is not the current routing model and should not be
-  read into workflow fields.
 
 The `workflowMode` object includes `modeId`, `selectedBy`,
 `selectionReason`, `initial_mode`, optional `escalated_mode`, optional


### PR DESCRIPTION
## Summary
This PR consolidates and clarifies the docs that explain response metadata boundaries across provenance, TRACE, workflow routing, planner influence, and steerability controls.

## What Changed
- Reworked the main metadata explainer into `docs/architecture/response-metadata.md` and removed the older `provenance-label-taxonomy.md` path.
- Updated architecture reading-path links to point to the new metadata doc and keep the current-doc path clear.
- Trimmed workflow docs so they stay focused on workflow concerns instead of repeating metadata taxonomy guidance.
- Kept steerability foundation docs aligned with the new metadata doc naming and cross-links.
- Updated top-level docs links (`README.md`, `docs/README.md`) to match the cleaned architecture path.

## Why
The branch task was to reduce confusion between related concepts without changing runtime behavior:
- mode = routing/how the request ran
- TRACE = answer posture
- planner metadata = planner influence during the run
- steerability controls = bounded backend control records
- provenance = what happened and how it was classified

The goal was to make this easier for contributors to read in one pass, reduce duplicated wording, and keep current behavior separate from future direction.

## Implementation Notes
- This is a docs-only change; no schema, runtime metadata behavior, or control implementation was changed.
- The metadata explainer now sits at a stable filename (`response-metadata.md`) and is referenced from architecture and root docs.
- Workflow docs were intentionally narrowed to workflow routing/lineage content to avoid scope bleed.
- Validation was run during the branch work (`pnpm lint:fix`, `pnpm lint`, `pnpm review`).

This PR was written using [Vibe Kanban](https://vibekanban.com)