### PR TITLE
Lazy-load non-home web routes to reduce initial bundle size (Vibe Kanban)

### DIFF
--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -6,18 +6,27 @@
  * @footnote-ethics: medium - The top-level route map affects access to transparency and self-hosting guidance.
  */
 
+import { Suspense, lazy } from 'react';
 import { Routes, Route } from 'react-router-dom';
 import Hero from '@components/Hero';
 import Invite from '@components/Invite';
 import Services from '@components/Services';
 import OpenAccountable from '@components/OpenAccountable';
 import Footer from '@components/Footer';
-import TracePage from '@pages/TracePage';
-import SetupPage from '@pages/SetupPage';
-import BlogListPage from '@pages/BlogListPage';
-import BlogPostPage from '@pages/BlogPostPage';
-import EmbedPage from '@pages/EmbedPage';
-import AboutPage from '@pages/AboutPage';
+
+const TracePage = lazy(() => import('@pages/TracePage'));
+const SetupPage = lazy(() => import('@pages/SetupPage'));
+const BlogListPage = lazy(() => import('@pages/BlogListPage'));
+const BlogPostPage = lazy(() => import('@pages/BlogPostPage'));
+const EmbedPage = lazy(() => import('@pages/EmbedPage'));
+const AboutPage = lazy(() => import('@pages/AboutPage'));
+
+const routeFallback = (
+    <section className="interaction-status" aria-live="polite">
+        <div className="spinner" aria-hidden="true" />
+        <p>Loading page...</p>
+    </section>
+);
 
 // The App component stitches together the landing page sections in their intended scroll order.
 const App = (): JSX.Element => (
@@ -44,16 +53,86 @@ const App = (): JSX.Element => (
                     </main>
                 }
             />
-            <Route path="/setup" element={<SetupPage />} />
-            <Route path="/setup/" element={<SetupPage />} />
-            <Route path="/about" element={<AboutPage />} />
-            <Route path="/about/" element={<AboutPage />} />
-            <Route path="/embed" element={<EmbedPage />} />
-            <Route path="/blog" element={<BlogListPage />} />
-            <Route path="/blog/" element={<BlogListPage />} />
-            <Route path="/blog/:number" element={<BlogPostPage />} />
-            <Route path="/traces/:responseId" element={<TracePage />} />
-            <Route path="/api/traces/:responseId" element={<TracePage />} />
+            <Route
+                path="/setup"
+                element={
+                    <Suspense fallback={routeFallback}>
+                        <SetupPage />
+                    </Suspense>
+                }
+            />
+            <Route
+                path="/setup/"
+                element={
+                    <Suspense fallback={routeFallback}>
+                        <SetupPage />
+                    </Suspense>
+                }
+            />
+            <Route
+                path="/about"
+                element={
+                    <Suspense fallback={routeFallback}>
+                        <AboutPage />
+                    </Suspense>
+                }
+            />
+            <Route
+                path="/about/"
+                element={
+                    <Suspense fallback={routeFallback}>
+                        <AboutPage />
+                    </Suspense>
+                }
+            />
+            <Route
+                path="/embed"
+                element={
+                    <Suspense fallback={routeFallback}>
+                        <EmbedPage />
+                    </Suspense>
+                }
+            />
+            <Route
+                path="/blog"
+                element={
+                    <Suspense fallback={routeFallback}>
+                        <BlogListPage />
+                    </Suspense>
+                }
+            />
+            <Route
+                path="/blog/"
+                element={
+                    <Suspense fallback={routeFallback}>
+                        <BlogListPage />
+                    </Suspense>
+                }
+            />
+            <Route
+                path="/blog/:number"
+                element={
+                    <Suspense fallback={routeFallback}>
+                        <BlogPostPage />
+                    </Suspense>
+                }
+            />
+            <Route
+                path="/traces/:responseId"
+                element={
+                    <Suspense fallback={routeFallback}>
+                        <TracePage />
+                    </Suspense>
+                }
+            />
+            <Route
+                path="/api/traces/:responseId"
+                element={
+                    <Suspense fallback={routeFallback}>
+                        <TracePage />
+                    </Suspense>
+                }
+            />
         </Routes>
     </div>
 );


### PR DESCRIPTION
## Summary
This PR reduces the initial web bundle by lazy-loading non-home routes in the React app router.

## What Changed
- Updated `packages/web/src/App.tsx` to switch non-home pages from eager imports to `React.lazy` imports.
- Wrapped non-home route elements in `Suspense` with a minimal existing-style loading fallback.
- Applied lazy-loading to:
  - `SetupPage`
  - `TracePage`
  - `BlogListPage`
  - `BlogPostPage`
  - `EmbedPage`
  - `AboutPage`
- Kept landing page sections/components eagerly loaded.
- Kept all existing route paths and route behavior intact.

## Why
The branch task was to reduce first-load JavaScript by avoiding eager inclusion of non-home route code in the initial chunk. This also ensures blog-only dependencies (including markdown rendering libraries used by the blog post route) are loaded when needed instead of during homepage startup.

## Implementation Details
- Routing structure was preserved; only import/loading strategy changed.
- A lightweight fallback was intentionally used to match existing UI conventions and avoid introducing new loading UX complexity.
- No SSR/manual chunk configuration/routing redesign was introduced in this change.
- Change scope is intentionally narrow to one file and one concern (`App.tsx` route loading behavior).

This PR was written using [Vibe Kanban](https://vibekanban.com)