### PR TITLE
Attach planner StepRecord to bounded-review workflow lineage (Vibe Kanban)

### DIFF
--- a/packages/backend/src/services/chatOrchestrator.ts
+++ b/packages/backend/src/services/chatOrchestrator.ts
@@ -704,9 +704,10 @@ export const createChatOrchestrator = ({
                 // so traces can distinguish successful planning from fallback.
                 // This metadata reports planner influence; it does not delegate
                 // orchestration ownership or policy authority to planner.
-                // TODO(workflow-planner-lineage): Keep this metadata bridge
-                // until planner execution is represented directly as workflow
-                // lineage instead of orchestrator-frontloaded context.
+                // TODO(workflow-planner-metadata-cleanup): Planner execution
+                // is now also attached to bounded-review workflow lineage as a
+                // `plan` StepRecord. Keep this execution[] metadata bridge only
+                // for temporary compatibility with non-migrated paths.
                 planner: {
                     status: plannerExecution.status,
                     ...(plannerExecution.reasonCode !== undefined && {

--- a/packages/backend/src/services/chatService.ts
+++ b/packages/backend/src/services/chatService.ts
@@ -16,6 +16,7 @@ import type {
     PartialResponseTemperament,
     ResponseMetadata,
     SafetyTier,
+    StepRecord,
     TraceAxisScore,
     ToolExecutionContext,
     ToolInvocationRequest,
@@ -46,6 +47,7 @@ import {
     type WorkflowModeEscalationRequest,
 } from './workflowProfileRegistry.js';
 import {
+    buildPlannerStepRecord,
     runBoundedReviewWorkflow,
     type RunBoundedReviewWorkflowResult,
     type WorkflowPolicy,
@@ -572,6 +574,44 @@ export const createChatService = ({
         let generationResult: GenerationResult;
         let workflowLineage: WorkflowRecord | undefined;
         let fallbackAfterInternalNoGeneration = false;
+        const plannerExecutionContext = executionContext?.planner;
+        const plannerWorkflowStepRecord: StepRecord | undefined =
+            plannerExecutionContext !== undefined
+                ? buildPlannerStepRecord({
+                      stepId: 'step_1',
+                      attempt: 1,
+                      startedAtMs:
+                          plannerExecutionContext.durationMs !== undefined
+                              ? Math.max(
+                                    0,
+                                    generationStartedAt -
+                                        plannerExecutionContext.durationMs
+                                )
+                              : undefined,
+                      finishedAtMs: generationStartedAt,
+                      summary: {
+                          status: plannerExecutionContext.status,
+                          ...(plannerExecutionContext.reasonCode !==
+                              undefined && {
+                              reasonCode: plannerExecutionContext.reasonCode,
+                          }),
+                          purpose: plannerExecutionContext.purpose,
+                          contractType: plannerExecutionContext.contractType,
+                          applyOutcome: plannerExecutionContext.applyOutcome,
+                          durationMs: plannerExecutionContext.durationMs,
+                          profileId: plannerExecutionContext.profileId,
+                          originalProfileId:
+                              plannerExecutionContext.originalProfileId,
+                          effectiveProfileId:
+                              plannerExecutionContext.effectiveProfileId,
+                          provider: plannerExecutionContext.provider,
+                          model: plannerExecutionContext.model,
+                          mattered: plannerExecutionContext.mattered,
+                          matteredControlIds:
+                              plannerExecutionContext.matteredControlIds,
+                      },
+                  })
+                : undefined;
         if (workflowExecutionEnabled) {
             const workflowPolicy: WorkflowPolicy = workflowProfile.policy;
             const workflowResult = await runReviewWorkflow({
@@ -601,6 +641,7 @@ export const createChatService = ({
                 workflowPolicy,
                 captureUsage: (result, requestedModel) =>
                     recordUsageForStep(result, requestedModel),
+                plannerStepRecord: plannerWorkflowStepRecord,
             });
             switch (workflowResult.outcome) {
                 case 'generated':

--- a/packages/backend/src/services/workflowEngine.ts
+++ b/packages/backend/src/services/workflowEngine.ts
@@ -154,6 +154,7 @@ export type RunBoundedReviewWorkflowInput = {
         result: GenerationResult,
         requestedModel: string | undefined
     ) => ReviewWorkflowUsageSummary;
+    plannerStepRecord?: StepRecord;
 };
 
 export type RunBoundedReviewWorkflowResult =
@@ -429,20 +430,18 @@ export const buildPlannerStepRecord = ({
     summary,
 }: BuildPlannerStepRecordInput): StepRecord => {
     const coercedFinishedAtMs = Number(finishedAtMs);
-    const normalizedFinishedAtMs =
-        Number.isFinite(coercedFinishedAtMs)
-            ? Math.floor(coercedFinishedAtMs)
-            : Date.now();
+    const normalizedFinishedAtMs = Number.isFinite(coercedFinishedAtMs)
+        ? Math.floor(coercedFinishedAtMs)
+        : Date.now();
     const coercedStartedAtMs = Number(startedAtMs);
-    const normalizedDurationMs =
-        Number.isFinite(coercedStartedAtMs)
-            ? Math.max(
-                  0,
-                  Math.floor(
-                      normalizedFinishedAtMs - Math.floor(coercedStartedAtMs)
-                  )
+    const normalizedDurationMs = Number.isFinite(coercedStartedAtMs)
+        ? Math.max(
+              0,
+              Math.floor(
+                  normalizedFinishedAtMs - Math.floor(coercedStartedAtMs)
               )
-            : toNonNegativeIntegerOrZero(summary.durationMs);
+          )
+        : toNonNegativeIntegerOrZero(summary.durationMs);
     const normalizedStartedAtMs = normalizedFinishedAtMs - normalizedDurationMs;
     const normalizedAttempt = Number.isFinite(Number(attempt))
         ? Math.max(1, Math.floor(Number(attempt)))
@@ -559,6 +558,7 @@ export const runBoundedReviewWorkflow = async ({
     revisionPromptPrefix,
     parseReviewDecision,
     captureUsage,
+    plannerStepRecord,
 }: RunBoundedReviewWorkflowInput): Promise<RunBoundedReviewWorkflowResult> => {
     const UNBOUNDED_LIMIT = Number.MAX_SAFE_INTEGER;
     const sanitizeNonNegativeInteger = (
@@ -593,6 +593,12 @@ export const runBoundedReviewWorkflow = async ({
     const workflowId = `wf_${workflowStartedAt.toString(36)}_${Math.random().toString(36).slice(2, 8)}`;
     const workflowSteps: StepRecord[] = [];
     let stepCounter = 0;
+    let plannerRootStepId: string | undefined;
+    if (plannerStepRecord?.stepKind === 'plan') {
+        workflowSteps.push(plannerStepRecord);
+        stepCounter = 1;
+        plannerRootStepId = plannerStepRecord.stepId;
+    }
     let terminationReason: WorkflowTerminationReason = 'budget_exhausted_steps';
     let workflowStatus: WorkflowRecord['status'] = 'degraded';
     let draftResult: GenerationResult | null = null;
@@ -757,6 +763,7 @@ export const runBoundedReviewWorkflow = async ({
                     model: initialDraftUsage.model,
                     usage: draftResult.usage,
                     estimatedCost: initialDraftUsage.estimatedCost,
+                    parentStepId: plannerRootStepId,
                     attempt: 1,
                 });
                 draftParentStepId = initialDraftStepId;
@@ -792,6 +799,7 @@ export const runBoundedReviewWorkflow = async ({
                     reasonCode: 'generation_runtime_error',
                     startedAtMs: initialDraftStartedAt,
                     finishedAtMs: initialDraftFinishedAt,
+                    parentStepId: plannerRootStepId,
                     attempt: 1,
                 });
                 workflowState = applyStepExecutionToState(
@@ -1044,7 +1052,7 @@ export const runBoundedReviewWorkflow = async ({
         workflowId,
         workflowName: workflowConfig.workflowName,
         status: workflowStatus,
-        stepCount: workflowState.stepCount,
+        stepCount: workflowSteps.length,
         maxSteps: executionLimits.maxWorkflowSteps,
         maxDurationMs: executionLimits.maxDurationMs,
         terminationReason,

--- a/packages/backend/test/chatService.test.ts
+++ b/packages/backend/test/chatService.test.ts
@@ -13,7 +13,10 @@ import type {
     GenerationRuntime,
 } from '@footnote/agent-runtime';
 import { createVoltAgentRuntime } from '@footnote/agent-runtime';
-import type { ResponseMetadata } from '@footnote/contracts/ethics-core';
+import type {
+    ResponseMetadata,
+    StepRecord,
+} from '@footnote/contracts/ethics-core';
 import { ResponseMetadataSchema } from '@footnote/contracts/web';
 import { createMetadata } from './fixtures/responseMetadataFixture.js';
 import {
@@ -1100,6 +1103,112 @@ test('runChatMessages falls back to reviewed workflow behavior for unknown workf
     );
     assert.equal(capturedWorkflowRunConfig?.maxIterations, 2);
     assert.equal(capturedWorkflow?.workflowName, 'message_with_review_loop');
+});
+
+test('runChatMessages maps planner execution context into a workflow planner step for bounded-review lineage', async () => {
+    let capturedPlannerStep: StepRecord | undefined;
+
+    const chatService = createChatService({
+        generationRuntime: createRuntime(),
+        storeTrace: async () => undefined,
+        buildResponseMetadata: () => createMetadata(),
+        defaultModel: 'gpt-5-mini',
+        recordUsage: () => undefined,
+        chatWorkflowConfig: {
+            modeId: 'grounded',
+            reviewLoopEnabled: true,
+            maxIterations: 2,
+            maxDurationMs: 15000,
+        },
+        runReviewWorkflow: async (input) => {
+            capturedPlannerStep = input.plannerStepRecord;
+            return {
+                outcome: 'generated',
+                generationResult: {
+                    text: 'workflow response',
+                    model: input.generationRequest.model,
+                    usage: {
+                        promptTokens: 10,
+                        completionTokens: 5,
+                        totalTokens: 15,
+                    },
+                    provenance: 'Inferred',
+                    citations: [],
+                },
+                workflowLineage: {
+                    workflowId: 'wf_planner_bridge',
+                    workflowName: input.workflowConfig.workflowName,
+                    status: 'completed',
+                    terminationReason: 'goal_satisfied',
+                    stepCount: 2,
+                    maxSteps: 3,
+                    maxDurationMs: input.workflowConfig.maxDurationMs,
+                    steps: [
+                        input.plannerStepRecord ?? {
+                            stepId: 'step_1',
+                            attempt: 1,
+                            stepKind: 'plan',
+                            startedAt: new Date().toISOString(),
+                            finishedAt: new Date().toISOString(),
+                            durationMs: 1,
+                            outcome: {
+                                status: 'failed',
+                                summary: 'planner placeholder',
+                            },
+                        },
+                        {
+                            stepId: 'step_2',
+                            parentStepId: 'step_1',
+                            attempt: 1,
+                            stepKind: 'generate',
+                            startedAt: new Date().toISOString(),
+                            finishedAt: new Date().toISOString(),
+                            durationMs: 1,
+                            outcome: {
+                                status: 'executed',
+                                summary: 'Generated workflow response.',
+                            },
+                        },
+                    ],
+                },
+            } satisfies RunBoundedReviewWorkflowResult;
+        },
+    });
+
+    const response = await chatService.runChatMessages({
+        messages: [{ role: 'user', content: 'Summarize this.' }],
+        conversationSnapshot: 'Summarize this.',
+        executionContext: {
+            planner: {
+                status: 'failed',
+                reasonCode: 'planner_runtime_error',
+                purpose: 'chat_orchestrator_action_selection',
+                contractType: 'fallback',
+                applyOutcome: 'not_applied',
+                mattered: false,
+                matteredControlIds: [],
+                profileId: 'openai-text-fast',
+                originalProfileId: 'openai-text-fast',
+                effectiveProfileId: 'openai-text-fast',
+                provider: 'openai',
+                model: 'gpt-5-nano',
+                durationMs: 9,
+            },
+        },
+    });
+
+    assert.equal(response.message, 'workflow response');
+    assert.equal(capturedPlannerStep?.stepKind, 'plan');
+    assert.equal(capturedPlannerStep?.outcome.status, 'failed');
+    assert.equal(capturedPlannerStep?.reasonCode, 'planner_runtime_error');
+    assert.equal(
+        capturedPlannerStep?.outcome.signals?.applyOutcome,
+        'not_applied'
+    );
+    assert.equal(
+        capturedPlannerStep?.outcome.signals?.contractType,
+        'fallback'
+    );
 });
 
 test('runChatMessages executes fast workflow mode as direct generation without workflow lineage', async () => {

--- a/packages/backend/test/workflowEngine.test.ts
+++ b/packages/backend/test/workflowEngine.test.ts
@@ -567,6 +567,171 @@ test('runBoundedReviewWorkflow persists assess machine decision and reason in li
     assert.equal(generationCalls, 2);
 });
 
+test('runBoundedReviewWorkflow attaches planner plan step to lineage and links initial generate step to planner root', async () => {
+    let generationCalls = 0;
+    const generationRuntime: GenerationRuntime = {
+        kind: 'test-runtime',
+        async generate() {
+            generationCalls += 1;
+            return {
+                text: 'initial draft',
+                model: 'gpt-5-mini',
+                usage: {
+                    promptTokens: 12,
+                    completionTokens: 6,
+                    totalTokens: 18,
+                },
+                provenance: 'Inferred',
+                citations: [],
+            };
+        },
+    };
+
+    const plannerStep = buildPlannerStepRecord({
+        stepId: 'step_1',
+        attempt: 1,
+        finishedAtMs: Date.now(),
+        summary: {
+            status: 'executed',
+            purpose: 'chat_orchestrator_action_selection',
+            contractType: 'structured',
+            applyOutcome: 'applied',
+            profileId: 'openai-text-fast',
+            provider: 'openai',
+            model: 'gpt-5-nano',
+            mattered: true,
+            matteredControlIds: ['provider_preference'],
+        },
+    });
+
+    const result = await runBoundedReviewWorkflow({
+        generationRuntime,
+        generationRequest: {
+            model: 'gpt-5-mini',
+            messages: [{ role: 'user', content: 'Summarize this.' }],
+        },
+        messagesWithHints: [{ role: 'user', content: 'Summarize this.' }],
+        generationStartedAtMs: Date.now(),
+        workflowConfig: {
+            workflowName: 'message_with_review_loop',
+            maxIterations: 0,
+            maxDurationMs: 15000,
+        },
+        workflowPolicy: {
+            enablePlanning: false,
+            enableToolUse: false,
+            enableReplanning: false,
+            enableGeneration: true,
+            enableAssessment: true,
+            enableRevision: true,
+        },
+        plannerStepRecord: plannerStep,
+        captureUsage: (generationResult, requestedModel) => ({
+            model: requestedModel ?? generationResult.model ?? 'gpt-5-mini',
+            promptTokens: generationResult.usage?.promptTokens ?? 0,
+            completionTokens: generationResult.usage?.completionTokens ?? 0,
+            totalTokens: generationResult.usage?.totalTokens ?? 0,
+            estimatedCost: {
+                inputCostUsd: 0,
+                outputCostUsd: 0,
+                totalCostUsd: 0,
+            },
+        }),
+    });
+
+    assert.equal(result.outcome, 'generated');
+    assert.equal(result.workflowLineage.stepCount, 2);
+    assert.equal(result.workflowLineage.steps[0].stepKind, 'plan');
+    assert.equal(result.workflowLineage.steps[1].stepKind, 'generate');
+    assert.equal(result.workflowLineage.steps[1].parentStepId, 'step_1');
+    assert.equal(generationCalls, 1);
+});
+
+test('runBoundedReviewWorkflow preserves failed planner fallback status on injected plan step', async () => {
+    let generationCalls = 0;
+    const generationRuntime: GenerationRuntime = {
+        kind: 'test-runtime',
+        async generate() {
+            generationCalls += 1;
+            return {
+                text: 'should not run',
+                model: 'gpt-5-mini',
+                usage: {
+                    promptTokens: 1,
+                    completionTokens: 1,
+                    totalTokens: 2,
+                },
+                provenance: 'Inferred',
+                citations: [],
+            };
+        },
+    };
+
+    const plannerStep = buildPlannerStepRecord({
+        stepId: 'step_1',
+        attempt: 1,
+        finishedAtMs: Date.now(),
+        summary: {
+            status: 'failed',
+            reasonCode: 'planner_runtime_error',
+            purpose: 'chat_orchestrator_action_selection',
+            contractType: 'fallback',
+            applyOutcome: 'not_applied',
+            profileId: 'openai-text-fast',
+            provider: 'openai',
+            model: 'gpt-5-nano',
+            mattered: false,
+            matteredControlIds: [],
+        },
+    });
+
+    const result = await runBoundedReviewWorkflow({
+        generationRuntime,
+        generationRequest: {
+            model: 'gpt-5-mini',
+            messages: [{ role: 'user', content: 'Summarize this.' }],
+        },
+        messagesWithHints: [{ role: 'user', content: 'Summarize this.' }],
+        generationStartedAtMs: Date.now(),
+        workflowConfig: {
+            workflowName: 'message_with_review_loop',
+            maxIterations: 1,
+            maxDurationMs: 15000,
+        },
+        workflowPolicy: {
+            enablePlanning: false,
+            enableToolUse: false,
+            enableReplanning: false,
+            enableGeneration: false,
+            enableAssessment: true,
+            enableRevision: true,
+        },
+        plannerStepRecord: plannerStep,
+        captureUsage: () => ({
+            model: 'gpt-5-mini',
+            promptTokens: 0,
+            completionTokens: 0,
+            totalTokens: 0,
+            estimatedCost: {
+                inputCostUsd: 0,
+                outputCostUsd: 0,
+                totalCostUsd: 0,
+            },
+        }),
+    });
+
+    assert.equal(result.outcome, 'no_generation');
+    assert.equal(generationCalls, 0);
+    assert.equal(result.workflowLineage.stepCount, 1);
+    assert.equal(result.workflowLineage.steps.length, 1);
+    assert.equal(result.workflowLineage.steps[0].stepKind, 'plan');
+    assert.equal(result.workflowLineage.steps[0].outcome.status, 'failed');
+    assert.equal(
+        result.workflowLineage.steps[0].reasonCode,
+        'planner_runtime_error'
+    );
+});
+
 test('buildPlannerStepRecord creates schema-safe plan step with bounded planner summary fields', () => {
     const startedAtMs = Date.now() - 24;
     const finishedAtMs = Date.now();


### PR DESCRIPTION
## What changed
- Added workflow-native planner lineage attachment for bounded-review runs by passing an optional `plannerStepRecord` into `runBoundedReviewWorkflow`.
- In `chatService`, mapped existing orchestrator planner execution context into a bounded `plan` step via `buildPlannerStepRecord` and injected it only when workflow execution is enabled.
- In `workflowEngine`, inserted the injected planner step as the lineage root, linked the first generate step to that root, and emitted `stepCount` from the actual `steps` array.
- Kept existing execution metadata bridge in `chatOrchestrator` and marked it as temporary compatibility with a cleanup TODO.
- Added tests covering planner lineage visibility and fallback reflection in both workflow-engine and chat-service integration paths.

## Why this was changed
This ticket’s goal is to make bounded-review traces show a real `plan` step in workflow lineage without changing response behavior. The planner remains a bounded action-selection helper, while workflow sequencing and execution-contract policy ownership remain unchanged. This update bridges planner execution into workflow lineage for migrated bounded-review paths while keeping fast/non-migrated paths stable.

## Important implementation details
- Planner execution still runs in the orchestrator for this slice; only lineage attachment moved into the bounded-review workflow path.
- Planner fallback status/reason is preserved in the injected `plan` step (`failed` + `planner_runtime_error`/`planner_invalid_output` when applicable).
- Action/modality/profile/tool/prompt behavior was intentionally left unchanged.
- Legacy planner execution metadata is intentionally duplicated for compatibility and explicitly marked temporary.
- Fast mode remains on the direct path and is not forced into workflow lineage.

## Validation
- `pnpm lint:fix`
- `pnpm lint`
- `pnpm review`
- `pnpm exec tsx --test packages/backend/test/workflowEngine.test.ts packages/backend/test/chatService.test.ts`

This PR was written using [Vibe Kanban](https://vibekanban.com)