### PR TITLE
Refocus web /about as public product page and align setup/about naming (Vibe Kanban)

### DIFF
--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -13,11 +13,11 @@ import Services from '@components/Services';
 import OpenAccountable from '@components/OpenAccountable';
 import Footer from '@components/Footer';
 import TracePage from '@pages/TracePage';
-import InvitePage from '@pages/InvitePage';
+import SetupPage from '@pages/SetupPage';
 import BlogListPage from '@pages/BlogListPage';
 import BlogPostPage from '@pages/BlogPostPage';
 import EmbedPage from '@pages/EmbedPage';
-import GuidePage from '@pages/GuidePage';
+import AboutPage from '@pages/AboutPage';
 
 // The App component stitches together the landing page sections in their intended scroll order.
 const App = (): JSX.Element => (
@@ -44,10 +44,10 @@ const App = (): JSX.Element => (
                     </main>
                 }
             />
-            <Route path="/setup" element={<InvitePage />} />
-            <Route path="/setup/" element={<InvitePage />} />
-            <Route path="/about" element={<GuidePage />} />
-            <Route path="/about/" element={<GuidePage />} />
+            <Route path="/setup" element={<SetupPage />} />
+            <Route path="/setup/" element={<SetupPage />} />
+            <Route path="/about" element={<AboutPage />} />
+            <Route path="/about/" element={<AboutPage />} />
             <Route path="/embed" element={<EmbedPage />} />
             <Route path="/blog" element={<BlogListPage />} />
             <Route path="/blog/" element={<BlogListPage />} />

--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -44,10 +44,10 @@ const App = (): JSX.Element => (
                     </main>
                 }
             />
-            <Route path="/invite" element={<InvitePage />} />
-            <Route path="/invite/" element={<InvitePage />} />
-            <Route path="/guide" element={<GuidePage />} />
-            <Route path="/guide/" element={<GuidePage />} />
+            <Route path="/setup" element={<InvitePage />} />
+            <Route path="/setup/" element={<InvitePage />} />
+            <Route path="/about" element={<GuidePage />} />
+            <Route path="/about/" element={<GuidePage />} />
             <Route path="/embed" element={<EmbedPage />} />
             <Route path="/blog" element={<BlogListPage />} />
             <Route path="/blog/" element={<BlogListPage />} />

--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -17,6 +17,7 @@ import InvitePage from '@pages/InvitePage';
 import BlogListPage from '@pages/BlogListPage';
 import BlogPostPage from '@pages/BlogPostPage';
 import EmbedPage from '@pages/EmbedPage';
+import GuidePage from '@pages/GuidePage';
 
 // The App component stitches together the landing page sections in their intended scroll order.
 const App = (): JSX.Element => (
@@ -45,6 +46,8 @@ const App = (): JSX.Element => (
             />
             <Route path="/invite" element={<InvitePage />} />
             <Route path="/invite/" element={<InvitePage />} />
+            <Route path="/guide" element={<GuidePage />} />
+            <Route path="/guide/" element={<GuidePage />} />
             <Route path="/embed" element={<EmbedPage />} />
             <Route path="/blog" element={<BlogListPage />} />
             <Route path="/blog/" element={<BlogListPage />} />

--- a/packages/web/src/components/Breadcrumb.tsx
+++ b/packages/web/src/components/Breadcrumb.tsx
@@ -7,7 +7,7 @@
  */
 
 /**
- * Breadcrumb component displays navigation trail for blog and invite pages.
+ * Breadcrumb component displays navigation trail for blog and standalone pages.
  * Shows current page and provides links back to parent pages and home.
  */
 import { Link } from 'react-router-dom';

--- a/packages/web/src/components/Header.tsx
+++ b/packages/web/src/components/Header.tsx
@@ -30,6 +30,9 @@ const Header = ({ breadcrumbItems }: HeaderProps): JSX.Element => {
     // Hide Setup button on setup/invite page
     const showSetupButton = !pathname.startsWith('/invite');
 
+    // Hide Guide button on guide page
+    const showGuideButton = !pathname.startsWith('/guide');
+
     // Hide Blog button on blog pages
     const showBlogButton = !pathname.startsWith('/blog');
 
@@ -46,6 +49,31 @@ const Header = ({ breadcrumbItems }: HeaderProps): JSX.Element => {
                     <Breadcrumb items={breadcrumbItems} />
                 </div>
                 <div className="site-header-actions">
+                    {showGuideButton && (
+                        <a
+                            className="header-button secondary"
+                            href="/guide"
+                            {...(pathname === '/embed'
+                                ? {
+                                      target: '_blank',
+                                      rel: 'noopener noreferrer',
+                                  }
+                                : {})}
+                            aria-label={
+                                pathname === '/embed'
+                                    ? 'Guide (opens in new tab)'
+                                    : 'Guide'
+                            }
+                        >
+                            Guide
+                            {pathname === '/embed' && (
+                                <>
+                                    {' '}
+                                    <span aria-hidden="true">↗</span>
+                                </>
+                            )}
+                        </a>
+                    )}
                     {showSetupButton && (
                         <a
                             className="header-button secondary"

--- a/packages/web/src/components/Header.tsx
+++ b/packages/web/src/components/Header.tsx
@@ -27,11 +27,11 @@ const Header = ({ breadcrumbItems }: HeaderProps): JSX.Element => {
     const location = useLocation();
     const pathname = location.pathname;
 
-    // Hide Setup button on setup/invite page
-    const showSetupButton = !pathname.startsWith('/invite');
+    // Hide Setup button on setup page
+    const showSetupButton = !pathname.startsWith('/setup');
 
-    // Hide Guide button on guide page
-    const showGuideButton = !pathname.startsWith('/guide');
+    // Hide About button on about page
+    const showAboutButton = !pathname.startsWith('/about');
 
     // Hide Blog button on blog pages
     const showBlogButton = !pathname.startsWith('/blog');
@@ -49,10 +49,10 @@ const Header = ({ breadcrumbItems }: HeaderProps): JSX.Element => {
                     <Breadcrumb items={breadcrumbItems} />
                 </div>
                 <div className="site-header-actions">
-                    {showGuideButton && (
+                    {showAboutButton && (
                         <a
                             className="header-button secondary"
-                            href="/guide"
+                            href="/about"
                             {...(pathname === '/embed'
                                 ? {
                                       target: '_blank',
@@ -61,11 +61,11 @@ const Header = ({ breadcrumbItems }: HeaderProps): JSX.Element => {
                                 : {})}
                             aria-label={
                                 pathname === '/embed'
-                                    ? 'Guide (opens in new tab)'
-                                    : 'Guide'
+                                    ? 'About (opens in new tab)'
+                                    : 'About'
                             }
                         >
-                            Guide
+                            About
                             {pathname === '/embed' && (
                                 <>
                                     {' '}
@@ -77,7 +77,7 @@ const Header = ({ breadcrumbItems }: HeaderProps): JSX.Element => {
                     {showSetupButton && (
                         <a
                             className="header-button secondary"
-                            href="/invite/"
+                            href="/setup/"
                             {...(pathname === '/embed'
                                 ? {
                                       target: '_blank',

--- a/packages/web/src/components/Hero.tsx
+++ b/packages/web/src/components/Hero.tsx
@@ -122,7 +122,7 @@ const Hero = (): JSX.Element => {
                                         <code>pnpm dev</code>
                                     </li>
                                 </ol>
-                                <a href="/invite/" className="inline-cta">
+                                <a href="/setup/" className="inline-cta">
                                     Full setup guide
                                     <span aria-hidden="true">↗</span>
                                 </a>

--- a/packages/web/src/components/Invite.tsx
+++ b/packages/web/src/components/Invite.tsx
@@ -43,7 +43,7 @@ const Invite = (): JSX.Element => (
         </div>
         <a
             className="inline-cta"
-            href="/invite/"
+            href="/setup/"
             aria-label="View setup instructions"
         >
             <span aria-hidden="true">🛠</span> Open Setup Guide

--- a/packages/web/src/components/OpenAccountable.tsx
+++ b/packages/web/src/components/OpenAccountable.tsx
@@ -33,7 +33,7 @@ const PRINCIPLES: Principle[] = [
         description:
             'Keep control of credentials, runtime, and policy boundaries in your own environment.',
         link: {
-            href: '/invite/',
+            href: '/setup/',
             label: 'Quickstart setup',
         },
     },

--- a/packages/web/src/components/OpenPhilosophy.tsx
+++ b/packages/web/src/components/OpenPhilosophy.tsx
@@ -38,7 +38,7 @@ const OpenPhilosophy = (): JSX.Element => (
                 <div className="cta-group" aria-label="Primary actions">
                     <a
                         className="cta-button primary"
-                        href="/invite/"
+                        href="/setup/"
                         aria-label="View setup guide"
                     >
                         Setup Guide <span aria-hidden="true">↗</span>

--- a/packages/web/src/pages/AboutPage.tsx
+++ b/packages/web/src/pages/AboutPage.tsx
@@ -2,7 +2,7 @@
  * @description: Renders the Footnote engineering guide for contributors who
  * need a quick, current map of the repo and runtime.
  * @footnote-scope: web
- * @footnote-module: GuidePage
+ * @footnote-module: AboutPage
  * @footnote-risk: low - Incorrect guide copy can mislead contributors about package ownership and request flow.
  * @footnote-ethics: medium - This page shapes contributor understanding of provenance, trace, and backend-owned controls.
  */
@@ -154,7 +154,7 @@ const renderFlowStep = (title: string, body: ReactNode): JSX.Element => (
     </li>
 );
 
-const GuidePage = (): JSX.Element => (
+const AboutPage = (): JSX.Element => (
     <>
         <Header breadcrumbItems={breadcrumbItems} />
         <main className="guide-page" id="main-content">
@@ -435,4 +435,4 @@ const GuidePage = (): JSX.Element => (
     </>
 );
 
-export default GuidePage;
+export default AboutPage;

--- a/packages/web/src/pages/AboutPage.tsx
+++ b/packages/web/src/pages/AboutPage.tsx
@@ -1,176 +1,111 @@
 /**
- * @description: Renders the Footnote engineering guide for contributors who
- * need a quick, current map of the repo and runtime.
+ * @description: Renders the public About page for Footnote with a plain
+ * explanation of what the project is, what it shows, and where to go next.
  * @footnote-scope: web
  * @footnote-module: AboutPage
- * @footnote-risk: low - Incorrect guide copy can mislead contributors about package ownership and request flow.
- * @footnote-ethics: medium - This page shapes contributor understanding of provenance, trace, and backend-owned controls.
+ * @footnote-risk: low - Inaccurate copy can misstate what the product shows or overstate project guarantees.
+ * @footnote-ethics: medium - This page shapes user expectations about transparency, review, and self-hosting limits.
  */
 
-import type { ReactNode } from 'react';
 import Header from '@components/Header';
 import Footer from '@components/Footer';
 
-type GuideSectionId =
-    | 'what-footnote-is'
-    | 'repo-map'
-    | 'request-flow'
-    | 'runtime-boundaries'
-    | 'workflow-planner-trace'
-    | 'trustgraph'
-    | 'current-migrations'
-    | 'common-mistakes'
-    | 'further-reading';
+type AboutSectionId =
+    | 'why-footnote-exists'
+    | 'reading-a-response'
+    | 'what-a-trace-is'
+    | 'open-source-and-self-hosting'
+    | 'what-we-are-careful-about'
+    | 'developers';
 
-type GuideJumpLink = {
-    id: GuideSectionId;
+type SectionLink = {
+    id: AboutSectionId;
     label: string;
 };
 
-type RepoMapEntry = {
-    name: string;
-    description: string;
-};
-
-type ReadingLink = {
+type DeveloperLink = {
     href: string;
     label: string;
-    description: string;
 };
 
-const breadcrumbItems = [{ label: 'Engineering Guide' }];
+const breadcrumbItems = [{ label: 'About' }];
 
-const guideJumpLinks: GuideJumpLink[] = [
-    { id: 'what-footnote-is', label: 'What Footnote is' },
-    { id: 'repo-map', label: 'Repo map' },
-    { id: 'request-flow', label: 'Request flow' },
-    { id: 'runtime-boundaries', label: 'Runtime boundaries' },
-    { id: 'workflow-planner-trace', label: 'Workflow, planner, and trace' },
-    { id: 'trustgraph', label: 'TrustGraph' },
-    { id: 'current-migrations', label: 'Current migrations' },
-    { id: 'common-mistakes', label: 'Common mistakes' },
-    { id: 'further-reading', label: 'Further reading' },
-];
-
-const repoMapEntries: RepoMapEntry[] = [
+const sectionLinks: SectionLink[] = [
+    { id: 'why-footnote-exists', label: 'Why Footnote exists' },
+    { id: 'reading-a-response', label: 'Reading a response' },
+    { id: 'what-a-trace-is', label: 'What a trace is' },
     {
-        name: 'packages/backend',
-        description:
-            'Main runtime. Owns request routing, planner and workflow decisions, prompt assembly, traces, incidents, and cost records.',
+        id: 'open-source-and-self-hosting',
+        label: 'Open source and self-hosting',
     },
     {
-        name: 'packages/agent-runtime',
-        description:
-            'Provider adapter layer. Translates Footnote generation requests to vendor runtimes and returns normalized results.',
+        id: 'what-we-are-careful-about',
+        label: 'What we are careful about',
     },
-    {
-        name: 'packages/contracts',
-        description:
-            'Shared request, response, and metadata contracts. If you change shapes here, expect backend, web, and Discord to move with it.',
-    },
-    {
-        name: 'packages/api-client',
-        description:
-            'Typed client helpers for calling Footnote APIs from other packages.',
-    },
-    {
-        name: 'packages/web',
-        description:
-            'Browser app. Renders chat, traces, blog, and setup pages. It calls backend APIs and does not own generation rules.',
-    },
-    {
-        name: 'packages/discord-bot',
-        description:
-            'Discord surface for chat, commands, and voice. It uses backend-owned APIs instead of making product decisions on the edge.',
-    },
-    {
-        name: 'packages/prompts',
-        description:
-            'Shared prompt assets and registry code. Use this package when a prompt change must stay aligned across runtimes.',
-    },
-    {
-        name: 'docs',
-        description:
-            'Architecture notes, decision records, and status docs. Start with the architecture reading guide, then check status notes for rollout context.',
-    },
+    { id: 'developers', label: 'Developers and contributors' },
 ];
 
 const repoBaseUrl = 'https://github.com/footnote-ai/footnote/blob/main';
 
-const furtherReadingLinks: ReadingLink[] = [
+const developerLinks: DeveloperLink[] = [
     {
         href: `${repoBaseUrl}/README.md`,
         label: 'README',
-        description:
-            'Start here for local setup and the top-level product summary.',
+    },
+    {
+        href: `${repoBaseUrl}/docs/README.md`,
+        label: 'Docs',
     },
     {
         href: `${repoBaseUrl}/docs/architecture/README.md`,
-        label: 'Architecture reading guide',
-        description:
-            'Best first stop for current architecture docs and the recommended reading order.',
+        label: 'Architecture docs',
     },
     {
-        href: `${repoBaseUrl}/docs/architecture/execution-contract-authority-map.md`,
-        label: 'Execution Contract authority map',
-        description: 'Shows which part owns each decision in chat execution.',
-    },
-    {
-        href: `${repoBaseUrl}/docs/architecture/workflow-mode-routing.md`,
-        label: 'Workflow mode routing',
-        description:
-            'Explains how fast, balanced, and grounded modes map to runtime behavior.',
-    },
-    {
-        href: `${repoBaseUrl}/docs/architecture/workflow-engine-and-provenance.md`,
-        label: 'Workflow engine and provenance',
-        description:
-            'Covers the reviewed workflow path and the records it emits.',
-    },
-    {
-        href: `${repoBaseUrl}/docs/architecture/execution_contract_trustgraph/architecture.md`,
-        label: 'TrustGraph architecture',
-        description:
-            'Detailed TrustGraph seam rules, constraints, and rollout guardrails.',
-    },
-    {
-        href: `${repoBaseUrl}/docs/status/2026-04-workflow-engine-rollout-status.md`,
-        label: 'Workflow engine rollout status',
-        description:
-            'Current rollout note for the workflow engine. Use it for current status, not first-pass architecture.',
+        href: `${repoBaseUrl}/AGENTS.md`,
+        label: 'AGENTS.md',
     },
     {
         href: `${repoBaseUrl}/docs/ai/README.md`,
         label: 'AI assistance guide',
-        description:
-            'Short contributor guide for using AI tools in this repo without drifting from project rules.',
+    },
+    {
+        href: `${repoBaseUrl}/deploy/README.md`,
+        label: 'Deploy docs',
     },
 ];
 
-const renderFlowStep = (title: string, body: ReactNode): JSX.Element => (
-    <li className="guide-flow__item">
-        <p className="guide-flow__title">{title}</p>
-        <p>{body}</p>
-    </li>
-);
+const responseDetails = [
+    'the answer itself',
+    'source links',
+    'confidence and safety notes',
+    'tradeoffs or constraints when they matter',
+    'a trace page with more detail about the run',
+] as const;
 
 const AboutPage = (): JSX.Element => (
     <>
         <Header breadcrumbItems={breadcrumbItems} />
-        <main className="guide-page" id="main-content">
-            <section className="guide-hero" aria-labelledby="guide-title">
-                <p className="guide-eyebrow">Engineering Guide</p>
-                <h1 id="guide-title">Footnote engineering guide</h1>
-                <p className="guide-summary">
-                    Footnote is a backend, web app, and Discord bot for AI
-                    responses you can inspect after the fact. The backend
-                    decides how a request runs, which workflow and model profile
-                    to use, which tools are allowed, and what trace data gets
-                    recorded.
+        <main className="about-page" id="main-content">
+            <section className="about-hero" aria-labelledby="about-title">
+                <p className="about-eyebrow">About</p>
+                <h1 id="about-title">See what is behind an answer</h1>
+                <p className="about-summary">
+                    Footnote is an AI assistant that helps you see what is
+                    behind an answer.
                 </p>
-                <nav className="guide-jump-nav" aria-label="Guide sections">
-                    <ul className="guide-jump-list">
-                        {guideJumpLinks.map((link) => (
+                <p>
+                    It gives you a response with receipts: source links,
+                    confidence and safety notes, and a trace page for digging
+                    deeper.
+                </p>
+                <p>
+                    This page explains why the project exists, what Footnote
+                    shows you, and where to go next if you want to run it or
+                    contribute to it.
+                </p>
+                <nav className="about-jump-nav" aria-label="About sections">
+                    <ul className="about-jump-list">
+                        {sectionLinks.map((link) => (
                             <li key={link.id}>
                                 <a href={`#${link.id}`}>{link.label}</a>
                             </li>
@@ -180,243 +115,120 @@ const AboutPage = (): JSX.Element => (
             </section>
 
             <section
-                className="guide-section"
-                id="what-footnote-is"
-                aria-labelledby="what-footnote-is-title"
+                className="about-section"
+                id="why-footnote-exists"
+                aria-labelledby="why-footnote-exists-title"
             >
-                <h2 id="what-footnote-is-title">What Footnote is</h2>
+                <h2 id="why-footnote-exists-title">Why Footnote exists</h2>
                 <p>
-                    The backend is the real executor. Models generate text, but
-                    the backend decides the rules around that generation:
-                    request normalization, planner use, workflow limits, tool
-                    access, trace recording, and response metadata.
+                    AI answers can sound more certain than they are. Footnote is
+                    built around a different habit: keep the answer connected to
+                    the context around it.
                 </p>
                 <p>
-                    That is the main repo habit to keep in mind. If a change is
-                    deciding what the system should do, it probably belongs in
-                    `packages/backend`, not in a provider adapter, the web app,
-                    or the Discord bot.
+                    The goal is not to make every answer automatically correct.
+                    The goal is to give people more to inspect before they
+                    decide what to do with the answer.
                 </p>
             </section>
 
             <section
-                className="guide-section"
-                id="repo-map"
-                aria-labelledby="repo-map-title"
+                className="about-section"
+                id="reading-a-response"
+                aria-labelledby="reading-a-response-title"
             >
-                <h2 id="repo-map-title">Repo map</h2>
-                <dl className="guide-map">
-                    {repoMapEntries.map((entry) => (
-                        <div className="guide-map__row" key={entry.name}>
-                            <dt>{entry.name}</dt>
-                            <dd>{entry.description}</dd>
-                        </div>
+                <h2 id="reading-a-response-title">Reading a response</h2>
+                <p>
+                    A Footnote response can include a few layers of context
+                    alongside the answer.
+                </p>
+                <ul className="about-list">
+                    {responseDetails.map((detail) => (
+                        <li key={detail}>{detail}</li>
                     ))}
-                </dl>
-            </section>
-
-            <section
-                className="guide-section"
-                id="request-flow"
-                aria-labelledby="request-flow-title"
-            >
-                <h2 id="request-flow-title">Request flow</h2>
-                <ol className="guide-flow">
-                    {renderFlowStep(
-                        '1. Request enters backend',
-                        <>
-                            `server.ts` boots services. `handlers/chat.ts`
-                            handles HTTP concerns such as auth, rate limiting,
-                            and request normalization.
-                        </>
-                    )}
-                    {renderFlowStep(
-                        '2. Orchestrator decides the run',
-                        <>
-                            `chatOrchestrator.ts` applies safety checks, planner
-                            output, profile overlays, tool rules, and runtime
-                            routing before handing off execution.
-                        </>
-                    )}
-                    {renderFlowStep(
-                        '3. Chat service executes',
-                        <>
-                            `chatService.ts` builds the generation request, runs
-                            either direct generation or the workflow path,
-                            records usage and cost, and assembles public
-                            metadata.
-                        </>
-                    )}
-                    {renderFlowStep(
-                        '4. Provider runtime returns normalized output',
-                        <>
-                            `packages/agent-runtime` talks to provider APIs and
-                            returns citations and result data in Footnote-owned
-                            shapes.
-                        </>
-                    )}
-                    {renderFlowStep(
-                        '5. Trace is stored and rendered',
-                        <>
-                            The backend writes trace data. The web app later
-                            renders it on the trace page, and Discord can show a
-                            smaller provenance view inline.
-                        </>
-                    )}
-                </ol>
-            </section>
-
-            <section
-                className="guide-section"
-                id="runtime-boundaries"
-                aria-labelledby="runtime-boundaries-title"
-            >
-                <h2 id="runtime-boundaries-title">Runtime boundaries</h2>
-                <ul className="guide-list">
-                    <li>
-                        Backend owns policy, workflow legality, trace records,
-                        and cost recording.
-                    </li>
-                    <li>
-                        Provider adapters translate requests and responses. They
-                        should not decide product behavior.
-                    </li>
-                    <li>
-                        `packages/contracts` owns serializable public shapes.
-                        Treat contract edits as cross-package changes.
-                    </li>
-                    <li>
-                        Web and Discord are clients. They can choose
-                        presentation, but they should not replace backend
-                        decisions with local ones.
-                    </li>
                 </ul>
+                <p>
+                    The point is simple: if something feels uncertain, you
+                    should have more than a polished paragraph to work from.
+                </p>
             </section>
 
             <section
-                className="guide-section"
-                id="workflow-planner-trace"
-                aria-labelledby="workflow-planner-trace-title"
+                className="about-section"
+                id="what-a-trace-is"
+                aria-labelledby="what-a-trace-is-title"
             >
-                <h2 id="workflow-planner-trace-title">
-                    Workflow, planner, and trace
+                <h2 id="what-a-trace-is-title">What a trace is</h2>
+                <p>
+                    A trace is the receipt for a response. It collects the
+                    details Footnote recorded while answering: sources,
+                    model/runtime information, safety notes, and workflow
+                    details when they apply.
+                </p>
+                <p>
+                    A trace does not prove the answer is correct. It gives you
+                    something to inspect.
+                </p>
+            </section>
+
+            <section
+                className="about-section"
+                id="open-source-and-self-hosting"
+                aria-labelledby="open-source-and-self-hosting-title"
+            >
+                <h2 id="open-source-and-self-hosting-title">
+                    Open source and self-hosting
                 </h2>
                 <p>
-                    The current reviewed path is a bounded workflow loop. The
-                    main step pattern is `generate`, `assess`, and `revise`,
-                    with backend limits controlling step count, deliberation,
-                    and duration.
+                    Footnote is open source and built to run outside the hosted
+                    demo. You can try the browser demo, run your own copy from
+                    the repo, or self-host it with your own setup.
                 </p>
                 <p>
-                    The planner is still separate from the workflow engine in
-                    the main chat path. It runs before workflow execution and
-                    can suggest action details, but it does not get to change
-                    the backend rules.
-                </p>
-                <p>
-                    Trace data is a first-class output. The response metadata
-                    and stored trace should let you answer basic review
-                    questions later: which mode ran, which workflow profile was
-                    selected, which tools were used, and what evidence or
-                    citations were attached.
+                    That does not remove every external dependency by itself. If
+                    you use hosted model providers, their privacy and retention
+                    rules still matter.
                 </p>
             </section>
 
             <section
-                className="guide-section"
-                id="trustgraph"
-                aria-labelledby="trustgraph-title"
+                className="about-section"
+                id="what-we-are-careful-about"
+                aria-labelledby="what-we-are-careful-about-title"
             >
-                <h2 id="trustgraph-title">TrustGraph</h2>
-                <p>
-                    TrustGraph is an advisory evidence seam under backend
-                    control. It can add evidence and provenance detail, but it
-                    does not become the authority for routing or final output.
-                </p>
-                <ul className="guide-list">
+                <h2 id="what-we-are-careful-about-title">
+                    What we are careful about
+                </h2>
+                <ul className="about-list">
+                    <li>Inspectable does not mean always correct.</li>
+                    <li>Review signals do not guarantee answer quality.</li>
                     <li>
-                        Backend validates scope and ownership before using
-                        TrustGraph data.
+                        Self-hosting does not automatically put external model
+                        providers under your control.
                     </li>
                     <li>
-                        Retrieval and tenancy checks stay strict. User-facing
-                        continuity stays fail-open when external retrieval has a
-                        problem.
+                        TrustGraph stays advisory unless visible product output
+                        says otherwise.
                     </li>
                     <li>
-                        The mapping registry only allows registered TrustGraph
-                        fields to affect backend predicate views.
+                        Steerability should not be overclaimed before there are
+                        clearer user-facing controls.
                     </li>
                 </ul>
             </section>
 
             <section
-                className="guide-section"
-                id="current-migrations"
-                aria-labelledby="current-migrations-title"
+                className="about-section"
+                id="developers"
+                aria-labelledby="developers-title"
             >
-                <h2 id="current-migrations-title">Current migrations</h2>
-                <ul className="guide-list">
-                    <li>
-                        The active rollout note is the workflow engine rollout.
-                        The reviewed chat path now uses the shared engine shape,
-                        but planner-as-workflow-step and tool-step expansion are
-                        still open work.
-                    </li>
-                    <li>
-                        Legacy OpenAI removal is mostly a history topic now.
-                        Text, image, and voice have been moved behind backend or
-                        internal Footnote seams, but some cleanup debt and old
-                        naming still remain.
-                    </li>
-                    <li>
-                        Prompt and rule consolidation is already reflected in
-                        the repo layout: `packages/prompts` is the shared prompt
-                        home, and `AGENTS.md` is the canonical agent rule file.
-                    </li>
-                </ul>
-            </section>
-
-            <section
-                className="guide-section"
-                id="common-mistakes"
-                aria-labelledby="common-mistakes-title"
-            >
-                <h2 id="common-mistakes-title">Common mistakes</h2>
-                <ul className="guide-list">
-                    <li>
-                        Putting policy or routing logic in `packages/web`,
-                        `packages/discord-bot`, or provider adapters.
-                    </li>
-                    <li>
-                        Trusting a status note over the source when they
-                        disagree. Status docs help with rollout context, but the
-                        code is the final answer.
-                    </li>
-                    <li>
-                        Assuming planner output is already safe to use as-is.
-                        The backend still normalizes and bounds planner output.
-                    </li>
-                    <li>
-                        Trying to make every failure path identical. Some paths
-                        are intentionally fail-open for continuity, while scope
-                        and ownership checks stay strict.
-                    </li>
-                    <li>
-                        Changing shared contracts without checking every caller
-                        and trace surface that depends on them.
-                    </li>
-                </ul>
-            </section>
-
-            <section
-                className="guide-section"
-                id="further-reading"
-                aria-labelledby="further-reading-title"
-            >
-                <h2 id="further-reading-title">Further reading</h2>
-                <ul className="guide-links">
-                    {furtherReadingLinks.map((link) => (
+                <h2 id="developers-title">Developers and contributors</h2>
+                <p>
+                    If you want the architecture details or want to work in the
+                    repo, start with these.
+                </p>
+                <ul className="about-links">
+                    {developerLinks.map((link) => (
                         <li key={link.href}>
                             <a
                                 href={link.href}
@@ -425,7 +237,6 @@ const AboutPage = (): JSX.Element => (
                             >
                                 {link.label} <span aria-hidden="true">↗</span>
                             </a>
-                            <p>{link.description}</p>
                         </li>
                     ))}
                 </ul>

--- a/packages/web/src/pages/GuidePage.tsx
+++ b/packages/web/src/pages/GuidePage.tsx
@@ -1,0 +1,438 @@
+/**
+ * @description: Renders the Footnote engineering guide for contributors who
+ * need a quick, current map of the repo and runtime.
+ * @footnote-scope: web
+ * @footnote-module: GuidePage
+ * @footnote-risk: low - Incorrect guide copy can mislead contributors about package ownership and request flow.
+ * @footnote-ethics: medium - This page shapes contributor understanding of provenance, trace, and backend-owned controls.
+ */
+
+import type { ReactNode } from 'react';
+import Header from '@components/Header';
+import Footer from '@components/Footer';
+
+type GuideSectionId =
+    | 'what-footnote-is'
+    | 'repo-map'
+    | 'request-flow'
+    | 'runtime-boundaries'
+    | 'workflow-planner-trace'
+    | 'trustgraph'
+    | 'current-migrations'
+    | 'common-mistakes'
+    | 'further-reading';
+
+type GuideJumpLink = {
+    id: GuideSectionId;
+    label: string;
+};
+
+type RepoMapEntry = {
+    name: string;
+    description: string;
+};
+
+type ReadingLink = {
+    href: string;
+    label: string;
+    description: string;
+};
+
+const breadcrumbItems = [{ label: 'Engineering Guide' }];
+
+const guideJumpLinks: GuideJumpLink[] = [
+    { id: 'what-footnote-is', label: 'What Footnote is' },
+    { id: 'repo-map', label: 'Repo map' },
+    { id: 'request-flow', label: 'Request flow' },
+    { id: 'runtime-boundaries', label: 'Runtime boundaries' },
+    { id: 'workflow-planner-trace', label: 'Workflow, planner, and trace' },
+    { id: 'trustgraph', label: 'TrustGraph' },
+    { id: 'current-migrations', label: 'Current migrations' },
+    { id: 'common-mistakes', label: 'Common mistakes' },
+    { id: 'further-reading', label: 'Further reading' },
+];
+
+const repoMapEntries: RepoMapEntry[] = [
+    {
+        name: 'packages/backend',
+        description:
+            'Main runtime. Owns request routing, planner and workflow decisions, prompt assembly, traces, incidents, and cost records.',
+    },
+    {
+        name: 'packages/agent-runtime',
+        description:
+            'Provider adapter layer. Translates Footnote generation requests to vendor runtimes and returns normalized results.',
+    },
+    {
+        name: 'packages/contracts',
+        description:
+            'Shared request, response, and metadata contracts. If you change shapes here, expect backend, web, and Discord to move with it.',
+    },
+    {
+        name: 'packages/api-client',
+        description:
+            'Typed client helpers for calling Footnote APIs from other packages.',
+    },
+    {
+        name: 'packages/web',
+        description:
+            'Browser app. Renders chat, traces, blog, and setup pages. It calls backend APIs and does not own generation rules.',
+    },
+    {
+        name: 'packages/discord-bot',
+        description:
+            'Discord surface for chat, commands, and voice. It uses backend-owned APIs instead of making product decisions on the edge.',
+    },
+    {
+        name: 'packages/prompts',
+        description:
+            'Shared prompt assets and registry code. Use this package when a prompt change must stay aligned across runtimes.',
+    },
+    {
+        name: 'docs',
+        description:
+            'Architecture notes, decision records, and status docs. Start with the architecture reading guide, then check status notes for rollout context.',
+    },
+];
+
+const repoBaseUrl = 'https://github.com/footnote-ai/footnote/blob/main';
+
+const furtherReadingLinks: ReadingLink[] = [
+    {
+        href: `${repoBaseUrl}/README.md`,
+        label: 'README',
+        description:
+            'Start here for local setup and the top-level product summary.',
+    },
+    {
+        href: `${repoBaseUrl}/docs/architecture/README.md`,
+        label: 'Architecture reading guide',
+        description:
+            'Best first stop for current architecture docs and the recommended reading order.',
+    },
+    {
+        href: `${repoBaseUrl}/docs/architecture/execution-contract-authority-map.md`,
+        label: 'Execution Contract authority map',
+        description: 'Shows which part owns each decision in chat execution.',
+    },
+    {
+        href: `${repoBaseUrl}/docs/architecture/workflow-mode-routing.md`,
+        label: 'Workflow mode routing',
+        description:
+            'Explains how fast, balanced, and grounded modes map to runtime behavior.',
+    },
+    {
+        href: `${repoBaseUrl}/docs/architecture/workflow-engine-and-provenance.md`,
+        label: 'Workflow engine and provenance',
+        description:
+            'Covers the reviewed workflow path and the records it emits.',
+    },
+    {
+        href: `${repoBaseUrl}/docs/architecture/execution_contract_trustgraph/architecture.md`,
+        label: 'TrustGraph architecture',
+        description:
+            'Detailed TrustGraph seam rules, constraints, and rollout guardrails.',
+    },
+    {
+        href: `${repoBaseUrl}/docs/status/2026-04-workflow-engine-rollout-status.md`,
+        label: 'Workflow engine rollout status',
+        description:
+            'Current rollout note for the workflow engine. Use it for current status, not first-pass architecture.',
+    },
+    {
+        href: `${repoBaseUrl}/docs/ai/README.md`,
+        label: 'AI assistance guide',
+        description:
+            'Short contributor guide for using AI tools in this repo without drifting from project rules.',
+    },
+];
+
+const renderFlowStep = (title: string, body: ReactNode): JSX.Element => (
+    <li className="guide-flow__item">
+        <p className="guide-flow__title">{title}</p>
+        <p>{body}</p>
+    </li>
+);
+
+const GuidePage = (): JSX.Element => (
+    <>
+        <Header breadcrumbItems={breadcrumbItems} />
+        <main className="guide-page" id="main-content">
+            <section className="guide-hero" aria-labelledby="guide-title">
+                <p className="guide-eyebrow">Engineering Guide</p>
+                <h1 id="guide-title">Footnote engineering guide</h1>
+                <p className="guide-summary">
+                    Footnote is a backend, web app, and Discord bot for AI
+                    responses you can inspect after the fact. The backend
+                    decides how a request runs, which workflow and model profile
+                    to use, which tools are allowed, and what trace data gets
+                    recorded.
+                </p>
+                <nav className="guide-jump-nav" aria-label="Guide sections">
+                    <ul className="guide-jump-list">
+                        {guideJumpLinks.map((link) => (
+                            <li key={link.id}>
+                                <a href={`#${link.id}`}>{link.label}</a>
+                            </li>
+                        ))}
+                    </ul>
+                </nav>
+            </section>
+
+            <section
+                className="guide-section"
+                id="what-footnote-is"
+                aria-labelledby="what-footnote-is-title"
+            >
+                <h2 id="what-footnote-is-title">What Footnote is</h2>
+                <p>
+                    The backend is the real executor. Models generate text, but
+                    the backend decides the rules around that generation:
+                    request normalization, planner use, workflow limits, tool
+                    access, trace recording, and response metadata.
+                </p>
+                <p>
+                    That is the main repo habit to keep in mind. If a change is
+                    deciding what the system should do, it probably belongs in
+                    `packages/backend`, not in a provider adapter, the web app,
+                    or the Discord bot.
+                </p>
+            </section>
+
+            <section
+                className="guide-section"
+                id="repo-map"
+                aria-labelledby="repo-map-title"
+            >
+                <h2 id="repo-map-title">Repo map</h2>
+                <dl className="guide-map">
+                    {repoMapEntries.map((entry) => (
+                        <div className="guide-map__row" key={entry.name}>
+                            <dt>{entry.name}</dt>
+                            <dd>{entry.description}</dd>
+                        </div>
+                    ))}
+                </dl>
+            </section>
+
+            <section
+                className="guide-section"
+                id="request-flow"
+                aria-labelledby="request-flow-title"
+            >
+                <h2 id="request-flow-title">Request flow</h2>
+                <ol className="guide-flow">
+                    {renderFlowStep(
+                        '1. Request enters backend',
+                        <>
+                            `server.ts` boots services. `handlers/chat.ts`
+                            handles HTTP concerns such as auth, rate limiting,
+                            and request normalization.
+                        </>
+                    )}
+                    {renderFlowStep(
+                        '2. Orchestrator decides the run',
+                        <>
+                            `chatOrchestrator.ts` applies safety checks, planner
+                            output, profile overlays, tool rules, and runtime
+                            routing before handing off execution.
+                        </>
+                    )}
+                    {renderFlowStep(
+                        '3. Chat service executes',
+                        <>
+                            `chatService.ts` builds the generation request, runs
+                            either direct generation or the workflow path,
+                            records usage and cost, and assembles public
+                            metadata.
+                        </>
+                    )}
+                    {renderFlowStep(
+                        '4. Provider runtime returns normalized output',
+                        <>
+                            `packages/agent-runtime` talks to provider APIs and
+                            returns citations and result data in Footnote-owned
+                            shapes.
+                        </>
+                    )}
+                    {renderFlowStep(
+                        '5. Trace is stored and rendered',
+                        <>
+                            The backend writes trace data. The web app later
+                            renders it on the trace page, and Discord can show a
+                            smaller provenance view inline.
+                        </>
+                    )}
+                </ol>
+            </section>
+
+            <section
+                className="guide-section"
+                id="runtime-boundaries"
+                aria-labelledby="runtime-boundaries-title"
+            >
+                <h2 id="runtime-boundaries-title">Runtime boundaries</h2>
+                <ul className="guide-list">
+                    <li>
+                        Backend owns policy, workflow legality, trace records,
+                        and cost recording.
+                    </li>
+                    <li>
+                        Provider adapters translate requests and responses. They
+                        should not decide product behavior.
+                    </li>
+                    <li>
+                        `packages/contracts` owns serializable public shapes.
+                        Treat contract edits as cross-package changes.
+                    </li>
+                    <li>
+                        Web and Discord are clients. They can choose
+                        presentation, but they should not replace backend
+                        decisions with local ones.
+                    </li>
+                </ul>
+            </section>
+
+            <section
+                className="guide-section"
+                id="workflow-planner-trace"
+                aria-labelledby="workflow-planner-trace-title"
+            >
+                <h2 id="workflow-planner-trace-title">
+                    Workflow, planner, and trace
+                </h2>
+                <p>
+                    The current reviewed path is a bounded workflow loop. The
+                    main step pattern is `generate`, `assess`, and `revise`,
+                    with backend limits controlling step count, deliberation,
+                    and duration.
+                </p>
+                <p>
+                    The planner is still separate from the workflow engine in
+                    the main chat path. It runs before workflow execution and
+                    can suggest action details, but it does not get to change
+                    the backend rules.
+                </p>
+                <p>
+                    Trace data is a first-class output. The response metadata
+                    and stored trace should let you answer basic review
+                    questions later: which mode ran, which workflow profile was
+                    selected, which tools were used, and what evidence or
+                    citations were attached.
+                </p>
+            </section>
+
+            <section
+                className="guide-section"
+                id="trustgraph"
+                aria-labelledby="trustgraph-title"
+            >
+                <h2 id="trustgraph-title">TrustGraph</h2>
+                <p>
+                    TrustGraph is an advisory evidence seam under backend
+                    control. It can add evidence and provenance detail, but it
+                    does not become the authority for routing or final output.
+                </p>
+                <ul className="guide-list">
+                    <li>
+                        Backend validates scope and ownership before using
+                        TrustGraph data.
+                    </li>
+                    <li>
+                        Retrieval and tenancy checks stay strict. User-facing
+                        continuity stays fail-open when external retrieval has a
+                        problem.
+                    </li>
+                    <li>
+                        The mapping registry only allows registered TrustGraph
+                        fields to affect backend predicate views.
+                    </li>
+                </ul>
+            </section>
+
+            <section
+                className="guide-section"
+                id="current-migrations"
+                aria-labelledby="current-migrations-title"
+            >
+                <h2 id="current-migrations-title">Current migrations</h2>
+                <ul className="guide-list">
+                    <li>
+                        The active rollout note is the workflow engine rollout.
+                        The reviewed chat path now uses the shared engine shape,
+                        but planner-as-workflow-step and tool-step expansion are
+                        still open work.
+                    </li>
+                    <li>
+                        Legacy OpenAI removal is mostly a history topic now.
+                        Text, image, and voice have been moved behind backend or
+                        internal Footnote seams, but some cleanup debt and old
+                        naming still remain.
+                    </li>
+                    <li>
+                        Prompt and rule consolidation is already reflected in
+                        the repo layout: `packages/prompts` is the shared prompt
+                        home, and `AGENTS.md` is the canonical agent rule file.
+                    </li>
+                </ul>
+            </section>
+
+            <section
+                className="guide-section"
+                id="common-mistakes"
+                aria-labelledby="common-mistakes-title"
+            >
+                <h2 id="common-mistakes-title">Common mistakes</h2>
+                <ul className="guide-list">
+                    <li>
+                        Putting policy or routing logic in `packages/web`,
+                        `packages/discord-bot`, or provider adapters.
+                    </li>
+                    <li>
+                        Trusting a status note over the source when they
+                        disagree. Status docs help with rollout context, but the
+                        code is the final answer.
+                    </li>
+                    <li>
+                        Assuming planner output is already safe to use as-is.
+                        The backend still normalizes and bounds planner output.
+                    </li>
+                    <li>
+                        Trying to make every failure path identical. Some paths
+                        are intentionally fail-open for continuity, while scope
+                        and ownership checks stay strict.
+                    </li>
+                    <li>
+                        Changing shared contracts without checking every caller
+                        and trace surface that depends on them.
+                    </li>
+                </ul>
+            </section>
+
+            <section
+                className="guide-section"
+                id="further-reading"
+                aria-labelledby="further-reading-title"
+            >
+                <h2 id="further-reading-title">Further reading</h2>
+                <ul className="guide-links">
+                    {furtherReadingLinks.map((link) => (
+                        <li key={link.href}>
+                            <a
+                                href={link.href}
+                                target="_blank"
+                                rel="noreferrer"
+                            >
+                                {link.label} <span aria-hidden="true">↗</span>
+                            </a>
+                            <p>{link.description}</p>
+                        </li>
+                    ))}
+                </ul>
+            </section>
+        </main>
+        <Footer />
+    </>
+);
+
+export default GuidePage;

--- a/packages/web/src/pages/SetupPage.tsx
+++ b/packages/web/src/pages/SetupPage.tsx
@@ -47,7 +47,7 @@ const SetupPage: React.FC = () => {
         visible: false,
     });
 
-    // Breadcrumb items for invite page
+    // Breadcrumb items for setup page
     const breadcrumbItems = [{ label: 'Self-Hosting Setup' }];
     const optionalEnv = `# Optional generation providers (configure at least one for AI responses)
 OPENAI_API_KEY=your_openai_api_key

--- a/packages/web/src/pages/SetupPage.tsx
+++ b/packages/web/src/pages/SetupPage.tsx
@@ -1,7 +1,7 @@
 /**
  * @description: Renders the self-hosting setup page with copyable commands and deployment guidance.
  * @footnote-scope: web
- * @footnote-module: InvitePage
+ * @footnote-module: SetupPage
  * @footnote-risk: medium - Incorrect setup instructions can derail local installs or deployment attempts.
  * @footnote-ethics: medium - Clear setup guidance affects user autonomy, hosting control, and privacy expectations.
  */
@@ -13,7 +13,7 @@ import Footer from '@components/Footer';
 type ToastState = { message: string; visible: boolean };
 type ToastSetter = React.Dispatch<React.SetStateAction<ToastState>>;
 
-const InvitePage: React.FC = () => {
+const SetupPage: React.FC = () => {
     const [cloneToast, setCloneToast] = useState<ToastState>({
         message: '',
         visible: false,
@@ -1220,4 +1220,4 @@ DISCORD_GUILD_ID=your_discord_guild_id          # Discord server/guild ID (Strin
     );
 };
 
-export default InvitePage;
+export default SetupPage;

--- a/packages/web/src/styles/global.css
+++ b/packages/web/src/styles/global.css
@@ -3312,3 +3312,142 @@ kbd {
 .inline-cta:focus {
     border-bottom-color: var(--link-hover);
 }
+
+/* ===== ENGINEERING GUIDE ===== */
+.guide-page {
+    display: grid;
+    gap: clamp(2rem, 4vw, 3rem);
+}
+
+.guide-hero {
+    display: grid;
+    gap: 1rem;
+}
+
+.guide-eyebrow {
+    margin: 0;
+    font-family: var(--mono-font);
+    font-size: 0.8rem;
+    letter-spacing: 0.12em;
+    text-transform: uppercase;
+    color: var(--accent);
+}
+
+.guide-summary {
+    font-size: 1.08rem;
+    max-width: 70ch;
+    margin: 0;
+}
+
+.guide-jump-nav {
+    margin-top: 0.25rem;
+}
+
+.guide-jump-list {
+    list-style: none;
+    display: grid;
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+    gap: 0.75rem 1.25rem;
+    padding: 0;
+    margin: 0;
+}
+
+.guide-jump-list li {
+    margin: 0;
+}
+
+.guide-jump-list a {
+    display: inline-block;
+    font-family: var(--mono-font);
+    font-size: 0.95rem;
+    text-decoration: none;
+}
+
+.guide-section {
+    border-top: 1px solid var(--border);
+    padding-top: clamp(1.5rem, 3vw, 2rem);
+    scroll-margin-top: 7rem;
+}
+
+.guide-section h2 {
+    font-size: clamp(1.25rem, 2.5vw, 1.55rem);
+    margin-bottom: 0.9rem;
+}
+
+.guide-map {
+    margin: 0;
+    display: grid;
+    gap: 1rem;
+}
+
+.guide-map__row {
+    display: grid;
+    grid-template-columns: minmax(0, 15rem) minmax(0, 1fr);
+    gap: 1rem 1.5rem;
+    align-items: start;
+}
+
+.guide-map dt {
+    font-family: var(--mono-font);
+    font-size: 0.95rem;
+    color: var(--text);
+}
+
+.guide-map dd {
+    margin: 0;
+}
+
+.guide-flow,
+.guide-list,
+.guide-links {
+    margin: 0;
+    padding-left: 1.25rem;
+}
+
+.guide-flow {
+    display: grid;
+    gap: 1rem;
+}
+
+.guide-flow__item {
+    padding-left: 0.25rem;
+}
+
+.guide-flow__title {
+    margin-bottom: 0.35rem;
+    font-family: var(--mono-font);
+    font-size: 0.95rem;
+    color: var(--text);
+}
+
+.guide-list li,
+.guide-links li {
+    margin-bottom: 0.9rem;
+}
+
+.guide-links a {
+    font-family: var(--mono-font);
+    font-size: 0.95rem;
+    text-decoration: none;
+}
+
+.guide-links p {
+    margin: 0.25rem 0 0;
+}
+
+@media (max-width: 900px) {
+    .guide-jump-list {
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+    }
+
+    .guide-map__row {
+        grid-template-columns: 1fr;
+        gap: 0.35rem;
+    }
+}
+
+@media (max-width: 600px) {
+    .guide-jump-list {
+        grid-template-columns: 1fr;
+    }
+}

--- a/packages/web/src/styles/global.css
+++ b/packages/web/src/styles/global.css
@@ -3313,18 +3313,18 @@ kbd {
     border-bottom-color: var(--link-hover);
 }
 
-/* ===== ENGINEERING GUIDE ===== */
-.guide-page {
+/* ===== ABOUT PAGE ===== */
+.about-page {
     display: grid;
     gap: clamp(2rem, 4vw, 3rem);
 }
 
-.guide-hero {
+.about-hero {
     display: grid;
     gap: 1rem;
 }
 
-.guide-eyebrow {
+.about-eyebrow {
     margin: 0;
     font-family: var(--mono-font);
     font-size: 0.8rem;
@@ -3333,17 +3333,17 @@ kbd {
     color: var(--accent);
 }
 
-.guide-summary {
+.about-summary {
     font-size: 1.08rem;
     max-width: 70ch;
     margin: 0;
 }
 
-.guide-jump-nav {
+.about-jump-nav {
     margin-top: 0.25rem;
 }
 
-.guide-jump-list {
+.about-jump-list {
     list-style: none;
     display: grid;
     grid-template-columns: repeat(3, minmax(0, 1fr));
@@ -3352,102 +3352,53 @@ kbd {
     margin: 0;
 }
 
-.guide-jump-list li {
+.about-jump-list li {
     margin: 0;
 }
 
-.guide-jump-list a {
+.about-jump-list a {
     display: inline-block;
     font-family: var(--mono-font);
     font-size: 0.95rem;
     text-decoration: none;
 }
 
-.guide-section {
+.about-section {
     border-top: 1px solid var(--border);
     padding-top: clamp(1.5rem, 3vw, 2rem);
     scroll-margin-top: 7rem;
 }
 
-.guide-section h2 {
+.about-section h2 {
     font-size: clamp(1.25rem, 2.5vw, 1.55rem);
     margin-bottom: 0.9rem;
 }
 
-.guide-map {
-    margin: 0;
-    display: grid;
-    gap: 1rem;
-}
-
-.guide-map__row {
-    display: grid;
-    grid-template-columns: minmax(0, 15rem) minmax(0, 1fr);
-    gap: 1rem 1.5rem;
-    align-items: start;
-}
-
-.guide-map dt {
-    font-family: var(--mono-font);
-    font-size: 0.95rem;
-    color: var(--text);
-}
-
-.guide-map dd {
-    margin: 0;
-}
-
-.guide-flow,
-.guide-list,
-.guide-links {
+.about-list,
+.about-links {
     margin: 0;
     padding-left: 1.25rem;
 }
 
-.guide-flow {
-    display: grid;
-    gap: 1rem;
-}
-
-.guide-flow__item {
-    padding-left: 0.25rem;
-}
-
-.guide-flow__title {
-    margin-bottom: 0.35rem;
-    font-family: var(--mono-font);
-    font-size: 0.95rem;
-    color: var(--text);
-}
-
-.guide-list li,
-.guide-links li {
+.about-list li,
+.about-links li {
     margin-bottom: 0.9rem;
 }
 
-.guide-links a {
+.about-links a {
     font-family: var(--mono-font);
     font-size: 0.95rem;
     text-decoration: none;
 }
 
-.guide-links p {
-    margin: 0.25rem 0 0;
-}
-
 @media (max-width: 900px) {
-    .guide-jump-list {
+    .about-jump-list {
         grid-template-columns: repeat(2, minmax(0, 1fr));
-    }
-
-    .guide-map__row {
-        grid-template-columns: 1fr;
-        gap: 0.35rem;
     }
 }
 
 @media (max-width: 600px) {
-    .guide-jump-list {
+    .about-jump-list {
         grid-template-columns: 1fr;
     }
 }


### PR DESCRIPTION
## Summary
This PR turns `/about` into a public-facing About page and aligns related navigation naming in the web app.

## What changed
- Replaced the onboarding-style `/about` content with a simpler public About page focused on:
  - what Footnote is
  - why it exists
  - what users can see with a response
  - what a trace is
  - open source and self-hosting context
  - careful scope/overclaim boundaries
  - where contributors should go next
- Removed contributor-heavy sections from `/about` (repo map, request flow, runtime boundaries, current migrations, common mistakes) and linked to existing docs entry points instead.
- Renamed route/page naming to match intent:
  - setup routes now use `SetupPage`
  - about routes now use `AboutPage`
- Updated linked landing-page/setup references and cleaned stale breadcrumb/setup wording.
- Kept implementation inside existing web routes/components/styles without adding backend behavior or a new design system.

## Why these changes were made
The branch originally landed as an onboarding/engineering artifact. The requested direction was to make `/about` read like a real public product page in the same plain, human voice as the README, while moving deeper engineering context back to docs.

## Implementation details
- Routing and imports were updated in `packages/web/src/App.tsx` to use `/about` + `AboutPage` and `/setup` + `SetupPage`.
- The About page content was rewritten in `packages/web/src/pages/AboutPage.tsx` with fewer sections and clearer public framing.
- Page-specific styles were kept local in `packages/web/src/styles/global.css` and renamed from `guide-*` to `about-*` for clarity.
- Stale naming references were cleaned in `packages/web/src/pages/SetupPage.tsx` and `packages/web/src/components/Breadcrumb.tsx`.
- Developer links on `/about` now point to existing repo docs (`README`, `docs/README.md`, `docs/architecture/README.md`, `AGENTS.md`, `docs/ai/README.md`, `deploy/README.md`).

This PR was written using [Vibe Kanban](https://vibekanban.com)