### PR TITLE
Clarify homepage first-contact messaging and visible answer signals (Vibe Kanban)

### DIFF
--- a/packages/web/src/components/AskMeAnything.tsx
+++ b/packages/web/src/components/AskMeAnything.tsx
@@ -657,8 +657,8 @@ const AskMeAnything = (): JSX.Element => {
                 </div>
             </div>
             <p className="interaction-helper">
-                After each reply, Footnote can show sources (when used),
-                provenance, safety tier, and a trace link.
+                After each reply, you can check sources when they were used,
+                safety signals, and the full trace.
             </p>
             <form className="interaction-form" onSubmit={onSubmit}>
                 <div className="interaction-input-group">

--- a/packages/web/src/components/AskMeAnything.tsx
+++ b/packages/web/src/components/AskMeAnything.tsx
@@ -677,7 +677,6 @@ const AskMeAnything = (): JSX.Element => {
                             placeholder="What should we talk about?"
                             autoComplete="off"
                             ref={inputRef}
-                            aria-label="Question input field"
                             rows={1}
                             onFocus={() => {
                                 void ensureRuntimeConfigLoaded();

--- a/packages/web/src/components/AskMeAnything.tsx
+++ b/packages/web/src/components/AskMeAnything.tsx
@@ -617,7 +617,7 @@ const AskMeAnything = (): JSX.Element => {
     return (
         <div className="interaction">
             <div className="interaction-heading-row">
-                <h2 className="interaction-heading">Ask me anything</h2>
+                <h2 className="interaction-heading">Ask a question</h2>
                 <div className="interaction-prompt-buttons-row">
                     <div className="interaction-prompt-text-button-wrapper">
                         <button
@@ -656,6 +656,10 @@ const AskMeAnything = (): JSX.Element => {
                     </button>
                 </div>
             </div>
+            <p className="interaction-helper">
+                After each reply, Footnote can show sources (when used),
+                provenance, safety tier, and a trace link.
+            </p>
             <form className="interaction-form" onSubmit={onSubmit}>
                 <div className="interaction-input-group">
                     <label htmlFor="question-input" className="sr-only">

--- a/packages/web/src/components/Hero.tsx
+++ b/packages/web/src/components/Hero.tsx
@@ -47,10 +47,12 @@ const Hero = (): JSX.Element => {
             <Header breadcrumbItems={breadcrumbItems} />
 
             <div className="hero-copy">
-                <h1 id="hero-title">AI you can inspect and steer.</h1>
+                <h1 id="hero-title">
+                    Ask a question. Get an answer with a trail.
+                </h1>
                 <p className="hero-copy__subtitle">
-                    A transparency-first framework for people who want more than
-                    a black-box answer.
+                    Footnote gives you a direct answer, then shows what shaped
+                    it so you can inspect the result instead of guessing.
                 </p>
                 <div className="hero-action-hub">
                     <div className="hero-action-tabs" role="tablist">
@@ -157,13 +159,27 @@ const Hero = (): JSX.Element => {
                             />
                         </div>
                         <div className="intro-card-text">
-                            <h2 id="intro-card-title">Footnote, at a glance</h2>
+                            <h2 id="intro-card-title">
+                                What you get after asking
+                            </h2>
                             <p>
-                                Footnote pairs model output with inspectable
-                                metadata, including confidence, sources,
-                                trade-offs, and applied constraints. Run it
-                                locally, self-host it, or bring it into Discord
-                                while keeping human oversight in the loop.
+                                The response is not just text in a chat box. You
+                                can inspect what happened.
+                            </p>
+                            <ul className="intro-card-list">
+                                <li>A direct answer.</li>
+                                <li>Source links when web sources are used.</li>
+                                <li>
+                                    Provenance details with safety and
+                                    confidence signals.
+                                </li>
+                                <li>
+                                    A trace link so you can open the full run.
+                                </li>
+                            </ul>
+                            <p>
+                                If you want full control, use the setup tab and
+                                run Footnote in your own environment.
                             </p>
                         </div>
                     </div>

--- a/packages/web/src/components/Hero.tsx
+++ b/packages/web/src/components/Hero.tsx
@@ -52,7 +52,7 @@ const Hero = (): JSX.Element => {
                 </h1>
                 <p className="hero-copy__subtitle">
                     Footnote gives you a direct answer, then shows what shaped
-                    it so you can inspect the result instead of guessing.
+                    it so you can see what shaped it, not just the final text.
                 </p>
                 <div className="hero-action-hub">
                     <div className="hero-action-tabs" role="tablist">

--- a/packages/web/src/components/Hero.tsx
+++ b/packages/web/src/components/Hero.tsx
@@ -48,11 +48,11 @@ const Hero = (): JSX.Element => {
 
             <div className="hero-copy">
                 <h1 id="hero-title">
-                    Ask a question. Get an answer with a trail.
+                    Ask a question. See what shaped the answer.
                 </h1>
                 <p className="hero-copy__subtitle">
-                    Footnote gives you a direct answer, then shows what shaped
-                    it so you can see what shaped it, not just the final text.
+                    Footnote answers your question, then shows the sources,
+                    signals, and trace behind the response.
                 </p>
                 <div className="hero-action-hub">
                     <div className="hero-action-tabs" role="tablist">
@@ -163,18 +163,16 @@ const Hero = (): JSX.Element => {
                                 What you get after asking
                             </h2>
                             <p>
-                                The response is not just text in a chat box. You
-                                can inspect what happened.
+                                Footnote does not stop at the answer. It also
+                                gives you a few ways to check how the response
+                                was produced.
                             </p>
                             <ul className="intro-card-list">
-                                <li>A direct answer.</li>
-                                <li>Source links when web sources are used.</li>
+                                <li>The answer itself.</li>
+                                <li>Source links, when sources were used.</li>
+                                <li>Safety and confidence signals.</li>
                                 <li>
-                                    Provenance details with safety and
-                                    confidence signals.
-                                </li>
-                                <li>
-                                    A trace link so you can open the full run.
+                                    A trace you can open to see what happened.
                                 </li>
                             </ul>
                             <p>

--- a/packages/web/src/components/OpenAccountable.tsx
+++ b/packages/web/src/components/OpenAccountable.tsx
@@ -19,9 +19,9 @@ interface Principle {
 
 const PRINCIPLES: Principle[] = [
     {
-        title: 'Open source',
+        title: 'Inspect the product, not just the promise',
         description:
-            'Inspect the implementation, trace decisions, and adapt Footnote to your governance model.',
+            'Footnote shows answer-level provenance, safety signals, and trace links so you can verify what happened.',
         link: {
             href: 'https://github.com/footnote-ai/footnote/tree/main',
             label: 'Repository',
@@ -29,18 +29,18 @@ const PRINCIPLES: Principle[] = [
         },
     },
     {
-        title: 'Self-hosted first',
+        title: 'Run it yourself',
         description:
-            'Keep control of credentials, runtime, and policy boundaries in your own environment.',
+            'Self-hosting keeps your keys, runtime, and policy boundaries in your environment.',
         link: {
             href: '/invite/',
             label: 'Quickstart setup',
         },
     },
     {
-        title: 'Dual license',
+        title: 'Open code with clear license terms',
         description:
-            'Dual-licensed under MIT and Hippocratic License v3 (HL3-CORE) for practical use with explicit guardrails.',
+            'Footnote is dual-licensed under MIT and Hippocratic License v3 (HL3-CORE).',
         link: {
             href: 'https://github.com/footnote-ai/footnote/blob/main/docs/LICENSE_STRATEGY.md',
             label: 'License strategy',
@@ -52,7 +52,9 @@ const PRINCIPLES: Principle[] = [
 // Transparency block with three concise commitments.
 const OpenAccountable = (): JSX.Element => (
     <section className="transparency" aria-labelledby="transparency-title">
-        <h2 id="transparency-title">Built to be inspectable</h2>
+        <h2 id="transparency-title">
+            Why this is different from a normal chat box
+        </h2>
         <div className="card-grid" role="list">
             {PRINCIPLES.map((principle) => (
                 <article key={principle.title} className="card" role="listitem">

--- a/packages/web/src/components/OpenAccountable.tsx
+++ b/packages/web/src/components/OpenAccountable.tsx
@@ -19,9 +19,9 @@ interface Principle {
 
 const PRINCIPLES: Principle[] = [
     {
-        title: 'Inspect the product, not just the promise',
+        title: 'Open source',
         description:
-            'Footnote shows answer-level provenance, safety signals, and trace links so you can verify what happened.',
+            'Read the code, inspect the implementation, and adapt Footnote to your needs.',
         link: {
             href: 'https://github.com/footnote-ai/footnote/tree/main',
             label: 'Repository',
@@ -29,18 +29,18 @@ const PRINCIPLES: Principle[] = [
         },
     },
     {
-        title: 'Run it yourself',
+        title: 'Self-hosted',
         description:
-            'Self-hosting keeps your keys, runtime, and policy boundaries in your environment.',
+            'Run Footnote in your own environment, with your own credentials and provider choices.',
         link: {
             href: '/invite/',
             label: 'Quickstart setup',
         },
     },
     {
-        title: 'Open code with clear license terms',
+        title: 'Clear license terms',
         description:
-            'Footnote is dual-licensed under MIT and Hippocratic License v3 (HL3-CORE).',
+            'Dual-licensed under MIT and Hippocratic License v3 (HL3-CORE), with the license strategy documented in the repo.',
         link: {
             href: 'https://github.com/footnote-ai/footnote/blob/main/docs/LICENSE_STRATEGY.md',
             label: 'License strategy',
@@ -52,9 +52,7 @@ const PRINCIPLES: Principle[] = [
 // Transparency block with three concise commitments.
 const OpenAccountable = (): JSX.Element => (
     <section className="transparency" aria-labelledby="transparency-title">
-        <h2 id="transparency-title">
-            Why this is different from a normal chat box
-        </h2>
+        <h2 id="transparency-title">What makes Footnote different</h2>
         <div className="card-grid" role="list">
             {PRINCIPLES.map((principle) => (
                 <article key={principle.title} className="card" role="listitem">

--- a/packages/web/src/components/Services.tsx
+++ b/packages/web/src/components/Services.tsx
@@ -20,9 +20,9 @@ interface ServiceFeature {
 const FEATURES: ServiceFeature[] = [
     {
         id: 'chat',
-        title: 'Answer + trail',
+        title: 'Answers you can inspect',
         description:
-            'Get an answer, then inspect provenance, safety tier, and trace details in the same flow.',
+            'Ask a question, get a response, and open the trace to see what sources and signals shaped it.',
     },
     {
         id: 'sources',
@@ -34,19 +34,19 @@ const FEATURES: ServiceFeature[] = [
         id: 'call',
         title: '/call',
         description:
-            'Run live voice sessions in Discord while keeping the same inspectable output model.',
+            'Run live voice sessions in Discord and keep response context visible.',
     },
     {
         id: 'image-understanding',
         title: 'Image understanding',
         description:
-            'Ask about an image and get findings folded into the same answer trail.',
+            'Ask about an image and see the findings alongside the response context.',
     },
     {
         id: 'image',
         title: '/image',
         description:
-            'Generate images inside the same workspace where answers and traces are visible.',
+            'Generate images from Discord while keeping the surrounding conversation in one place.',
         variant: 'wide',
     },
 ];

--- a/packages/web/src/components/Services.tsx
+++ b/packages/web/src/components/Services.tsx
@@ -20,33 +20,33 @@ interface ServiceFeature {
 const FEATURES: ServiceFeature[] = [
     {
         id: 'chat',
-        title: 'Chat',
+        title: 'Answer + trail',
         description:
-            'Get answers with confidence signals, trade-offs, and traceable context.',
+            'Get an answer, then inspect provenance, safety tier, and trace details in the same flow.',
     },
     {
         id: 'realtime',
-        title: 'Realtime search',
+        title: 'Sources when needed',
         description:
-            'Pull fresh web context and show which sources shaped the response.',
+            'When live web context is used, source links are shown with the response.',
     },
     {
         id: 'call',
         title: '/call',
         description:
-            'Run live voice sessions in Discord while preserving inspectable output.',
+            'Run live voice sessions in Discord while keeping the same inspectable output model.',
     },
     {
         id: 'image-understanding',
         title: 'Image understanding',
         description:
-            'Analyze visual inputs and fold findings into grounded, auditable replies.',
+            'Ask about an image and get findings folded into the same answer trail.',
     },
     {
         id: 'image',
         title: '/image',
         description:
-            'Generate visual artifacts that support discussion and decision workflows.',
+            'Generate images inside the same workspace where answers and traces are visible.',
         variant: 'wide',
     },
 ];
@@ -115,7 +115,7 @@ const Services = (): JSX.Element => {
     return (
         <>
             <section className="services" aria-labelledby="services-title">
-                <h2 id="services-title">What Footnote surfaces</h2>
+                <h2 id="services-title">What you can see today</h2>
                 <div className="services-grid">
                     {FEATURES.map((feature) => (
                         <article

--- a/packages/web/src/components/Services.tsx
+++ b/packages/web/src/components/Services.tsx
@@ -25,7 +25,7 @@ const FEATURES: ServiceFeature[] = [
             'Get an answer, then inspect provenance, safety tier, and trace details in the same flow.',
     },
     {
-        id: 'realtime',
+        id: 'sources',
         title: 'Sources when needed',
         description:
             'When live web context is used, source links are shown with the response.',
@@ -56,7 +56,7 @@ const getFeatureImage = (featureId: string, theme: string): string | null => {
     // Map feature IDs to image names
     const imageMap: Record<string, string> = {
         chat: 'chat',
-        realtime: 'search',
+        sources: 'search',
         call: 'call',
         'image-understanding': 'image-understanding',
         image: 'image',

--- a/packages/web/src/styles/global.css
+++ b/packages/web/src/styles/global.css
@@ -2040,7 +2040,7 @@ div.interaction-status:not(.interaction-status-visible) *,
 }
 
 .intro-card-list li {
-    margin-bottom: 0.35rem;
+    margin-bottom: 0.4rem;
 }
 
 /* ===== FOOTER ===== */

--- a/packages/web/src/styles/global.css
+++ b/packages/web/src/styles/global.css
@@ -890,6 +890,13 @@ section:has(.site-header-sticky) {
     white-space: nowrap;
 }
 
+.interaction-helper {
+    margin: 0 0 1rem;
+    color: var(--subtle-text);
+    font-size: 0.95rem;
+    max-width: 68ch;
+}
+
 .interaction-description {
     margin: 0 0 1.4rem;
     color: var(--subtle-text);
@@ -2025,6 +2032,15 @@ div.interaction-status:not(.interaction-status-visible) *,
 
 .intro-card-text p:last-child {
     margin-bottom: 0;
+}
+
+.intro-card-list {
+    margin: 0 0 1rem;
+    padding-left: 1.25rem;
+}
+
+.intro-card-list li {
+    margin-bottom: 0.35rem;
 }
 
 /* ===== FOOTER ===== */


### PR DESCRIPTION
## Summary
This PR improves homepage first-contact clarity so a new visitor can quickly understand what Footnote is and what appears after they ask a question.

## What changed
- Rewrote hero first-screen messaging to lead with plain product behavior instead of architecture framing.
- Added a concrete "what you get after asking" checklist near the hero.
- Updated the live ask panel copy to explicitly connect responses with visible sources/provenance/safety/trace output.
- Retitled and rewrote nearby landing sections to focus on user-visible outcomes and practical differentiation from a normal chat box.
- Kept self-hosting visible in first-contact copy without making it the sole value explanation.
- Added minimal CSS hooks for the new helper/checklist copy while preserving the existing visual direction.

## Why these changes were made
The task goal was to reduce bounce risk in the first few seconds by answering:
- What is this?
- What do I get after asking a question?
- Why is this different from a normal AI chat box?

The previous wording leaned on framework/architecture language. This pass shifts the page toward concrete, observable product output (answer + trail) while keeping claims aligned with what is currently visible in the UI.

## Implementation details
- Updated homepage copy in:
  - `packages/web/src/components/Hero.tsx`
  - `packages/web/src/components/AskMeAnything.tsx`
  - `packages/web/src/components/Services.tsx`
  - `packages/web/src/components/OpenAccountable.tsx`
- Added lightweight supporting styles in:
  - `packages/web/src/styles/global.css`
- No backend logic or API behavior was changed.
- The pass intentionally avoids implying unavailable controls/signals (workflow mode controls, TrustGraph-visible signals, or unshown steerability).

## Validation
- `pnpm lint:fix`
- `pnpm lint`
- `pnpm review`
- `pnpm validate-footnote-tags`
- Focused web checks:
  - `pnpm --filter @footnote/web build` (pass)
  - `pnpm --filter @footnote/web type-check` (existing workspace/build-state issues outside this diff)

This PR was written using [Vibe Kanban](https://vibekanban.com)
