### PR TITLE
Refactor trace lineage: make workflow plan steps the sole planner source (Vibe Kanban)

### DIFF
--- a/packages/backend/src/services/chatOrchestrator.ts
+++ b/packages/backend/src/services/chatOrchestrator.ts
@@ -288,9 +288,6 @@ export const createChatOrchestrator = ({
         // Planner is a bounded, execution-relevant helper. It can suggest
         // action-selection details, but it is not policy authority, contract
         // authority, runtime ownership, or a second orchestrator.
-        // TODO(workflow-planner-lineage): Planner is orchestrator-frontloaded
-        // today. When planner becomes workflow-native, persist it as a
-        // first-class workflow step in workflow lineage.
         const plannerInvocationContext: ChatPlannerInvocationContext = {
             owner: 'workflow',
             workflowName: 'chat_orchestration',
@@ -704,9 +701,6 @@ export const createChatOrchestrator = ({
                 // so traces can distinguish successful planning from fallback.
                 // This metadata reports planner influence; it does not delegate
                 // orchestration ownership or policy authority to planner.
-                // TODO(workflow-planner-lineage): Keep this metadata bridge
-                // until planner execution is represented directly as workflow
-                // lineage instead of orchestrator-frontloaded context.
                 planner: {
                     status: plannerExecution.status,
                     ...(plannerExecution.reasonCode !== undefined && {

--- a/packages/backend/src/services/chatService.ts
+++ b/packages/backend/src/services/chatService.ts
@@ -46,6 +46,7 @@ import {
     type WorkflowModeEscalationRequest,
 } from './workflowProfileRegistry.js';
 import {
+    buildPlannerStepRecord,
     runBoundedReviewWorkflow,
     type RunBoundedReviewWorkflowResult,
     type WorkflowPolicy,
@@ -245,6 +246,62 @@ const OWNERSHIP_DENIAL_PREFIXES: readonly string[] = [
     'validator_error:',
     'insufficient_data:',
 ];
+
+const hasPlannerWorkflowStep = (workflow: WorkflowRecord): boolean =>
+    workflow.steps.some((step) => step.stepKind === 'plan');
+
+const attachPlannerWorkflowLineage = (input: {
+    workflowLineage: WorkflowRecord;
+    executionContext: ResponseMetadataRuntimeContext['executionContext'];
+    generationStartedAtMs: number;
+}): WorkflowRecord => {
+    const plannerExecution = input.executionContext?.planner;
+    if (plannerExecution === undefined) {
+        return input.workflowLineage;
+    }
+
+    if (hasPlannerWorkflowStep(input.workflowLineage)) {
+        return input.workflowLineage;
+    }
+
+    const existingStepIds = new Set(
+        input.workflowLineage.steps.map((step) => step.stepId)
+    );
+    let plannerStepId = 'step_plan_1';
+    let plannerStepIndex = 1;
+    while (existingStepIds.has(plannerStepId)) {
+        plannerStepIndex += 1;
+        plannerStepId = `step_plan_${plannerStepIndex}`;
+    }
+
+    const plannerStep = buildPlannerStepRecord({
+        stepId: plannerStepId,
+        attempt: 1,
+        finishedAtMs: input.generationStartedAtMs,
+        summary: {
+            status: plannerExecution.status,
+            reasonCode: plannerExecution.reasonCode,
+            purpose: plannerExecution.purpose,
+            contractType: plannerExecution.contractType,
+            applyOutcome: plannerExecution.applyOutcome,
+            durationMs: plannerExecution.durationMs,
+            profileId: plannerExecution.profileId,
+            originalProfileId: plannerExecution.originalProfileId,
+            effectiveProfileId: plannerExecution.effectiveProfileId,
+            provider: plannerExecution.provider,
+            model: plannerExecution.model,
+            mattered: plannerExecution.mattered,
+            matteredControlIds: plannerExecution.matteredControlIds,
+        },
+    });
+
+    return {
+        ...input.workflowLineage,
+        stepCount: input.workflowLineage.steps.length + 1,
+        maxSteps: input.workflowLineage.maxSteps + 1,
+        steps: [plannerStep, ...input.workflowLineage.steps],
+    };
+};
 
 const extractOwnershipDenialReason = (
     details: string | undefined
@@ -896,14 +953,22 @@ export const createChatService = ({
                     durationMs: generationDurationMs,
                 } satisfies GenerationExecutionContext)
               : undefined;
+        const normalizedWorkflowLineage =
+            workflowLineage !== undefined
+                ? attachPlannerWorkflowLineage({
+                      workflowLineage,
+                      executionContext,
+                      generationStartedAtMs: generationStartedAt,
+                  })
+                : undefined;
 
         const runtimeContext: ResponseMetadataRuntimeContext = {
             modelVersion: usageModel,
             conversationSnapshot: `${conversationSnapshot}\n\n${generationResult.text}`,
             ...(totalDurationMs !== undefined && { totalDurationMs }),
             plannerTemperament,
-            ...(workflowLineage !== undefined && {
-                workflow: workflowLineage,
+            ...(normalizedWorkflowLineage !== undefined && {
+                workflow: normalizedWorkflowLineage,
             }),
             executionContext: {
                 // Preserve upstream execution context and overlay runtime facts

--- a/packages/backend/src/services/openaiService/metadata.ts
+++ b/packages/backend/src/services/openaiService/metadata.ts
@@ -140,6 +140,10 @@ const isSteerabilityControlId = (
     value === 'persona_tone_overlay' ||
     value === 'tool_allowance';
 
+const hasWorkflowPlannerLineage = (
+    workflow: ResponseMetadataRuntimeContext['workflow']
+): boolean => workflow?.steps.some((step) => step.stepKind === 'plan') ?? false;
+
 const normalizeEvaluatorReasonCode = (
     status: ExecutionStatus,
     reasonCode: ExecutionReasonCode | undefined
@@ -209,7 +213,8 @@ const normalizeToolReasonCode = (
  * - execution/workflow are structural record surfaces for what happened.
  * - workflowMode is execution-policy metadata.
  * - TRACE (trace_target/trace_final + optional chips) is answer-posture metadata.
- * - planner influence is represented in execution[] planner events.
+ * - planner influence is represented in workflow.steps[] (stepKind=plan) when
+ *   available, with execution[] planner events as compatibility fallback.
  * - steerability control influence is represented in steerabilityControls.
  * - provenance/provenanceAssessment are compact grounding classification-method
  *   metadata and may include deterministic heuristic derivation.
@@ -321,15 +326,12 @@ const buildResponseMetadata = (
     const licenseContext = 'MIT + HL3';
     const execution: ExecutionEvent[] = [];
     const plannerExecution = runtimeContext.executionContext?.planner;
-    if (plannerExecution) {
-        // TODO(workflow-planner-step-metadata): Planner is not workflow-native
-        // in lineage yet. If workflows support multiple planner invocations,
-        // add explicit attempt/correlation metadata without letting planner
-        // events redefine orchestration authority or step ownership.
-        // Treat this block as metadata ingestion only, not a policy hook.
-        // Turn the planner record from runtime context into the shared
-        // execution-event shape. If required fields are missing, drop it here
-        // instead of storing something half-valid.
+    if (
+        plannerExecution &&
+        !hasWorkflowPlannerLineage(runtimeContext.workflow)
+    ) {
+        // Compatibility bridge for legacy/unmigrated traces.
+        // Migrated workflow traces expose planner lineage in workflow.steps[].
         const normalizedPlannerReasonCode = normalizePlannerReasonCode(
             plannerExecution.status,
             plannerExecution.reasonCode

--- a/packages/backend/src/services/openaiService/metadata.ts
+++ b/packages/backend/src/services/openaiService/metadata.ts
@@ -14,13 +14,8 @@ import type {
     ExecutionStatus,
     EvaluatorExecutionReasonCode,
     GenerationExecutionReasonCode,
-    PlannerExecutionApplyOutcome,
-    PlannerExecutionContractType,
-    PlannerExecutionPurpose,
-    PlannerExecutionReasonCode,
     ResponseMetadata,
     SafetyTier,
-    SteerabilityControlId,
     ToolInvocationReasonCode,
     TraceAxisScore,
 } from '@footnote/contracts/ethics-core';
@@ -78,71 +73,6 @@ const normalizePlannerTemperament = (
 
     return Object.keys(normalized).length > 0 ? normalized : undefined;
 };
-
-const normalizePlannerReasonCode = (
-    status: ExecutionStatus,
-    reasonCode: ExecutionReasonCode | undefined
-): PlannerExecutionReasonCode | undefined => {
-    if (status === 'executed' || status === 'skipped') {
-        return undefined;
-    }
-
-    if (
-        reasonCode === 'planner_runtime_error' ||
-        reasonCode === 'planner_invalid_output'
-    ) {
-        return reasonCode;
-    }
-
-    return undefined;
-};
-
-const parsePlannerPurpose = (
-    value: unknown
-): PlannerExecutionPurpose | undefined =>
-    value === 'chat_orchestrator_action_selection' ? value : undefined;
-
-const parsePlannerContractType = (
-    value: unknown
-): PlannerExecutionContractType | undefined => {
-    if (
-        value === 'structured' ||
-        value === 'text_json' ||
-        value === 'fallback'
-    ) {
-        return value;
-    }
-
-    return undefined;
-};
-
-const parsePlannerApplyOutcome = (
-    value: unknown
-): PlannerExecutionApplyOutcome | undefined => {
-    if (
-        value === 'applied' ||
-        value === 'adjusted_by_policy' ||
-        value === 'not_applied'
-    ) {
-        return value;
-    }
-
-    return undefined;
-};
-
-const isSteerabilityControlId = (
-    value: unknown
-): value is SteerabilityControlId =>
-    value === 'workflow_mode' ||
-    value === 'evidence_strictness' ||
-    value === 'review_intensity' ||
-    value === 'provider_preference' ||
-    value === 'persona_tone_overlay' ||
-    value === 'tool_allowance';
-
-const hasWorkflowPlannerLineage = (
-    workflow: ResponseMetadataRuntimeContext['workflow']
-): boolean => workflow?.steps.some((step) => step.stepKind === 'plan') ?? false;
 
 const normalizeEvaluatorReasonCode = (
     status: ExecutionStatus,
@@ -213,8 +143,7 @@ const normalizeToolReasonCode = (
  * - execution/workflow are structural record surfaces for what happened.
  * - workflowMode is execution-policy metadata.
  * - TRACE (trace_target/trace_final + optional chips) is answer-posture metadata.
- * - planner influence is represented in workflow.steps[] (stepKind=plan) when
- *   available, with execution[] planner events as compatibility fallback.
+ * - planner influence is represented in workflow.steps[] (stepKind=plan).
  * - steerability control influence is represented in steerabilityControls.
  * - provenance/provenanceAssessment are compact grounding classification-method
  *   metadata and may include deterministic heuristic derivation.
@@ -325,118 +254,6 @@ const buildResponseMetadata = (
     const safetyTier: SafetyTier = 'Low';
     const licenseContext = 'MIT + HL3';
     const execution: ExecutionEvent[] = [];
-    const plannerExecution = runtimeContext.executionContext?.planner;
-    if (
-        plannerExecution &&
-        !hasWorkflowPlannerLineage(runtimeContext.workflow)
-    ) {
-        // Compatibility bridge for legacy/unmigrated traces.
-        // Migrated workflow traces expose planner lineage in workflow.steps[].
-        const normalizedPlannerReasonCode = normalizePlannerReasonCode(
-            plannerExecution.status,
-            plannerExecution.reasonCode
-        );
-        const validatedPlannerPurpose = parsePlannerPurpose(
-            plannerExecution.purpose
-        );
-        const validatedPlannerContractType = parsePlannerContractType(
-            plannerExecution.contractType
-        );
-        const validatedPlannerApplyOutcome = parsePlannerApplyOutcome(
-            plannerExecution.applyOutcome
-        );
-        const plannerExecutionSource =
-            'runtimeContext.executionContext.planner';
-        const hasValidMattered = typeof plannerExecution.mattered === 'boolean';
-        const sanitizedMatteredControlIds = Array.isArray(
-            plannerExecution.matteredControlIds
-        )
-            ? plannerExecution.matteredControlIds.filter(
-                  isSteerabilityControlId
-              )
-            : [];
-        const invalidPlannerFields: Array<{
-            field:
-                | 'purpose'
-                | 'contractType'
-                | 'applyOutcome'
-                | 'mattered'
-                | 'matteredControlIds';
-            value: unknown;
-        }> = [];
-        if (validatedPlannerPurpose === undefined) {
-            invalidPlannerFields.push({
-                field: 'purpose',
-                value: plannerExecution.purpose,
-            });
-        }
-        if (validatedPlannerContractType === undefined) {
-            invalidPlannerFields.push({
-                field: 'contractType',
-                value: plannerExecution.contractType,
-            });
-        }
-        if (validatedPlannerApplyOutcome === undefined) {
-            invalidPlannerFields.push({
-                field: 'applyOutcome',
-                value: plannerExecution.applyOutcome,
-            });
-        }
-        if (!hasValidMattered) {
-            invalidPlannerFields.push({
-                field: 'mattered',
-                value: plannerExecution.mattered,
-            });
-        }
-        if (!Array.isArray(plannerExecution.matteredControlIds)) {
-            invalidPlannerFields.push({
-                field: 'matteredControlIds',
-                value: plannerExecution.matteredControlIds,
-            });
-        }
-
-        if (
-            validatedPlannerPurpose === undefined ||
-            validatedPlannerContractType === undefined ||
-            validatedPlannerApplyOutcome === undefined ||
-            !hasValidMattered
-        ) {
-            logger.error(
-                'planner execution metadata dropped due invalid required fields',
-                {
-                    responseId,
-                    source: plannerExecutionSource,
-                    plannerStatus: plannerExecution.status,
-                    invalidPlannerFields,
-                }
-            );
-        } else {
-            execution.push({
-                kind: 'planner',
-                status: plannerExecution.status,
-                purpose: validatedPlannerPurpose,
-                contractType: validatedPlannerContractType,
-                applyOutcome: validatedPlannerApplyOutcome,
-                mattered: plannerExecution.mattered,
-                matteredControlIds: sanitizedMatteredControlIds,
-                profileId: plannerExecution.profileId,
-                ...(plannerExecution.originalProfileId !== undefined && {
-                    originalProfileId: plannerExecution.originalProfileId,
-                }),
-                ...(plannerExecution.effectiveProfileId !== undefined && {
-                    effectiveProfileId: plannerExecution.effectiveProfileId,
-                }),
-                provider: plannerExecution.provider,
-                model: plannerExecution.model,
-                ...(normalizedPlannerReasonCode !== undefined && {
-                    reasonCode: normalizedPlannerReasonCode,
-                }),
-                ...(plannerExecution.durationMs !== undefined && {
-                    durationMs: plannerExecution.durationMs,
-                }),
-            });
-        }
-    }
     const evaluatorExecution = runtimeContext.executionContext?.evaluator;
     if (evaluatorExecution) {
         // The evaluator already decided this. We are only copying that result

--- a/packages/backend/src/services/workflowEngine.ts
+++ b/packages/backend/src/services/workflowEngine.ts
@@ -414,8 +414,7 @@ const isPlannerReasonCode = (
 > => value === 'planner_runtime_error' || value === 'planner_invalid_output';
 
 /**
- * Builds a planner-specific workflow step record for short-lived lineage
- * bridging while planner execution is still orchestrator-frontloaded.
+ * Builds a planner-specific workflow step record for workflow lineage.
  *
  * Keep this mapper narrow and bounded to planner-safe summary fields only.
  * It must not become a generic workflow-step factory.
@@ -429,20 +428,18 @@ export const buildPlannerStepRecord = ({
     summary,
 }: BuildPlannerStepRecordInput): StepRecord => {
     const coercedFinishedAtMs = Number(finishedAtMs);
-    const normalizedFinishedAtMs =
-        Number.isFinite(coercedFinishedAtMs)
-            ? Math.floor(coercedFinishedAtMs)
-            : Date.now();
+    const normalizedFinishedAtMs = Number.isFinite(coercedFinishedAtMs)
+        ? Math.floor(coercedFinishedAtMs)
+        : Date.now();
     const coercedStartedAtMs = Number(startedAtMs);
-    const normalizedDurationMs =
-        Number.isFinite(coercedStartedAtMs)
-            ? Math.max(
-                  0,
-                  Math.floor(
-                      normalizedFinishedAtMs - Math.floor(coercedStartedAtMs)
-                  )
+    const normalizedDurationMs = Number.isFinite(coercedStartedAtMs)
+        ? Math.max(
+              0,
+              Math.floor(
+                  normalizedFinishedAtMs - Math.floor(coercedStartedAtMs)
               )
-            : toNonNegativeIntegerOrZero(summary.durationMs);
+          )
+        : toNonNegativeIntegerOrZero(summary.durationMs);
     const normalizedStartedAtMs = normalizedFinishedAtMs - normalizedDurationMs;
     const normalizedAttempt = Number.isFinite(Number(attempt))
         ? Math.max(1, Math.floor(Number(attempt)))

--- a/packages/backend/test/chatOrchestrator.test.ts
+++ b/packages/backend/test/chatOrchestrator.test.ts
@@ -2014,7 +2014,7 @@ test('planner invocation emits distinct metadata categories for mode TRACE plann
     // Category separation assertions for one end-to-end orchestrator path:
     // - mode => workflowMode (execution policy)
     // - TRACE => trace_target/trace_final (answer posture)
-    // - planner => execution[] planner event (workflow-step influence)
+    // - planner => workflow.steps[] plan step (execution lineage)
     // - controls => steerabilityControls (control influence)
     // - provenance => grounding classification + assessment/record surfaces
     assert.ok(response.metadata.workflowMode);
@@ -2041,32 +2041,34 @@ test('planner invocation emits distinct metadata categories for mode TRACE plann
     const plannerEvent = response.metadata.execution?.find(
         (event) => event.kind === 'planner'
     );
-    assert.ok(plannerEvent);
-    if (plannerEvent?.kind === 'planner') {
-        assert.equal(
-            plannerEvent.purpose,
-            'chat_orchestrator_action_selection'
-        );
-        assert.ok(
-            plannerEvent.contractType === 'structured' ||
-                plannerEvent.contractType === 'text_json' ||
-                plannerEvent.contractType === 'fallback'
-        );
-        assert.ok(
-            plannerEvent.applyOutcome === 'applied' ||
-                plannerEvent.applyOutcome === 'adjusted_by_policy' ||
-                plannerEvent.applyOutcome === 'not_applied'
-        );
-        assert.equal(typeof plannerEvent.mattered, 'boolean');
-        assert.ok(Array.isArray(plannerEvent.matteredControlIds));
-    }
+    assert.equal(plannerEvent, undefined);
+    const plannerStep = response.metadata.workflow?.steps.find(
+        (step) => step.stepKind === 'plan'
+    );
+    assert.ok(plannerStep);
+    assert.ok(
+        plannerStep?.outcome.status === 'executed' ||
+            plannerStep?.outcome.status === 'failed'
+    );
+    const plannerSignals = plannerStep?.outcome.signals;
+    assert.equal(plannerSignals?.purpose, 'chat_orchestrator_action_selection');
+    assert.ok(
+        plannerSignals?.contractType === 'structured' ||
+            plannerSignals?.contractType === 'text_json' ||
+            plannerSignals?.contractType === 'fallback'
+    );
+    assert.ok(
+        plannerSignals?.applyOutcome === 'applied' ||
+            plannerSignals?.applyOutcome === 'adjusted_by_policy' ||
+            plannerSignals?.applyOutcome === 'not_applied'
+    );
     // Planner influence must remain distinct from execution-policy and TRACE surfaces.
-    assert.equal(typeof plannerEvent?.kind, 'string');
+    assert.equal(plannerStep?.stepKind, 'plan');
     assert.notEqual(response.metadata.workflowMode?.modeId, undefined);
     assert.notEqual(response.metadata.trace_final, undefined);
 });
 
-test('planner execution metadata reports adjusted_by_policy when request override changes application path', async () => {
+test('planner workflow lineage reports adjusted_by_policy when request override changes application path', async () => {
     const orchestrator = createChatOrchestrator({
         generationRuntime: createGenerationRuntime(async (request) => {
             if (request.maxOutputTokens === PLANNER_TOKEN_SENTINEL) {
@@ -2120,13 +2122,18 @@ test('planner execution metadata reports adjusted_by_policy when request overrid
     );
 
     assert.equal(response.action, 'message');
+    const plannerStep = response.metadata.workflow?.steps.find(
+        (step) => step.stepKind === 'plan'
+    );
+    assert.ok(plannerStep);
+    assert.equal(
+        plannerStep?.outcome.signals?.applyOutcome,
+        'adjusted_by_policy'
+    );
+    assert.equal(plannerStep?.outcome.signals?.mattered, true);
+    assert.equal(plannerStep?.outcome.signals?.matteredControlCount, 1);
     const plannerEvent = response.metadata.execution?.find(
         (event) => event.kind === 'planner'
     );
-    assert.ok(plannerEvent);
-    if (plannerEvent?.kind === 'planner') {
-        assert.equal(plannerEvent.applyOutcome, 'adjusted_by_policy');
-        assert.equal(plannerEvent.mattered, true);
-        assert.deepEqual(plannerEvent.matteredControlIds, ['tool_allowance']);
-    }
+    assert.equal(plannerEvent, undefined);
 });

--- a/packages/backend/test/chatService.test.ts
+++ b/packages/backend/test/chatService.test.ts
@@ -369,6 +369,100 @@ test('runChatMessages forwards execution context into metadata runtime context (
     assert.ok((capturedExecutionContext?.generation?.durationMs ?? -1) >= 0);
 });
 
+test('runChatMessages records planner lineage in workflow steps for bounded-review runs and avoids duplicate planner execution events', async () => {
+    const chatService = createChatService({
+        generationRuntime: createRuntime({
+            model: 'gpt-5-mini',
+            provenance: 'Inferred',
+            citations: [],
+        }),
+        storeTrace: async () => undefined,
+        buildResponseMetadata,
+        defaultModel: 'gpt-5-mini',
+        recordUsage: () => undefined,
+        chatWorkflowConfig: {
+            modeId: 'grounded',
+            reviewLoopEnabled: true,
+            maxIterations: 1,
+            maxDurationMs: 15000,
+        },
+        runReviewWorkflow: async (input) =>
+            ({
+                outcome: 'generated',
+                generationResult: {
+                    text: 'workflow generated response',
+                    model: input.generationRequest.model,
+                    usage: {
+                        promptTokens: 10,
+                        completionTokens: 5,
+                        totalTokens: 15,
+                    },
+                    provenance: 'Inferred',
+                    citations: [],
+                },
+                workflowLineage: {
+                    workflowId: 'wf_lineage',
+                    workflowName: input.workflowConfig.workflowName,
+                    status: 'completed',
+                    terminationReason: 'goal_satisfied',
+                    stepCount: 1,
+                    maxSteps:
+                        input.workflowConfig.executionLimits
+                            ?.maxWorkflowSteps ?? 1,
+                    maxDurationMs: input.workflowConfig.maxDurationMs,
+                    steps: [
+                        {
+                            stepId: 'step_1',
+                            attempt: 1,
+                            stepKind: 'generate',
+                            startedAt: new Date().toISOString(),
+                            finishedAt: new Date().toISOString(),
+                            durationMs: 1,
+                            outcome: {
+                                status: 'executed',
+                                summary:
+                                    'Generated response through workflow path.',
+                            },
+                        },
+                    ],
+                },
+            }) satisfies RunBoundedReviewWorkflowResult,
+    });
+
+    const response = await chatService.runChatMessages({
+        messages: [{ role: 'user', content: 'Summarize this.' }],
+        conversationSnapshot: 'Summarize this.',
+        executionContext: {
+            planner: {
+                status: 'executed',
+                purpose: 'chat_orchestrator_action_selection',
+                contractType: 'structured',
+                applyOutcome: 'applied',
+                mattered: true,
+                matteredControlIds: ['tool_allowance'],
+                profileId: 'openai-text-fast',
+                provider: 'openai',
+                model: 'gpt-5-nano',
+                durationMs: 11,
+            },
+            generation: {
+                status: 'executed',
+                profileId: 'openai-text-medium',
+                provider: 'openai',
+                model: 'gpt-5-mini',
+            },
+        },
+    });
+
+    assert.ok(response.metadata.workflow);
+    assert.equal(response.metadata.workflow?.steps[0]?.stepKind, 'plan');
+    assert.equal(response.metadata.workflow?.stepCount, 2);
+    const plannerExecutionEvent = response.metadata.execution?.find(
+        (event) => event.kind === 'planner'
+    );
+    assert.equal(plannerExecutionEvent, undefined);
+});
+
 test('runChatMessages marks tool execution as executed when retrieval was used', async () => {
     let capturedExecutionContext:
         | ResponseMetadataRuntimeContext['executionContext']

--- a/packages/backend/test/openaiService.metadata.test.ts
+++ b/packages/backend/test/openaiService.metadata.test.ts
@@ -466,6 +466,80 @@ test('buildResponseMetadata writes execution timeline from runtime context', () 
     });
 });
 
+test('buildResponseMetadata uses workflow plan-step lineage over execution planner bridge when both are present', () => {
+    const metadata = buildResponseMetadata(
+        baseAssistantMetadata(),
+        baseRuntimeContext({
+            workflow: {
+                workflowId: 'wf_123',
+                workflowName: 'message_with_review_loop',
+                status: 'completed',
+                terminationReason: 'goal_satisfied',
+                stepCount: 2,
+                maxSteps: 3,
+                maxDurationMs: 15000,
+                steps: [
+                    {
+                        stepId: 'step_plan_1',
+                        attempt: 1,
+                        stepKind: 'plan',
+                        startedAt: '2026-04-01T00:00:00.000Z',
+                        finishedAt: '2026-04-01T00:00:00.010Z',
+                        durationMs: 10,
+                        outcome: {
+                            status: 'executed',
+                            summary:
+                                'Planner step emitted bounded action-selection summary.',
+                        },
+                    },
+                    {
+                        stepId: 'step_1',
+                        attempt: 1,
+                        stepKind: 'generate',
+                        startedAt: '2026-04-01T00:00:00.011Z',
+                        finishedAt: '2026-04-01T00:00:00.020Z',
+                        durationMs: 9,
+                        outcome: {
+                            status: 'executed',
+                            summary: 'Generated initial draft response.',
+                        },
+                    },
+                ],
+            },
+            executionContext: {
+                planner: {
+                    status: 'executed',
+                    purpose: 'chat_orchestrator_action_selection',
+                    contractType: 'structured',
+                    applyOutcome: 'applied',
+                    mattered: true,
+                    matteredControlIds: ['provider_preference'],
+                    profileId: 'openai-text-fast',
+                    provider: 'openai',
+                    model: 'gpt-5-nano',
+                    durationMs: 12,
+                },
+                generation: {
+                    status: 'executed',
+                    profileId: 'openai-text-medium',
+                    provider: 'openai',
+                    model: 'gpt-5-mini',
+                },
+            },
+        })
+    );
+
+    assert.deepEqual(metadata.execution, [
+        {
+            kind: 'generation',
+            status: 'executed',
+            profileId: 'openai-text-medium',
+            provider: 'openai',
+            model: 'gpt-5-mini',
+        },
+    ]);
+});
+
 test('buildResponseMetadata mirrors modelVersion from final generation execution model', () => {
     const metadata = buildResponseMetadata(
         baseAssistantMetadata({ model: 'fallback-model' }),

--- a/packages/backend/test/openaiService.metadata.test.ts
+++ b/packages/backend/test/openaiService.metadata.test.ts
@@ -412,19 +412,6 @@ test('buildResponseMetadata writes execution timeline from runtime context', () 
 
     assert.deepEqual(metadata.execution, [
         {
-            kind: 'planner',
-            status: 'executed',
-            purpose: 'chat_orchestrator_action_selection',
-            contractType: 'structured',
-            applyOutcome: 'applied',
-            mattered: true,
-            matteredControlIds: ['provider_preference'],
-            profileId: 'openai-text-fast',
-            provider: 'openai',
-            model: 'gpt-5-nano',
-            durationMs: 12,
-        },
-        {
             kind: 'evaluator',
             status: 'executed',
             evaluator: {
@@ -466,7 +453,7 @@ test('buildResponseMetadata writes execution timeline from runtime context', () 
     });
 });
 
-test('buildResponseMetadata uses workflow plan-step lineage over execution planner bridge when both are present', () => {
+test('buildResponseMetadata ignores planner execution bridge fields and keeps execution timeline non-planner only', () => {
     const metadata = buildResponseMetadata(
         baseAssistantMetadata(),
         baseRuntimeContext({
@@ -657,7 +644,7 @@ test('buildResponseMetadata normalizes failed tool event with fallback reasonCod
     ]);
 });
 
-test('buildResponseMetadata keeps failed planner reasonCode in execution timeline', () => {
+test('buildResponseMetadata ignores failed planner execution bridge fields', () => {
     const metadata = buildResponseMetadata(
         baseAssistantMetadata(),
         baseRuntimeContext({
@@ -678,24 +665,10 @@ test('buildResponseMetadata keeps failed planner reasonCode in execution timelin
         })
     );
 
-    assert.deepEqual(metadata.execution, [
-        {
-            kind: 'planner',
-            status: 'failed',
-            reasonCode: 'planner_runtime_error',
-            purpose: 'chat_orchestrator_action_selection',
-            contractType: 'fallback',
-            applyOutcome: 'not_applied',
-            mattered: false,
-            matteredControlIds: [],
-            profileId: 'openai-text-fast',
-            provider: 'openai',
-            model: 'gpt-5-nano',
-        },
-    ]);
+    assert.equal(metadata.execution, undefined);
 });
 
-test('buildResponseMetadata drops invalid planner reasonCode instead of rewriting it', () => {
+test('buildResponseMetadata ignores planner execution bridge fields regardless of planner reasonCode validity', () => {
     const metadata = buildResponseMetadata(
         baseAssistantMetadata(),
         baseRuntimeContext({
@@ -716,23 +689,10 @@ test('buildResponseMetadata drops invalid planner reasonCode instead of rewritin
         })
     );
 
-    assert.deepEqual(metadata.execution, [
-        {
-            kind: 'planner',
-            status: 'failed',
-            purpose: 'chat_orchestrator_action_selection',
-            contractType: 'fallback',
-            applyOutcome: 'not_applied',
-            mattered: false,
-            matteredControlIds: [],
-            profileId: 'openai-text-fast',
-            provider: 'openai',
-            model: 'gpt-5-nano',
-        },
-    ]);
+    assert.equal(metadata.execution, undefined);
 });
 
-test('buildResponseMetadata does not emit planner/evaluator/generation reasonCode for skipped status', () => {
+test('buildResponseMetadata does not emit evaluator/generation reasonCode for skipped status and ignores planner bridge', () => {
     const metadata = buildResponseMetadata(
         baseAssistantMetadata(),
         baseRuntimeContext({
@@ -765,18 +725,6 @@ test('buildResponseMetadata does not emit planner/evaluator/generation reasonCod
     );
 
     assert.deepEqual(metadata.execution, [
-        {
-            kind: 'planner',
-            status: 'skipped',
-            purpose: 'chat_orchestrator_action_selection',
-            contractType: 'fallback',
-            applyOutcome: 'not_applied',
-            mattered: false,
-            matteredControlIds: [],
-            profileId: 'openai-text-fast',
-            provider: 'openai',
-            model: 'gpt-5-nano',
-        },
         {
             kind: 'evaluator',
             status: 'skipped',

--- a/packages/contracts/src/ethics-core/executionFormatting.ts
+++ b/packages/contracts/src/ethics-core/executionFormatting.ts
@@ -5,7 +5,7 @@
  * @footnote-risk: low - Formatting mistakes may confuse operator visibility but do not affect runtime behavior.
  * @footnote-ethics: medium - Clear execution rendering supports transparency across user-facing surfaces.
  */
-import type { ExecutionEvent } from './types.js';
+import type { ExecutionEvent, StepRecord, WorkflowRecord } from './types.js';
 
 const formatEvaluatorSummary = (event: ExecutionEvent): string => {
     if (event.kind !== 'evaluator') {
@@ -87,15 +87,49 @@ const formatExecutionEvent = (event: ExecutionEvent): string => {
     return `${event.kind}:${modelOrProfile}(${event.status}${reasonSuffix}${durationSuffix})`;
 };
 
+const formatWorkflowPlannerStep = (step: StepRecord): string => {
+    const durationSuffix =
+        step.durationMs !== undefined ? `, ${step.durationMs}ms` : '';
+    const reasonSuffix =
+        step.outcome.status === 'executed' || !step.reasonCode
+            ? ''
+            : `, ${step.reasonCode}`;
+    const profileIdSignal = step.outcome.signals?.profileId;
+    const modelOrProfile =
+        step.model ??
+        (typeof profileIdSignal === 'string' &&
+        profileIdSignal.trim().length > 0
+            ? profileIdSignal
+            : 'workflow');
+    return `planner:${modelOrProfile}(${step.outcome.status}${reasonSuffix}${durationSuffix})`;
+};
+
 /**
  * Formats execution[] into a compact one-line summary.
  */
 export const formatExecutionTimelineSummary = (
-    execution: ExecutionEvent[] | undefined
+    execution: ExecutionEvent[] | undefined,
+    workflow?: WorkflowRecord
 ): string | null => {
-    if (!execution || execution.length === 0) {
+    const executionEvents = execution ?? [];
+    const executionIncludesPlanner = executionEvents.some(
+        (event) => event.kind === 'planner'
+    );
+    const workflowPlannerSummaries =
+        !executionIncludesPlanner && workflow !== undefined
+            ? workflow.steps
+                  .filter((step) => step.stepKind === 'plan')
+                  .map(formatWorkflowPlannerStep)
+            : [];
+    const executionSummaries = executionEvents.map(formatExecutionEvent);
+    const timelineSegments = [
+        ...workflowPlannerSummaries,
+        ...executionSummaries,
+    ];
+
+    if (timelineSegments.length === 0) {
         return null;
     }
 
-    return execution.map(formatExecutionEvent).join(' -> ');
+    return timelineSegments.join(' -> ');
 };

--- a/packages/contracts/src/ethics-core/executionFormatting.ts
+++ b/packages/contracts/src/ethics-core/executionFormatting.ts
@@ -112,16 +112,13 @@ export const formatExecutionTimelineSummary = (
     workflow?: WorkflowRecord
 ): string | null => {
     const executionEvents = execution ?? [];
-    const executionIncludesPlanner = executionEvents.some(
-        (event) => event.kind === 'planner'
-    );
     const workflowPlannerSummaries =
-        !executionIncludesPlanner && workflow !== undefined
-            ? workflow.steps
-                  .filter((step) => step.stepKind === 'plan')
-                  .map(formatWorkflowPlannerStep)
-            : [];
-    const executionSummaries = executionEvents.map(formatExecutionEvent);
+        workflow?.steps
+            .filter((step) => step.stepKind === 'plan')
+            .map(formatWorkflowPlannerStep) ?? [];
+    const executionSummaries = executionEvents
+        .filter((event) => event.kind !== 'planner')
+        .map(formatExecutionEvent);
     const timelineSegments = [
         ...workflowPlannerSummaries,
         ...executionSummaries,

--- a/packages/contracts/src/ethics-core/types.ts
+++ b/packages/contracts/src/ethics-core/types.ts
@@ -335,8 +335,8 @@ type ProfileExecutionEvent = BaseExecutionEvent & {
 
 export type PlannerExecutionEvent = ProfileExecutionEvent & {
     kind: 'planner';
-    // TODO(workflow-planner-step-alignment): If planner becomes a workflow
-    // native step, add correlation fields that map this event to step records.
+    // Legacy compatibility record. Prefer workflow `steps[]` with
+    // `stepKind=plan` when workflow lineage is available.
     purpose: PlannerExecutionPurpose;
     contractType: PlannerExecutionContractType;
     applyOutcome: PlannerExecutionApplyOutcome;
@@ -684,8 +684,8 @@ export type ResponseMetadata = {
     totalDurationMs?: number; // End-to-end orchestration duration when available.
     citations: Citation[]; // Sources used for the answer.
     provenanceAssessment?: ProvenanceAssessment; // Classification-method disclosure for provenance, including conflicts and limitations.
-    execution?: ExecutionEvent[]; // Structural execution record (planner/evaluator/tool/generation events).
-    workflow?: WorkflowRecord; // Optional workflow record of bounded multi-step execution.
+    execution?: ExecutionEvent[]; // Structural execution record; planner entries are compatibility fallback when workflow plan steps are unavailable.
+    workflow?: WorkflowRecord; // Optional workflow record of bounded multi-step execution; includes authoritative planner lineage when plan steps are present.
     workflowMode?: WorkflowModeDecision; // Execution-policy routing decision and behavior mapping.
     steerabilityControls?: SteerabilityControls; // Control-influence records explaining which controls shaped execution/output.
     evaluator?: EvaluatorOutcome; // Deterministic evaluator decision captured before breaker enforcement.

--- a/packages/contracts/src/ethics-core/types.ts
+++ b/packages/contracts/src/ethics-core/types.ts
@@ -335,8 +335,8 @@ type ProfileExecutionEvent = BaseExecutionEvent & {
 
 export type PlannerExecutionEvent = ProfileExecutionEvent & {
     kind: 'planner';
-    // Legacy compatibility record. Prefer workflow `steps[]` with
-    // `stepKind=plan` when workflow lineage is available.
+    // Deprecated in runtime emission. Planner lineage is represented by
+    // workflow `steps[]` with `stepKind=plan`.
     purpose: PlannerExecutionPurpose;
     contractType: PlannerExecutionContractType;
     applyOutcome: PlannerExecutionApplyOutcome;
@@ -684,8 +684,8 @@ export type ResponseMetadata = {
     totalDurationMs?: number; // End-to-end orchestration duration when available.
     citations: Citation[]; // Sources used for the answer.
     provenanceAssessment?: ProvenanceAssessment; // Classification-method disclosure for provenance, including conflicts and limitations.
-    execution?: ExecutionEvent[]; // Structural execution record; planner entries are compatibility fallback when workflow plan steps are unavailable.
-    workflow?: WorkflowRecord; // Optional workflow record of bounded multi-step execution; includes authoritative planner lineage when plan steps are present.
+    execution?: ExecutionEvent[]; // Structural execution record (evaluator/tool/generation events).
+    workflow?: WorkflowRecord; // Optional workflow record of bounded multi-step execution; includes planner lineage via plan steps.
     workflowMode?: WorkflowModeDecision; // Execution-policy routing decision and behavior mapping.
     steerabilityControls?: SteerabilityControls; // Control-influence records explaining which controls shaped execution/output.
     evaluator?: EvaluatorOutcome; // Deterministic evaluator decision captured before breaker enforcement.

--- a/packages/contracts/src/web/schemas.ts
+++ b/packages/contracts/src/web/schemas.ts
@@ -817,8 +817,8 @@ const TraceCardChipDataSchema = z
  * - Treat workflowMode as execution-policy metadata.
  * - Treat TRACE fields (`trace_target`, `trace_final`, optional chips) as
  *   answer-posture metadata.
- * - Treat planner influence as `execution[]` planner events (`kind=planner`,
- *   `applyOutcome`, `mattered`, `matteredControlIds`).
+ * - Treat planner influence as workflow `steps[]` with `stepKind=plan` when
+ *   present; use `execution[]` planner events as legacy compatibility fallback.
  * - Treat steerabilityControls as control-influence records.
  * - Treat provenance/provenanceAssessment as compact grounding
  *   classification-method metadata, not complete execution truth.

--- a/packages/contracts/src/web/schemas.ts
+++ b/packages/contracts/src/web/schemas.ts
@@ -817,8 +817,7 @@ const TraceCardChipDataSchema = z
  * - Treat workflowMode as execution-policy metadata.
  * - Treat TRACE fields (`trace_target`, `trace_final`, optional chips) as
  *   answer-posture metadata.
- * - Treat planner influence as workflow `steps[]` with `stepKind=plan` when
- *   present; use `execution[]` planner events as legacy compatibility fallback.
+ * - Treat planner influence as workflow `steps[]` with `stepKind=plan`.
  * - Treat steerabilityControls as control-influence records.
  * - Treat provenance/provenanceAssessment as compact grounding
  *   classification-method metadata, not complete execution truth.

--- a/packages/contracts/test/executionFormatting.test.ts
+++ b/packages/contracts/test/executionFormatting.test.ts
@@ -161,3 +161,59 @@ test('formatExecutionTimelineSummary returns null for missing or empty timelines
     assert.equal(formatExecutionTimelineSummary(undefined), null);
     assert.equal(formatExecutionTimelineSummary([]), null);
 });
+
+test('formatExecutionTimelineSummary surfaces planner lineage from workflow plan steps when execution planner bridge is absent', () => {
+    const summary = formatExecutionTimelineSummary(
+        [
+            {
+                kind: 'generation',
+                status: 'executed',
+                model: 'gpt-5-mini',
+            },
+        ],
+        {
+            workflowId: 'wf_1',
+            workflowName: 'message_with_review_loop',
+            status: 'completed',
+            terminationReason: 'goal_satisfied',
+            stepCount: 2,
+            maxSteps: 3,
+            maxDurationMs: 15000,
+            steps: [
+                {
+                    stepId: 'step_plan_1',
+                    attempt: 1,
+                    stepKind: 'plan',
+                    startedAt: '2026-04-01T00:00:00.000Z',
+                    finishedAt: '2026-04-01T00:00:00.010Z',
+                    durationMs: 10,
+                    outcome: {
+                        status: 'executed',
+                        summary:
+                            'Planner step emitted bounded action-selection summary.',
+                        signals: {
+                            profileId: 'openai-text-fast',
+                        },
+                    },
+                },
+                {
+                    stepId: 'step_1',
+                    attempt: 1,
+                    stepKind: 'generate',
+                    startedAt: '2026-04-01T00:00:00.010Z',
+                    finishedAt: '2026-04-01T00:00:00.020Z',
+                    durationMs: 10,
+                    outcome: {
+                        status: 'executed',
+                        summary: 'Generated initial draft response.',
+                    },
+                },
+            ],
+        }
+    );
+
+    assert.equal(
+        summary,
+        'planner:openai-text-fast(executed, 10ms) -> generation:gpt-5-mini(executed)'
+    );
+});

--- a/packages/contracts/test/executionFormatting.test.ts
+++ b/packages/contracts/test/executionFormatting.test.ts
@@ -15,50 +15,57 @@ import {
 } from '../src/ethics-core';
 
 test('formatExecutionTimelineSummary includes reasonCode for skipped and failed events', () => {
-    const summary = formatExecutionTimelineSummary([
+    const summary = formatExecutionTimelineSummary(
+        [
+            {
+                kind: 'tool',
+                status: 'skipped',
+                toolName: 'web_search',
+                reasonCode: 'search_not_supported_by_selected_profile',
+                durationMs: 5,
+            },
+            {
+                kind: 'generation',
+                status: 'executed',
+                model: 'gpt-5-mini',
+                durationMs: 22,
+            },
+        ],
         {
-            kind: 'planner',
-            status: 'failed',
-            purpose: 'chat_orchestrator_action_selection',
-            contractType: 'fallback',
-            applyOutcome: 'not_applied',
-            mattered: false,
-            matteredControlIds: [],
-            reasonCode: 'planner_runtime_error',
-            model: 'gpt-5-nano',
-        },
-        {
-            kind: 'tool',
-            status: 'skipped',
-            toolName: 'web_search',
-            reasonCode: 'search_not_supported_by_selected_profile',
-            durationMs: 5,
-        },
-        {
-            kind: 'generation',
-            status: 'executed',
-            model: 'gpt-5-mini',
-            durationMs: 22,
-        },
-    ]);
+            workflowId: 'wf_1',
+            workflowName: 'message_with_review_loop',
+            status: 'degraded',
+            terminationReason: 'goal_satisfied',
+            stepCount: 1,
+            maxSteps: 3,
+            maxDurationMs: 15000,
+            steps: [
+                {
+                    stepId: 'step_plan_1',
+                    attempt: 1,
+                    stepKind: 'plan',
+                    reasonCode: 'planner_runtime_error',
+                    startedAt: '2026-04-01T00:00:00.000Z',
+                    finishedAt: '2026-04-01T00:00:00.010Z',
+                    durationMs: 10,
+                    model: 'gpt-5-nano',
+                    outcome: {
+                        status: 'failed',
+                        summary: 'Planner step failed.',
+                    },
+                },
+            ],
+        }
+    );
 
     assert.equal(
         summary,
-        'planner:gpt-5-nano(failed, planner_runtime_error) -> tool:web_search(skipped, search_not_supported_by_selected_profile, 5ms) -> generation:gpt-5-mini(executed, 22ms)'
+        'planner:gpt-5-nano(failed, planner_runtime_error, 10ms) -> tool:web_search(skipped, search_not_supported_by_selected_profile, 5ms) -> generation:gpt-5-mini(executed, 22ms)'
     );
 });
 
 test('formatExecutionTimelineSummary handles missing optional fields', () => {
     const events: ExecutionEvent[] = [
-        {
-            kind: 'planner',
-            status: 'executed',
-            purpose: 'chat_orchestrator_action_selection',
-            contractType: 'text_json',
-            applyOutcome: 'applied',
-            mattered: false,
-            matteredControlIds: [],
-        },
         {
             kind: 'evaluator',
             status: 'executed',
@@ -85,8 +92,31 @@ test('formatExecutionTimelineSummary handles missing optional fields', () => {
     ];
 
     assert.equal(
-        formatExecutionTimelineSummary(events),
-        'planner:unknown(executed) -> evaluator:observe/Low/Inferred/allow(executed) -> tool:web_search(executed) -> generation:unknown(executed)'
+        formatExecutionTimelineSummary(events, {
+            workflowId: 'wf_2',
+            workflowName: 'message_with_review_loop',
+            status: 'completed',
+            terminationReason: 'goal_satisfied',
+            stepCount: 1,
+            maxSteps: 3,
+            maxDurationMs: 15000,
+            steps: [
+                {
+                    stepId: 'step_plan_1',
+                    attempt: 1,
+                    stepKind: 'plan',
+                    startedAt: '2026-04-01T00:00:00.000Z',
+                    finishedAt: '2026-04-01T00:00:00.010Z',
+                    durationMs: 10,
+                    outcome: {
+                        status: 'executed',
+                        summary:
+                            'Planner step emitted bounded action-selection summary.',
+                    },
+                },
+            ],
+        }),
+        'planner:workflow(executed, 10ms) -> evaluator:observe/Low/Inferred/allow(executed) -> tool:web_search(executed) -> generation:unknown(executed)'
     );
 });
 
@@ -160,6 +190,28 @@ test('formatExecutionTimelineSummary falls back to decision label for malformed 
 test('formatExecutionTimelineSummary returns null for missing or empty timelines', () => {
     assert.equal(formatExecutionTimelineSummary(undefined), null);
     assert.equal(formatExecutionTimelineSummary([]), null);
+});
+
+test('formatExecutionTimelineSummary ignores legacy planner execution events', () => {
+    const summary = formatExecutionTimelineSummary([
+        {
+            kind: 'planner',
+            status: 'executed',
+            purpose: 'chat_orchestrator_action_selection',
+            contractType: 'text_json',
+            applyOutcome: 'applied',
+            mattered: false,
+            matteredControlIds: [],
+            model: 'gpt-5-nano',
+        },
+        {
+            kind: 'generation',
+            status: 'executed',
+            model: 'gpt-5-mini',
+        },
+    ]);
+
+    assert.equal(summary, 'generation:gpt-5-mini(executed)');
 });
 
 test('formatExecutionTimelineSummary surfaces planner lineage from workflow plan steps when execution planner bridge is absent', () => {

--- a/packages/discord-bot/src/interactions/button/provenanceButtons.ts
+++ b/packages/discord-bot/src/interactions/button/provenanceButtons.ts
@@ -358,7 +358,10 @@ function formatExecutionSection(
     }
 
     const lines = ['**Execution**'];
-    const summary = formatExecutionTimelineSummary(payload.execution);
+    const summary = formatExecutionTimelineSummary(
+        payload.execution,
+        payload.workflow
+    );
     if (summary) {
         lines.push(`- Timeline: \`${formatMarkdownValue(summary, 180)}\``);
     } else {

--- a/packages/web/src/components/ProvenanceFooter.tsx
+++ b/packages/web/src/components/ProvenanceFooter.tsx
@@ -74,7 +74,10 @@ const ProvenanceFooter = ({
             }
         });
     }
-    const executionSummary = formatExecutionTimelineSummary(metadata.execution);
+    const executionSummary = formatExecutionTimelineSummary(
+        metadata.execution,
+        metadata.workflow
+    );
     const evaluatorOutcome = metadata.evaluator;
     const searchUnavailableWarning = metadata.execution?.some(
         (event) =>

--- a/packages/web/src/pages/TracePage.tsx
+++ b/packages/web/src/pages/TracePage.tsx
@@ -73,7 +73,7 @@ const resolveTraceModelLabel = (traceData: ServerMetadata): string => {
 };
 
 const resolveExecutionSummary = (traceData: ServerMetadata): string | null =>
-    formatExecutionTimelineSummary(traceData.execution);
+    formatExecutionTimelineSummary(traceData.execution, traceData.workflow);
 
 const buildDisplayTrace = (traceData: ServerMetadata): DisplayTrace => ({
     responseId: traceData.responseId ?? null,


### PR DESCRIPTION
## Summary
Make workflow lineage the single planner lineage surface by removing the old planner bridge from `metadata.execution[]` and keeping planner visibility sourced from `workflow.steps` (`stepKind=plan`).

## What Changed
- Injected planner lineage into workflow records for bounded-review runs when missing, so planner visibility is carried by `workflow.steps`.
- Removed planner event emission from `response.metadata.execution[]` in backend metadata assembly.
- Updated timeline formatting to derive planner timeline entries from workflow `plan` steps and ignore legacy planner execution events.
- Updated trace/provenance renderers (web + Discord) to pass workflow metadata into timeline formatting.
- Cleaned bridge-era comments/docs to reflect workflow-owned planner lineage.
- Updated backend/contracts tests to assert workflow-only planner lineage behavior and non-duplication.

## Why
The task context required ending the long-term dual representation of planner lineage. Planner is a bounded action-selection helper, while workflow owns sequencing and lineage. Keeping both `workflow.steps` and `metadata.execution[]` as planner sources creates conflicting trace narratives; this change makes one authoritative source.

## Important Implementation Details
- Planner lineage is now represented by workflow `plan` step records (including planner status/reason/apply outcome signals).
- `metadata.execution[]` remains for evaluator/tool/generation events only.
- Formatter behavior now treats workflow `plan` steps as planner timeline input; legacy planner execution events are ignored.
- No planner behavior, replanning logic, TrustGraph behavior, or runtime/provider architecture was changed.
- Validation run in-branch:
  - `pnpm lint:fix`
  - `pnpm lint`
  - `pnpm review`

This PR was written using [Vibe Kanban](https://vibekanban.com)
