### PR TITLE
perf(web): split routes and lazy-load validators (Vibe Kanban)

### DIFF
--- a/packages/api-client/package.json
+++ b/packages/api-client/package.json
@@ -9,6 +9,10 @@
         ".": {
             "types": "./dist/index.d.ts",
             "default": "./dist/index.js"
+        },
+        "./web-client": {
+            "types": "./dist/webClient.d.ts",
+            "default": "./dist/webClient.js"
         }
     },
     "scripts": {

--- a/packages/api-client/src/chat.ts
+++ b/packages/api-client/src/chat.ts
@@ -11,12 +11,11 @@ import type {
     PostChatResponse,
 } from '@footnote/contracts/web';
 import type { ToolExecutionContext } from '@footnote/contracts/ethics-core';
-import {
-    GetChatProfilesResponseSchema,
-    PostChatResponseSchema,
-    createSchemaResponseValidator,
-} from '@footnote/contracts/web/schemas';
 import type { ApiRequester } from './client.js';
+import {
+    loadGetChatProfilesResponseValidator,
+    loadPostChatResponseValidator,
+} from './lazyWebValidators.js';
 
 export type CreateChatApiOptions = {
     traceApiToken?: string;
@@ -66,15 +65,15 @@ export const createChatApi = (
     const getChatProfiles = async (options?: {
         signal?: AbortSignal;
     }): Promise<GetChatProfilesResponse> => {
+        const validateResponse = await loadGetChatProfilesResponseValidator();
+
         const response = await requestJson<GetChatProfilesResponse>(
             '/api/chat/profiles',
             {
                 method: 'GET',
                 signal: options?.signal,
                 cache: 'no-store',
-                validateResponse: createSchemaResponseValidator(
-                    GetChatProfilesResponseSchema
-                ),
+                validateResponse,
             }
         );
 
@@ -119,6 +118,7 @@ export const createChatApi = (
         request: PostChatRequest,
         options?: { turnstileToken?: string; signal?: AbortSignal }
     ): Promise<PostChatResponse> => {
+        const validateResponse = await loadPostChatResponseValidator();
         const headers: Record<string, string> = {};
 
         if (options?.turnstileToken) {
@@ -133,9 +133,7 @@ export const createChatApi = (
             headers,
             body: request,
             signal: options?.signal,
-            validateResponse: createSchemaResponseValidator(
-                PostChatResponseSchema
-            ),
+            validateResponse,
         });
 
         return response.data;

--- a/packages/api-client/src/lazyWebValidators.ts
+++ b/packages/api-client/src/lazyWebValidators.ts
@@ -1,0 +1,94 @@
+/**
+ * @description: Lazily loads web response validators so schema runtime is fetched only when endpoints are called.
+ * @footnote-scope: utility
+ * @footnote-module: LazyWebValidators
+ * @footnote-risk: medium - Broken lazy imports would fail endpoint-level response validation at runtime.
+ * @footnote-ethics: medium - Preserves validation while reducing eager startup code in user-facing surfaces.
+ */
+
+import type {
+    GetChatProfilesResponse,
+    GetTraceResponse,
+    GetTraceStaleResponse,
+    PostChatResponse,
+} from '@footnote/contracts/web';
+import type { ApiResponseValidator } from '@footnote/contracts/web/client-core';
+
+type WebSchemasModule = typeof import('@footnote/contracts/web/schemas');
+
+let webSchemasModulePromise: Promise<WebSchemasModule> | null = null;
+let getChatProfilesResponseValidatorPromise: Promise<
+    ApiResponseValidator<GetChatProfilesResponse>
+> | null = null;
+let postChatResponseValidatorPromise: Promise<
+    ApiResponseValidator<PostChatResponse>
+> | null = null;
+let getTraceApiResponseValidatorPromise: Promise<
+    ApiResponseValidator<GetTraceResponse | GetTraceStaleResponse>
+> | null = null;
+
+const loadWebSchemasModule = async (): Promise<WebSchemasModule> => {
+    if (!webSchemasModulePromise) {
+        webSchemasModulePromise = import('@footnote/contracts/web/schemas');
+    }
+
+    return webSchemasModulePromise;
+};
+
+export const loadGetChatProfilesResponseValidator = async (): Promise<
+    ApiResponseValidator<GetChatProfilesResponse>
+> => {
+    if (!getChatProfilesResponseValidatorPromise) {
+        getChatProfilesResponseValidatorPromise = loadWebSchemasModule()
+            .then(
+                ({
+                    GetChatProfilesResponseSchema,
+                    createSchemaResponseValidator,
+                }) =>
+                    createSchemaResponseValidator(GetChatProfilesResponseSchema)
+            )
+            .catch((error) => {
+                getChatProfilesResponseValidatorPromise = null;
+                throw error;
+            });
+    }
+
+    return getChatProfilesResponseValidatorPromise;
+};
+
+export const loadPostChatResponseValidator = async (): Promise<
+    ApiResponseValidator<PostChatResponse>
+> => {
+    if (!postChatResponseValidatorPromise) {
+        postChatResponseValidatorPromise = loadWebSchemasModule()
+            .then(({ PostChatResponseSchema, createSchemaResponseValidator }) =>
+                createSchemaResponseValidator(PostChatResponseSchema)
+            )
+            .catch((error) => {
+                postChatResponseValidatorPromise = null;
+                throw error;
+            });
+    }
+
+    return postChatResponseValidatorPromise;
+};
+
+export const loadGetTraceApiResponseValidator = async (): Promise<
+    ApiResponseValidator<GetTraceResponse | GetTraceStaleResponse>
+> => {
+    if (!getTraceApiResponseValidatorPromise) {
+        getTraceApiResponseValidatorPromise = loadWebSchemasModule()
+            .then(
+                ({
+                    GetTraceApiResponseSchema,
+                    createSchemaResponseValidator,
+                }) => createSchemaResponseValidator(GetTraceApiResponseSchema)
+            )
+            .catch((error) => {
+                getTraceApiResponseValidatorPromise = null;
+                throw error;
+            });
+    }
+
+    return getTraceApiResponseValidatorPromise;
+};

--- a/packages/api-client/src/lazyWebValidators.ts
+++ b/packages/api-client/src/lazyWebValidators.ts
@@ -29,7 +29,11 @@ let getTraceApiResponseValidatorPromise: Promise<
 
 const loadWebSchemasModule = async (): Promise<WebSchemasModule> => {
     if (!webSchemasModulePromise) {
-        webSchemasModulePromise = import('@footnote/contracts/web/schemas');
+        webSchemasModulePromise =
+            import('@footnote/contracts/web/schemas').catch((error) => {
+                webSchemasModulePromise = null;
+                throw error;
+            });
     }
 
     return webSchemasModulePromise;

--- a/packages/api-client/src/web-client.ts
+++ b/packages/api-client/src/web-client.ts
@@ -1,0 +1,9 @@
+/**
+ * @description: Kebab-case bridge entrypoint so workspace TS path mapping can resolve @footnote/api-client/web-client.
+ * @footnote-scope: interface
+ * @footnote-module: WebClientBridgeEntrypoint
+ * @footnote-risk: low - Re-export only; no runtime behavior changes.
+ * @footnote-ethics: low - No governance impact; maintains consistent validated API access.
+ */
+
+export * from './webClient.js';

--- a/packages/api-client/src/web.ts
+++ b/packages/api-client/src/web.ts
@@ -12,11 +12,8 @@ import type {
     GetTraceStaleResponse,
     ListBlogPostsResponse,
 } from '@footnote/contracts/web';
-import {
-    GetTraceApiResponseSchema,
-    createSchemaResponseValidator,
-} from '@footnote/contracts/web/schemas';
 import type { ApiJsonResult, ApiRequester } from './client.js';
+import { loadGetTraceApiResponseValidator } from './lazyWebValidators.js';
 
 export type WebReadApi = {
     getRuntimeConfig: (
@@ -95,6 +92,7 @@ export const createWebReadApi = (requestJson: ApiRequester): WebReadApi => {
         responseId: string,
         signal?: AbortSignal
     ): Promise<ApiJsonResult<GetTraceResponse | GetTraceStaleResponse>> => {
+        const validateResponse = await loadGetTraceApiResponseValidator();
         const encodedResponseId = encodeURIComponent(responseId);
         return requestJson<GetTraceResponse | GetTraceStaleResponse>(
             `/api/traces/${encodedResponseId}`,
@@ -105,9 +103,7 @@ export const createWebReadApi = (requestJson: ApiRequester): WebReadApi => {
                     Accept: 'application/json',
                 },
                 acceptedStatusCodes: [410],
-                validateResponse: createSchemaResponseValidator(
-                    GetTraceApiResponseSchema
-                ),
+                validateResponse,
             }
         );
     };

--- a/packages/api-client/src/webClient.ts
+++ b/packages/api-client/src/webClient.ts
@@ -1,0 +1,72 @@
+/**
+ * @description: Web-focused API client entrypoint that avoids importing Discord/internal API modules.
+ * @footnote-scope: interface
+ * @footnote-module: WebApiClientEntrypoint
+ * @footnote-risk: medium - Incorrect exports can break browser API wiring for chat, config, blog, and trace reads.
+ * @footnote-ethics: medium - Keeps response validation intact while reducing unnecessary startup code for web users.
+ */
+
+import {
+    createApiTransport,
+    isApiClientError,
+    type ApiClientError,
+    type ApiErrorResponse,
+    type ApiJsonResult,
+    type ApiRequestOptions,
+    type ApiRequester,
+    type CreateApiTransportOptions,
+} from './client.js';
+import {
+    createChatApi,
+    type ChatApi,
+    type CreateChatApiOptions,
+    type DiscordChatApiResponse,
+    type UnknownChatActionResponse,
+} from './chat.js';
+import { createWebReadApi, type WebReadApi } from './web.js';
+
+export type CreateWebApiClientOptions = CreateApiTransportOptions;
+
+export type WebApiClient = {
+    requestJson: ApiRequester;
+    chatQuestion: ChatApi['chatQuestion'];
+} & WebReadApi;
+
+export const createWebApiClient = ({
+    baseUrl,
+    defaultHeaders,
+    defaultTimeoutMs,
+    fetchImpl = fetch,
+}: CreateWebApiClientOptions = {}): WebApiClient => {
+    const { requestJson } = createApiTransport({
+        baseUrl,
+        defaultHeaders,
+        defaultTimeoutMs,
+        fetchImpl,
+        clientErrorName: 'ApiClientError',
+    });
+    const chatApi = createChatApi(requestJson);
+    const webReadApi = createWebReadApi(requestJson);
+
+    return {
+        requestJson,
+        chatQuestion: chatApi.chatQuestion,
+        ...webReadApi,
+    };
+};
+
+export { createApiTransport, isApiClientError };
+export { createChatApi, createWebReadApi };
+export type {
+    ApiClientError,
+    ApiErrorResponse,
+    ApiJsonResult,
+    ApiRequestOptions,
+    ApiRequester,
+    ChatApi,
+    CreateApiTransportOptions,
+    CreateChatApiOptions,
+    DiscordChatApiResponse,
+    UnknownChatActionResponse,
+    WebReadApi,
+};

--- a/packages/api-client/src/webClient.ts
+++ b/packages/api-client/src/webClient.ts
@@ -25,27 +25,35 @@ import {
 } from './chat.js';
 import { createWebReadApi, type WebReadApi } from './web.js';
 
-export type CreateWebApiClientOptions = CreateApiTransportOptions;
+export type CreateWebApiClientOptions = CreateApiTransportOptions &
+    Pick<CreateChatApiOptions, 'traceApiToken'>;
 
 export type WebApiClient = {
     requestJson: ApiRequester;
     chatQuestion: ChatApi['chatQuestion'];
 } & WebReadApi;
 
+/**
+ * @description: Creates the web API boundary client and wires `createApiTransport`, `createChatApi`, and `createWebReadApi`.
+ * @param options - `CreateWebApiClientOptions` including transport options such as `clientErrorName` and chat options such as `traceApiToken`.
+ * @returns Stable `WebApiClient` methods for JSON requests, chat, and web read endpoints.
+ */
 export const createWebApiClient = ({
     baseUrl,
     defaultHeaders,
     defaultTimeoutMs,
     fetchImpl = fetch,
+    clientErrorName,
+    traceApiToken,
 }: CreateWebApiClientOptions = {}): WebApiClient => {
     const { requestJson } = createApiTransport({
         baseUrl,
         defaultHeaders,
         defaultTimeoutMs,
         fetchImpl,
-        clientErrorName: 'ApiClientError',
+        clientErrorName,
     });
-    const chatApi = createChatApi(requestJson);
+    const chatApi = createChatApi(requestJson, { traceApiToken });
     const webReadApi = createWebReadApi(requestJson);
 
     return {

--- a/packages/web/index.html
+++ b/packages/web/index.html
@@ -70,6 +70,10 @@
             }
         </script>
         <style>
+            body {
+                margin: 0;
+            }
+
             #root {
                 min-height: 100dvh;
             }

--- a/packages/web/index.html
+++ b/packages/web/index.html
@@ -69,9 +69,103 @@
                 }
             }
         </script>
+        <style>
+            #root {
+                min-height: 100dvh;
+            }
+
+            .preload-shell {
+                box-sizing: border-box;
+                min-height: 100dvh;
+                margin: 0;
+                padding: clamp(2.5rem, 10vw, 6rem) 1.25rem 2rem;
+                display: flex;
+                flex-direction: column;
+                justify-content: center;
+                gap: 0.65rem;
+                background: #f7f7fc;
+                color: #10111a;
+                font-family:
+                    ui-sans-serif,
+                    system-ui,
+                    -apple-system,
+                    'Segoe UI',
+                    sans-serif;
+            }
+
+            .preload-shell__mark {
+                margin: 0;
+                font-weight: 700;
+                font-size: clamp(1.5rem, 4vw, 2rem);
+                letter-spacing: 0.02em;
+            }
+
+            .preload-shell__line,
+            .preload-shell__state {
+                margin: 0;
+                font-size: 1rem;
+                line-height: 1.5;
+            }
+
+            .preload-shell__line {
+                max-width: 28rem;
+            }
+
+            .preload-shell__state {
+                display: inline-flex;
+                align-items: center;
+                gap: 0.45rem;
+                color: #4a4d63;
+            }
+
+            .preload-shell__state::before {
+                content: '';
+                width: 0.55rem;
+                height: 0.55rem;
+                border-radius: 999px;
+                background: currentColor;
+                animation: preload-pulse 1.2s ease-in-out infinite;
+            }
+
+            @keyframes preload-pulse {
+                0%,
+                100% {
+                    opacity: 0.35;
+                    transform: scale(0.88);
+                }
+                50% {
+                    opacity: 1;
+                    transform: scale(1);
+                }
+            }
+
+            @media (prefers-color-scheme: dark) {
+                .preload-shell {
+                    background: #0b0c12;
+                    color: #f2f3f8;
+                }
+
+                .preload-shell__state {
+                    color: #adb1c7;
+                }
+            }
+
+            @media (prefers-reduced-motion: reduce) {
+                .preload-shell__state::before {
+                    animation: none;
+                    opacity: 0.8;
+                }
+            }
+        </style>
     </head>
     <body>
-        <div id="root"></div>
+        <div id="root">
+            <div class="preload-shell" aria-live="polite">
+                <p class="preload-shell__mark">Footnote</p>
+                <p class="preload-shell__line">AI answers with receipts.</p>
+                <p class="preload-shell__state">Loading Footnote…</p>
+            </div>
+        </div>
         <script type="module" src="/src/main.tsx"></script>
     </body>
 </html>

--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -22,9 +22,14 @@ const EmbedPage = lazy(() => import('@pages/EmbedPage'));
 const AboutPage = lazy(() => import('@pages/AboutPage'));
 
 const RouteLoadingFallback = (): JSX.Element => (
-    <div className="route-loading" role="status" aria-live="polite">
+    <main
+        id="main-content"
+        className="route-loading"
+        role="status"
+        aria-live="polite"
+    >
         Loading…
-    </div>
+    </main>
 );
 
 // The App component stitches together the landing page sections in their intended scroll order.

--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -6,18 +6,26 @@
  * @footnote-ethics: medium - The top-level route map affects access to transparency and self-hosting guidance.
  */
 
+import { Suspense, lazy } from 'react';
 import { Routes, Route } from 'react-router-dom';
 import Hero from '@components/Hero';
 import Invite from '@components/Invite';
 import Services from '@components/Services';
 import OpenAccountable from '@components/OpenAccountable';
 import Footer from '@components/Footer';
-import TracePage from '@pages/TracePage';
-import SetupPage from '@pages/SetupPage';
-import BlogListPage from '@pages/BlogListPage';
-import BlogPostPage from '@pages/BlogPostPage';
-import EmbedPage from '@pages/EmbedPage';
-import AboutPage from '@pages/AboutPage';
+
+const SetupPage = lazy(() => import('@pages/SetupPage'));
+const TracePage = lazy(() => import('@pages/TracePage'));
+const BlogListPage = lazy(() => import('@pages/BlogListPage'));
+const BlogPostPage = lazy(() => import('@pages/BlogPostPage'));
+const EmbedPage = lazy(() => import('@pages/EmbedPage'));
+const AboutPage = lazy(() => import('@pages/AboutPage'));
+
+const RouteLoadingFallback = (): JSX.Element => (
+    <div className="route-loading" role="status" aria-live="polite">
+        Loading…
+    </div>
+);
 
 // The App component stitches together the landing page sections in their intended scroll order.
 const App = (): JSX.Element => (
@@ -44,16 +52,86 @@ const App = (): JSX.Element => (
                     </main>
                 }
             />
-            <Route path="/setup" element={<SetupPage />} />
-            <Route path="/setup/" element={<SetupPage />} />
-            <Route path="/about" element={<AboutPage />} />
-            <Route path="/about/" element={<AboutPage />} />
-            <Route path="/embed" element={<EmbedPage />} />
-            <Route path="/blog" element={<BlogListPage />} />
-            <Route path="/blog/" element={<BlogListPage />} />
-            <Route path="/blog/:number" element={<BlogPostPage />} />
-            <Route path="/traces/:responseId" element={<TracePage />} />
-            <Route path="/api/traces/:responseId" element={<TracePage />} />
+            <Route
+                path="/setup"
+                element={
+                    <Suspense fallback={<RouteLoadingFallback />}>
+                        <SetupPage />
+                    </Suspense>
+                }
+            />
+            <Route
+                path="/setup/"
+                element={
+                    <Suspense fallback={<RouteLoadingFallback />}>
+                        <SetupPage />
+                    </Suspense>
+                }
+            />
+            <Route
+                path="/about"
+                element={
+                    <Suspense fallback={<RouteLoadingFallback />}>
+                        <AboutPage />
+                    </Suspense>
+                }
+            />
+            <Route
+                path="/about/"
+                element={
+                    <Suspense fallback={<RouteLoadingFallback />}>
+                        <AboutPage />
+                    </Suspense>
+                }
+            />
+            <Route
+                path="/embed"
+                element={
+                    <Suspense fallback={<RouteLoadingFallback />}>
+                        <EmbedPage />
+                    </Suspense>
+                }
+            />
+            <Route
+                path="/blog"
+                element={
+                    <Suspense fallback={<RouteLoadingFallback />}>
+                        <BlogListPage />
+                    </Suspense>
+                }
+            />
+            <Route
+                path="/blog/"
+                element={
+                    <Suspense fallback={<RouteLoadingFallback />}>
+                        <BlogListPage />
+                    </Suspense>
+                }
+            />
+            <Route
+                path="/blog/:number"
+                element={
+                    <Suspense fallback={<RouteLoadingFallback />}>
+                        <BlogPostPage />
+                    </Suspense>
+                }
+            />
+            <Route
+                path="/traces/:responseId"
+                element={
+                    <Suspense fallback={<RouteLoadingFallback />}>
+                        <TracePage />
+                    </Suspense>
+                }
+            />
+            <Route
+                path="/api/traces/:responseId"
+                element={
+                    <Suspense fallback={<RouteLoadingFallback />}>
+                        <TracePage />
+                    </Suspense>
+                }
+            />
         </Routes>
     </div>
 );

--- a/packages/web/src/styles/global.css
+++ b/packages/web/src/styles/global.css
@@ -240,6 +240,13 @@ body::before {
     box-sizing: border-box;
 }
 
+.route-loading {
+    padding: clamp(1.5rem, 4vw, 2.25rem) 0;
+    font-family: var(--mono-font);
+    font-size: 0.95rem;
+    color: var(--subtle-text);
+}
+
 @media (max-width: 560px) {
     .app-shell {
         padding: clamp(1.35rem, 4vw, 2rem) clamp(1.15rem, 4vw, 1.85rem);

--- a/packages/web/src/utils/api.ts
+++ b/packages/web/src/utils/api.ts
@@ -12,7 +12,7 @@ import {
     type ApiClientError,
     type ApiErrorResponse,
     type CreateWebApiClientOptions,
-} from '@footnote/api-client';
+} from '@footnote/api-client/web-client';
 import type {
     GetBlogPostResponse,
     GetRuntimeConfigResponse,


### PR DESCRIPTION
## What changed

This PR delivers the next web startup-performance slices as one branch:

- Added a tiny pre-hydration shell in `packages/web/index.html` so `/` paints useful content before React bootstraps.
- Kept homepage sections eager, and lazy-loaded non-home routes in `packages/web/src/App.tsx`:
  - `SetupPage`
  - `TracePage`
  - `BlogListPage`
  - `BlogPostPage`
  - `EmbedPage`
  - `AboutPage`
- Added route-level `Suspense` fallback for lazy page navigation.
- Moved web API response-validator loading to lazy dynamic imports in `@footnote/api-client`:
  - `GetChatProfilesResponseSchema`
  - `PostChatResponseSchema`
  - `GetTraceApiResponseSchema`
- Added validator loader promise caching in `packages/api-client/src/lazyWebValidators.ts`.
- Added a web-only api-client entrypoint composition path and passthrough options in `packages/api-client/src/webClient.ts`.
- Switched web API usage to the web-specific api-client entrypoint in `packages/web/src/utils/api.ts`.
- Added `packages/api-client/src/web-client.ts` bridge entrypoint so workspace TS path mapping resolves `@footnote/api-client/web-client` consistently in CI/review.
- Applied follow-up fixes:
  - Reset shared schemas import promise on transient lazy import failure (prevents permanent rejected-promise state).
  - Added `body { margin: 0; }` in critical shell CSS for true edge-to-edge first paint.
  - Ensured lazy-route fallback provides temporary skip-link target via `main#main-content`.

## Why these changes were made

The prior shell work improved first paint, but the startup graph still shipped too much JS up front. This PR continues the performance work by:

- reducing initial route JS via route-level lazy loading, and
- removing eager `@footnote/contracts/web/schemas` + Zod runtime from web startup by loading validators only when endpoints are actually called.

Validation behavior is preserved. The change is about *when* schema runtime loads, not whether responses are validated.

## Important implementation details

- API response validation is still enforced for the same endpoints; schemas and `createSchemaResponseValidator` are unchanged.
- Lazy validator loaders cache per-validator promises and now recover from transient module import failures by clearing the shared module promise on rejection.
- `createWebApiClient` now forwards `clientErrorName` into `createApiTransport` and `traceApiToken` into `createChatApi` while keeping the returned `WebApiClient` surface unchanged.
- Route paths and backend behavior were not changed.
- Turnstile was not turned into an eager first-paint gate in this branch.

This PR was written using [Vibe Kanban](https://vibekanban.com)
