### PR TITLE
Add Langfuse shadow observability proposal (Vibe Kanban)

### DIFF
--- a/docs/proposals/proposal_langfuse_shadow_observability.md
+++ b/docs/proposals/proposal_langfuse_shadow_observability.md
@@ -241,6 +241,54 @@ replacement of Footnote trace/provenance semantics.
 
 ---
 
+## Longer-Term Direction
+
+There is a larger idea behind this, but it should not be part of the first Langfuse integration.
+
+In the future, Footnote may be able to adjust workflow execution based on evidence gathered outside the current request. That could include things like:
+
+- eval results from previous runs,
+- fallback patterns across providers,
+- known weak prompt/model combinations,
+- TrustGraph evidence about sources or claims,
+- operator-reviewed examples,
+- or aggregate quality signals from observability tools.
+
+Used carefully, that could help Footnote choose a more appropriate workflow path. For example, it might route some requests toward a more careful review path, avoid a weak provider/model combination, require stronger grounding for certain source types, or flag a run for extra trace visibility.
+
+That is not what the first Langfuse experiment should do.
+
+The first Langfuse integration should observe. It should not steer.
+
+Any future adaptive workflow behavior needs its own design decision, because it changes the authority model. The question would no longer be only “what happened?” It would become “what outside evidence is allowed to change what happens next?”
+
+That boundary matters.
+
+If external signals ever influence workflow execution, Footnote should keep a few rules:
+
+- the Execution Contract still sets the allowed run rules;
+- workflow still owns sequencing;
+- external systems provide advisory signals, not hidden authority;
+- any adjustment should be visible in trace/provenance;
+- the reason for the adjustment should be recorded;
+- stale or missing external signals should fail open or fall back predictably;
+- user privacy and consent rules should apply before telemetry becomes control input;
+- and no vendor tool should become the silent policy engine.
+
+Langfuse might eventually help produce useful aggregate signals. TrustGraph might eventually provide source or evidence signals. Operator evals might eventually identify weak paths. But none of those should silently rewrite runtime behavior.
+
+The safe path is:
+
+1. observe runs;
+2. evaluate patterns;
+3. summarize findings;
+4. let Footnote-owned policy decide whether those findings can affect workflow;
+5. record any adjustment when it happens.
+
+That keeps the door open without pretending the door is already safe to walk through.
+
+---
+
 ## References And Notes
 
 - Footnote Workflow Engine And Provenance:

--- a/docs/proposals/proposal_langfuse_shadow_observability.md
+++ b/docs/proposals/proposal_langfuse_shadow_observability.md
@@ -6,27 +6,23 @@
 
 ## Overview
 
+We should try Langfuse as optional shadow observability for Footnote.
+
 Footnote already records enough information to explain one response: the
 selected mode, workflow lineage, planner influence, provenance, TRACE posture
 (the answer posture metadata described in
 `docs/architecture/response-metadata.md`), tool outcomes, and backend-recorded
-cost.
+cost. That works well for a user-facing trace.
 
-That is the right foundation for a user-facing trace.
+It does not give maintainers a great view across many runs.
 
-It does not give maintainers a great way to look across many runs.
+Langfuse may help there. It can help maintainers inspect patterns, debug
+failures, collect eval examples, compare cost patterns, and notice drift. It
+should not replace Footnote traces, decide what provenance means, move prompts
+out of review, or become part of the default self-hosted stack.
 
-That is the gap Langfuse might fill. It can help with cross-run inspection,
-debugging, eval collection, cost patterns, and drift spotting. It should not
-replace Footnote traces, own provenance semantics, move prompts out of review,
-or become part of the default self-hosted stack.
-
-The proposal is narrow: try Langfuse as optional shadow observability.
-
-By default it should be off. If enabled, it should export metadata only. If it
-fails, Footnote should keep running normally.
-
-Langfuse can help maintainers inspect runs. Footnote still owns the run.
+The first version should be boring: off by default, metadata-only, and
+fail-open.
 
 ---
 
@@ -51,22 +47,19 @@ Footnote could build more of that itself, and some of it may eventually belong
 in the product. But a full observability and evaluation surface is not the core
 product right now.
 
-Langfuse already works in that space. The useful experiment is not "move
-Footnote observability to Langfuse." The useful experiment is "mirror enough
-safe metadata to see whether Langfuse helps maintainers."
+Langfuse already works in that space. We do not need to move Footnote
+observability into Langfuse. We should mirror enough safe metadata to find out
+whether Langfuse is actually useful to maintainers.
 
 ---
 
 ## The Boundary
 
-Footnote has its own meanings for execution, workflow, provenance, incidents,
-pseudonymization, costs, and traces.
-
-Those meanings stay in Footnote.
+Footnote already has its own model for execution, workflow, provenance,
+incidents, pseudonymization, cost, and traces. That stays in Footnote.
 
 Langfuse uses similar words: traces, observations, scores, prompts, datasets,
-evaluations. Those are Langfuse concepts. They can be useful without becoming
-Footnote's product language.
+evaluations. Those terms can be useful without becoming Footnote's language.
 
 A Langfuse trace is not a Footnote trace.
 
@@ -75,7 +68,7 @@ A Langfuse score is not a policy signal.
 A Langfuse prompt version is not automatically a safe replacement for Footnote
 prompt resolution.
 
-Langfuse should not replace:
+Langfuse can receive a mirrored view of some metadata. It should not replace:
 
 - public trace retrieval,
 - response metadata,
@@ -91,34 +84,35 @@ Some metadata can be mirrored. Mirroring is not ownership.
 
 ---
 
-## Current Repo Fit
+## How This Fits The Repo
 
-The repo already has a few seams that make this plausible.
+The clean fit is a backend-owned exporter that runs after Footnote has already
+assembled response metadata.
 
-Footnote has durable trace storage and public trace routes keyed around
-`responseId`. It already records workflow and planner metadata. It already
-treats backend cost recording as authoritative. It also has some optional
-observability-related wiring around VoltAgent tracing.
+That matters. Langfuse should not sit inside request routing, planner
+decisions, workflow policy, or response generation. It should receive a
+mirrored view after Footnote has done its own work.
 
-That means Langfuse does not need to be pushed into request handling as a new
-authority layer.
+A few current repo details shape the first pass:
 
-The clean fit is a backend-owned exporter that runs after Footnote has
-assembled the metadata it already owns.
+- `responseId` is the durable public trace key.
+- Backend cost recording is already authoritative.
+- Planner metadata can appear in workflow metadata as a `plan` step when
+  available, but planner timing still lives before workflow execution in the
+  main chat path.
 
 One important caveat: Footnote does not currently have a broad user consent
 model. Incident records have incident-specific consent metadata, but that is
-not the same thing as a general consent framework for observability export.
-This proposal should not pretend that framework exists.
-
-One more current-state caveat: planner metadata affects execution today, but
-planner is not yet a first-class workflow step in workflow lineage.
+not the same thing as a general consent framework for observability export. Do
+not pretend that framework exists.
 
 ---
 
 ## Privacy Default
 
-The first version should export metadata only.
+Start conservative.
+
+The first version should send metadata, not content.
 
 That can include things like:
 
@@ -141,20 +135,20 @@ local paths, or unbounded tool output.
 If content export is added later, it should be an explicit opt-in. The default
 should remain off.
 
-That is not a nice-to-have. It is the difference between observability and a
+This is not a nice-to-have. It is the difference between observability and a
 privacy foot-gun.
 
 ---
 
 ## How To Try It
 
-Start with documentation and config, not runtime export.
+Start with config and export policy.
 
-The first implementation pass should add the configuration shape and the
-redaction/export policy. That gives maintainers a place to review the boundary
-before data starts moving.
+The first implementation pass should define the configuration shape and the
+redaction rules. That gives maintainers something concrete to review before
+data starts moving.
 
-A later pass can add the exporter. It should be small, backend-owned, and
+The exporter can come after that. It should be small, backend-owned, and
 isolated behind an internal interface. Langfuse SDK calls should not spread
 through handlers and services.
 
@@ -162,67 +156,41 @@ When enabled, the exporter should run after Footnote has produced its own
 response metadata. If Langfuse is down, slow, misconfigured, unreachable, or
 throws SDK errors, Footnote should continue normally.
 
-After that, test it against a local or development Langfuse instance and ask
-boring practical questions:
+Then test it against a local or development Langfuse instance:
 
-- Does it make fallback-heavy runs easier to find?
-- Does it help compare workflow modes?
-- Does it make cost patterns easier to inspect?
-- Does it help collect eval examples?
+- Can we find fallback-heavy runs more easily?
+- Can we compare workflow modes?
+- Can we inspect cost patterns?
+- Can we collect useful eval examples?
 - Do maintainers actually use it?
 
 If not, keep it experimental or remove it.
 
 ---
 
-## What Comes Later
+## Later Work
 
-Langfuse eval workflows may be useful after shadow export proves itself.
-Selected runs could become datasets, experiments, or scored examples.
+Eval workflows may be useful after shadow export proves itself. Selected runs
+could become datasets, experiments, or scored examples. Those scores should
+stay advisory unless Footnote explicitly decides otherwise.
 
-Those scores should stay advisory unless Footnote explicitly decides otherwise.
-
-Prompt management is also later. Footnote prompts are not just strings; some
+Prompt management is also later. Footnote prompts are not just strings. Some
 carry policy, review posture, provenance expectations, and product meaning. If
-Langfuse prompt management is tested, start with non-governance prompt
+Langfuse prompt management gets tested, start with non-governance prompt
 segments. Keep policy, safety, provenance, and review-sensitive prompt layers
-in the repo unless a later proposal changes that boundary.
+in the repo unless a later proposal changes that line.
 
----
+Adaptive workflow behavior is later still.
 
-## When This Becomes A Bad Idea
+Langfuse may eventually provide aggregate signals that help Footnote tune
+workflow behavior. TrustGraph may provide source or evidence signals. Operator
+evals may identify weak paths.
 
-This experiment should stop or stay parked if the value does not justify the
-weight.
+Those signals should not directly steer live execution. If outside evidence
+ever affects workflow behavior, it needs to pass through Footnote-owned policy
+and show up in trace/provenance.
 
-Warning signs:
-
-- maintainers do not use it,
-- the infra cost is too high,
-- raw content starts exporting by default,
-- Langfuse labels start replacing Footnote provenance language,
-- SDK details leak across backend code,
-- prompt management sneaks in before the boundary is clear,
-- or self-hosting Footnote starts to feel incomplete without Langfuse.
-
-The point is to learn whether the extra visibility is worth it. If it is not,
-delete the integration. Do not let it become permanent just because it exists.
-
----
-
-## What This Proposal Says
-
-This proposal says Langfuse is worth trying as optional maintainer/operator
-tooling.
-
-It should start as a metadata-only mirror of Footnote-owned execution data.
-
-It should be disabled by default, fail open, and remain removable.
-
-It does not say Langfuse should replace Footnote traces, provenance, incidents,
-cost accounting, prompt review, consent, or the default self-hosted stack.
-
-Those would be separate decisions.
+For now, keep the rule simple: Langfuse observes. Footnote decides.
 
 ---
 
@@ -230,62 +198,13 @@ Those would be separate decisions.
 
 Proceed with a narrow Langfuse experiment:
 
-1. Document the stance.
-2. Add config and export policy.
-3. Add a small metadata-only shadow exporter.
-4. Test against a local or development Langfuse instance.
-5. Keep it only if it helps maintainers.
+1. Add config and export policy.
+2. Add a small metadata-only shadow exporter.
+3. Test against a local or development Langfuse instance.
+4. Keep it only if it helps maintainers.
 
 No raw content by default. No prompt management in the first pass. No
 replacement of Footnote trace/provenance semantics.
-
----
-
-## Longer-Term Direction
-
-There is a larger idea behind this, but it should not be part of the first Langfuse integration.
-
-In the future, Footnote may be able to adjust workflow execution based on evidence gathered outside the current request. That could include things like:
-
-- eval results from previous runs,
-- fallback patterns across providers,
-- known weak prompt/model combinations,
-- TrustGraph evidence about sources or claims,
-- operator-reviewed examples,
-- or aggregate quality signals from observability tools.
-
-Used carefully, that could help Footnote choose a more appropriate workflow path. For example, it might route some requests toward a more careful review path, avoid a weak provider/model combination, require stronger grounding for certain source types, or flag a run for extra trace visibility.
-
-That is not what the first Langfuse experiment should do.
-
-The first Langfuse integration should observe. It should not steer.
-
-Any future adaptive workflow behavior needs its own design decision, because it changes the authority model. The question would no longer be only “what happened?” It would become “what outside evidence is allowed to change what happens next?”
-
-That boundary matters.
-
-If external signals ever influence workflow execution, Footnote should keep a few rules:
-
-- the Execution Contract still sets the allowed run rules;
-- workflow still owns sequencing;
-- external systems provide advisory signals, not hidden authority;
-- any adjustment should be visible in trace/provenance;
-- the reason for the adjustment should be recorded;
-- stale or missing external signals should fail open or fall back predictably;
-- user privacy and consent rules should apply before telemetry becomes control input;
-- and no vendor tool should become the silent policy engine.
-
-Langfuse might eventually help produce useful aggregate signals. TrustGraph might eventually provide source or evidence signals. Operator evals might eventually identify weak paths. But none of those should silently rewrite runtime behavior.
-
-The safe path is:
-
-1. observe runs;
-2. evaluate patterns;
-3. summarize findings;
-4. let Footnote-owned policy decide whether those findings can affect workflow;
-5. record any adjustment when it happens.
-
-That keeps the door open without pretending the door is already safe to walk through.
 
 ---
 
@@ -321,8 +240,3 @@ That keeps the door open without pretending the door is already safe to walk thr
   [https://langfuse.com/self-hosting](https://langfuse.com/self-hosting)
 - Langfuse license:
   [https://github.com/langfuse/langfuse/blob/main/LICENSE](https://github.com/langfuse/langfuse/blob/main/LICENSE)
-
----
-
-_Prepared for maintainer discussion and later implementation planning within
-Footnote._

--- a/docs/proposals/proposal_langfuse_shadow_observability.md
+++ b/docs/proposals/proposal_langfuse_shadow_observability.md
@@ -1,0 +1,465 @@
+# Feature Proposal: Optional Langfuse Shadow Observability
+
+**Last Updated:** 2026-04-21
+
+---
+
+## Overview
+
+This proposal recommends a narrow experiment: optional **Langfuse** integration
+as a shadow observability layer for Footnote maintainers and operators.
+
+Footnote already records a lot about one response. Current response metadata
+and trace storage cover routing, workflow lineage, planner influence,
+provenance, TRACE posture, steerability controls, tool outcomes, and
+backend-recorded cost. That is the right foundation for explaining one run.
+
+The missing piece is a good maintainer view across many runs.
+
+That gap is where Langfuse may help. Not as a replacement for Footnote traces,
+and not as a new policy or provenance authority. More as an optional operator
+workbench for cross-run inspection, debugging, evaluation collection, and drift
+spotting.
+
+The proposed direction is deliberately narrow:
+
+- optional,
+- disabled by default,
+- metadata-only by default,
+- fail-open,
+- removable without changing Footnote's public product meaning.
+
+Langfuse may help us inspect Footnote. It should not become the thing that
+defines Footnote.
+
+---
+
+## Why This Is Worth Considering
+
+Footnote's trace and metadata work already answers an important question:
+"what happened here?"
+
+For one response, maintainers can inspect:
+
+- selected workflow mode,
+- workflow lineage,
+- planner influence recorded in `metadata.execution[]`,
+- provenance classification,
+- TRACE target/final posture,
+- tool and evaluator outcomes,
+- and backend-recorded usage/cost metadata.
+
+That is useful for one run. It is less useful for watching patterns across many
+runs.
+
+A maintainer may want to know:
+
+- which workflow modes are actually common,
+- where planner or provider fallback happens,
+- which model routes are expensive,
+- whether a prompt change improved anything,
+- whether one workflow path generates noisy review cycles,
+- which runs should become eval examples,
+- or whether a regression is only visible at aggregate scale.
+
+Footnote could eventually build more of that natively. Some of it may belong in
+Footnote over time. But a full cross-run observability and evaluation surface is
+not the core product right now, and it is not free to build well.
+
+Langfuse already operates in that space. It is worth trying only if the
+experiment stays small and does not blur Footnote's own architecture.
+
+---
+
+## Footnote Context
+
+Footnote is not just a thin wrapper around a model provider.
+
+The project already has its own semantics for:
+
+- Execution Contract authority,
+- workflow mode and workflow profile selection,
+- TRACE posture,
+- provenance and response metadata,
+- steerability controls,
+- TrustGraph evidence handling,
+- incident storage and audit,
+- pseudonymization boundaries,
+- and backend cost recording.
+
+Those meanings are part of the product. They are not generic telemetry.
+
+That matters because Langfuse uses similar words: traces, observations, scores,
+prompts, datasets, evaluations. The overlap is useful, but it is also where the
+risk lives.
+
+A Langfuse trace is not automatically the same thing as a Footnote trace.
+A Langfuse score is not automatically a Footnote policy signal.
+A Langfuse prompt version is not automatically a safe replacement for Footnote's
+prompt resolution.
+
+Footnote's backend should remain the place where those meanings are decided.
+Langfuse can receive a mirrored view of some runtime metadata, but it should not
+become the source of truth for public trace retrieval, user-facing provenance,
+incident records, Execution Contract behavior, or cost accounting.
+
+Put simply: Langfuse can help maintainers inspect runs. Footnote still owns the
+run.
+
+---
+
+## Current Code Alignment
+
+This proposal assumes the current architecture and should be read with a few
+repo realities in mind:
+
+- Footnote already has optional observability-related wiring for VoltAgent
+  tracing configuration. This proposal is not introducing the first
+  observability seam in the repo. It is proposing a separate backend-owned
+  shadow exporter for Footnote runtime metadata.
+- The durable public trace key today is `responseId`. The current trace store
+  and public trace routes are keyed around that concept. This proposal should
+  not invent a second first-class "trace ID" concept unless the architecture
+  changes later.
+- Planner metadata affects execution today, but planner is not yet a first-class
+  workflow step in current workflow lineage. Planner influence is recorded in
+  `metadata.execution[]` and related metadata surfaces alongside workflow
+  lineage.
+- Backend is already the authority for LLM cost recording. Any export to
+  Langfuse should mirror that backend-owned value, not replace it.
+- Footnote does not currently have a broad, general-purpose user consent model.
+  There is incident-specific consent metadata (`consentedAt`) in incident
+  records, but this proposal should not imply that Langfuse integration plugs
+  into a wider consent framework that does not yet exist.
+
+These constraints are part of the proposal, not editorial footnotes.
+
+---
+
+## The Boundary We Should Keep
+
+The boundary is simple.
+
+Langfuse can inspect runs. It should not decide what a run means.
+
+That means Langfuse should not replace:
+
+- Footnote trace storage,
+- public trace retrieval,
+- response metadata assembly,
+- workflow semantics,
+- provenance labels,
+- steerability semantics,
+- incident storage and audit,
+- pseudonymization boundaries,
+- backend cost recording,
+- or Execution Contract behavior.
+
+It also should not become the place where policy-sensitive prompt layers are
+edited outside normal repo review.
+
+Observability tools can quietly become authority layers if a project stops
+treating them as mirrors. That is the failure mode to avoid here.
+
+If Langfuse is added, it should stay optional shadow telemetry: useful, narrow,
+and removable.
+
+---
+
+## Why Langfuse Fits The Narrow Use Case
+
+Langfuse fits best as operator-side observability.
+
+The strongest fit is not the user-facing trace page. Footnote already has that,
+and it should remain Footnote-owned.
+
+The stronger fit is the maintainer view across many runs. That may include:
+
+- finding fallback-heavy runs,
+- comparing `fast`, `balanced`, and `grounded` patterns,
+- spotting expensive provider paths,
+- gathering examples for evals,
+- or checking whether a prompt or workflow change helped in practice.
+
+Langfuse also has practical integration paths through JS/TS SDKs and API-based
+instrumentation. That gives Footnote options.
+
+The first pass should still avoid broad auto-instrumentation. Footnote already
+has meaningful backend-owned metadata. A small explicit exporter is easier to
+review, easier to test, and easier to remove.
+
+Langfuse also has a self-hosting path, which is important for Footnote. But it
+is not lightweight. It adds real infrastructure and operational cost. That
+means Langfuse should not become part of Footnote's default self-hosted stack.
+It should stay optional for operators who decide the extra visibility is worth
+it.
+
+---
+
+## What Langfuse Should Not Own
+
+Langfuse should not own Footnote's public product truth.
+
+Footnote should keep ownership of:
+
+- trace storage and retrieval,
+- response metadata,
+- workflow lineage,
+- planner influence metadata,
+- provenance labels,
+- steerability semantics,
+- incident and audit records,
+- pseudonymization,
+- privacy and retention decisions around export,
+- backend cost recording,
+- Execution Contract behavior,
+- and policy-sensitive prompt layers.
+
+Some of that metadata may later be mirrored to Langfuse. But mirroring is not
+ownership.
+
+If a user asks what happened for one answer, Footnote should answer from
+Footnote data.
+
+If a maintainer wants to compare many runs, Langfuse may help.
+
+That split is the proposal.
+
+---
+
+## Privacy Default
+
+The default export should be conservative.
+
+LLM traces can contain sensitive user text, assistant output, tool results,
+prompt details, provider responses, local paths, secrets, and internal
+metadata. Exporting all of that by default to an optional observability system
+would be a poor fit for Footnote's privacy posture.
+
+The first version should export metadata only.
+
+That likely means things like:
+
+- Footnote `responseId`,
+- workflow mode,
+- workflow step kinds and termination reason,
+- planner status if available,
+- evaluator/tool status if available,
+- provider and model,
+- duration,
+- token usage,
+- backend-recorded cost,
+- and redacted tags useful for debugging.
+
+The first version should not export:
+
+- raw user messages,
+- raw assistant messages,
+- full prompts,
+- raw planner payloads,
+- raw provider responses,
+- incident details,
+- trace API tokens or service secrets,
+- local filesystem paths,
+- or unbounded tool outputs.
+
+If content export is added later, it should be an explicit opt-in with an
+unambiguous config flag. The default should remain `false`.
+
+That is not paranoia. It is basic hygiene.
+
+---
+
+## How We Should Try It
+
+The first step should be documentation, not code.
+
+We should add a short architecture or proposal note that states the stance
+clearly:
+
+- Langfuse is optional shadow telemetry.
+- Footnote remains the source of truth.
+- Export is metadata-only by default.
+- Langfuse is disabled by default.
+- Export failures fail open.
+- Raw content export is opt-in.
+- Prompt management is not part of the first pass.
+- Incidents, provenance, workflow authority, and cost stay Footnote-owned.
+
+After that, add configuration without exporting anything yet. The config should
+be deliberately boring: enabled flag, base URL, public/secret keys, content
+export flag, and maybe an environment or sampling guard if needed.
+
+Only then should we add a small shadow exporter.
+
+That exporter should run after Footnote has already assembled the metadata it
+would own anyway. It should mirror a minimal safe payload to Langfuse when
+enabled. If Langfuse is down, slow, unreachable, misconfigured, or throws SDK
+errors, Footnote should continue normally.
+
+The integration should sit behind a small internal interface. Langfuse SDK
+calls should not spread through handlers and services.
+
+If the experiment proves useful, we can ask practical maintainer questions:
+
+- Can we find fallback-heavy runs more easily?
+- Can we compare workflow modes in a useful way?
+- Can we inspect cost patterns without inventing a second cost authority?
+- Can we collect better eval examples?
+- Does this materially help maintainers?
+
+If not, the feature should stay experimental or be removed. The integration
+should earn its keep.
+
+---
+
+## Evaluation Work Later
+
+Langfuse evaluation workflows may be useful after shadow observability proves
+itself.
+
+That could mean selected runs being copied into datasets, experiments, or score
+tracking for prompt/model changes.
+
+The important boundary is that eval results remain advisory unless Footnote
+explicitly decides otherwise later.
+
+A Langfuse score should not silently become policy.
+
+If eval results ever influence production behavior, that should be a separate
+proposal and a separate authority decision.
+
+---
+
+## Prompt Experiments Later
+
+Langfuse prompt management is also a later possibility, not a first step.
+
+Footnote's prompts are not just strings. Some prompt layers carry policy,
+review posture, provenance expectations, and product meaning. Moving those
+layers into an external prompt UI too early would blur review and deployment
+boundaries.
+
+If prompt management is tested later, start with non-governance prompt segments.
+
+Keep policy, safety, provenance, and review-sensitive prompt layers in-repo
+unless a later proposal explicitly changes that boundary.
+
+---
+
+## What Would Make This A Bad Idea
+
+This integration is not automatically worth it just because Langfuse is useful.
+
+It becomes a bad idea if:
+
+- the infrastructure cost is too high for the value returned,
+- maintainers do not actually use it,
+- raw content starts leaking by default,
+- Langfuse labels start replacing Footnote's provenance language,
+- SDK details spread through backend code,
+- prompt management sneaks in before the boundary is clear,
+- or self-hosting Footnote starts feeling incomplete without a separate
+  observability stack.
+
+Those are not reasons to reject the experiment now. They are the conditions to
+watch closely if the experiment begins.
+
+---
+
+## What This Proposal Does And Does Not Say
+
+### This proposal does say
+
+This proposal says Langfuse is worth exploring as optional maintainer/operator
+tooling.
+
+It may help with cross-run observability, debugging, evaluation collection, and
+operational visibility.
+
+It should start as a metadata-only mirror of Footnote-owned execution data.
+
+It should be disabled by default and fail open.
+
+### This proposal does not say
+
+It does not say Langfuse should replace Footnote traces.
+
+It does not say Langfuse should own provenance.
+
+It does not say Langfuse should own incidents or audit records.
+
+It does not say Langfuse should own cost accounting.
+
+It does not say prompt management should move to Langfuse.
+
+It does not say Langfuse should become part of Footnote's default self-hosted
+stack.
+
+It does not say user content should be exported by default.
+
+Those would be different decisions.
+
+---
+
+## Proposed Direction
+
+Footnote should try Langfuse as optional shadow observability.
+
+The first implementation should be narrow:
+
+- config first,
+- metadata-only export,
+- disabled by default,
+- fail-open,
+- no raw content by default,
+- no prompt management,
+- no incident replacement,
+- no provenance replacement,
+- no cost authority replacement.
+
+If that proves useful, the integration can later grow into evaluation support
+and carefully scoped prompt experiments.
+
+The point is to get maintainer/operator benefits without letting an
+observability tool become Footnote's source of truth.
+
+---
+
+## References And Notes
+
+- Footnote Workflow Engine And Provenance:
+  `docs/architecture/workflow-engine-and-provenance.md`
+- Footnote Workflow Mode Routing:
+  `docs/architecture/workflow-mode-routing.md`
+- Footnote Execution Contract Authority Map:
+  `docs/architecture/execution-contract-authority-map.md`
+- Footnote Response Metadata:
+  `docs/architecture/response-metadata.md`
+- Footnote Incident Storage And Audit:
+  `docs/architecture/incident-storage-and-audit.md`
+- Footnote Prompt Resolution:
+  `docs/architecture/prompt-resolution.md`
+- VoltAgent Runtime Adoption:
+  `docs/decisions/2026-03-voltagent-runtime-adoption.md`
+- Langfuse GitHub:
+  [https://github.com/langfuse/langfuse](https://github.com/langfuse/langfuse)
+- Langfuse docs:
+  [https://langfuse.com/docs](https://langfuse.com/docs)
+- Langfuse observability overview:
+  [https://langfuse.com/docs/observability/overview](https://langfuse.com/docs/observability/overview)
+- Langfuse prompt management overview:
+  [https://langfuse.com/docs/prompt-management/overview](https://langfuse.com/docs/prompt-management/overview)
+- Langfuse evaluation overview:
+  [https://langfuse.com/docs/evaluation/overview](https://langfuse.com/docs/evaluation/overview)
+- Langfuse OpenTelemetry integration:
+  [https://langfuse.com/integrations/native/opentelemetry](https://langfuse.com/integrations/native/opentelemetry)
+- Langfuse self-hosting:
+  [https://langfuse.com/self-hosting](https://langfuse.com/self-hosting)
+- Langfuse license:
+  [https://github.com/langfuse/langfuse/blob/main/LICENSE](https://github.com/langfuse/langfuse/blob/main/LICENSE)
+
+---
+
+_Prepared for maintainer discussion and later implementation planning within
+Footnote._

--- a/docs/proposals/proposal_langfuse_shadow_observability.md
+++ b/docs/proposals/proposal_langfuse_shadow_observability.md
@@ -6,423 +6,238 @@
 
 ## Overview
 
-This proposal recommends a narrow experiment: optional **Langfuse** integration
-as a shadow observability layer for Footnote maintainers and operators.
+Footnote already records enough information to explain one response: the
+selected mode, workflow lineage, planner influence, provenance, TRACE posture
+(the answer posture metadata described in
+`docs/architecture/response-metadata.md`), tool outcomes, and backend-recorded
+cost.
 
-Footnote already records a lot about one response. Current response metadata
-and trace storage cover routing, workflow lineage, planner influence,
-provenance, TRACE posture, steerability controls, tool outcomes, and
-backend-recorded cost. That is the right foundation for explaining one run.
+That is the right foundation for a user-facing trace.
 
-The missing piece is a good maintainer view across many runs.
+It does not give maintainers a great way to look across many runs.
 
-That gap is where Langfuse may help. Not as a replacement for Footnote traces,
-and not as a new policy or provenance authority. More as an optional operator
-workbench for cross-run inspection, debugging, evaluation collection, and drift
-spotting.
+That is the gap Langfuse might fill. It can help with cross-run inspection,
+debugging, eval collection, cost patterns, and drift spotting. It should not
+replace Footnote traces, own provenance semantics, move prompts out of review,
+or become part of the default self-hosted stack.
 
-The proposed direction is deliberately narrow:
+The proposal is narrow: try Langfuse as optional shadow observability.
 
-- optional,
-- disabled by default,
-- metadata-only by default,
-- fail-open,
-- removable without changing Footnote's public product meaning.
+By default it should be off. If enabled, it should export metadata only. If it
+fails, Footnote should keep running normally.
 
-Langfuse may help us inspect Footnote. It should not become the thing that
-defines Footnote.
+Langfuse can help maintainers inspect runs. Footnote still owns the run.
 
 ---
 
-## Why This Is Worth Considering
+## Why This Is Worth Trying
 
-Footnote's trace and metadata work already answers an important question:
-"what happened here?"
+Footnote's trace and metadata work answers a local question:
 
-For one response, maintainers can inspect:
+> What happened for this response?
 
-- selected workflow mode,
-- workflow lineage,
-- planner influence recorded in `metadata.execution[]`,
-- provenance classification,
-- TRACE target/final posture,
-- tool and evaluator outcomes,
-- and backend-recorded usage/cost metadata.
+That matters. It is part of the product.
 
-That is useful for one run. It is less useful for watching patterns across many
-runs.
+But maintainers also need a broader view sometimes:
 
-A maintainer may want to know:
-
-- which workflow modes are actually common,
-- where planner or provider fallback happens,
+- where fallback happens,
+- which workflow modes are common,
 - which model routes are expensive,
-- whether a prompt change improved anything,
-- whether one workflow path generates noisy review cycles,
+- whether a prompt change helped,
 - which runs should become eval examples,
-- or whether a regression is only visible at aggregate scale.
+- and whether a regression only shows up across many responses.
 
-Footnote could eventually build more of that natively. Some of it may belong in
-Footnote over time. But a full cross-run observability and evaluation surface is
-not the core product right now, and it is not free to build well.
+Footnote could build more of that itself, and some of it may eventually belong
+in the product. But a full observability and evaluation surface is not the core
+product right now.
 
-Langfuse already operates in that space. It is worth trying only if the
-experiment stays small and does not blur Footnote's own architecture.
+Langfuse already works in that space. The useful experiment is not "move
+Footnote observability to Langfuse." The useful experiment is "mirror enough
+safe metadata to see whether Langfuse helps maintainers."
 
 ---
 
-## Footnote Context
+## The Boundary
 
-Footnote is not just a thin wrapper around a model provider.
+Footnote has its own meanings for execution, workflow, provenance, incidents,
+pseudonymization, costs, and traces.
 
-The project already has its own semantics for:
+Those meanings stay in Footnote.
 
-- Execution Contract authority,
-- workflow mode and workflow profile selection,
-- TRACE posture,
-- provenance and response metadata,
-- steerability controls,
-- TrustGraph evidence handling,
-- incident storage and audit,
-- pseudonymization boundaries,
-- and backend cost recording.
+Langfuse uses similar words: traces, observations, scores, prompts, datasets,
+evaluations. Those are Langfuse concepts. They can be useful without becoming
+Footnote's product language.
 
-Those meanings are part of the product. They are not generic telemetry.
+A Langfuse trace is not a Footnote trace.
 
-That matters because Langfuse uses similar words: traces, observations, scores,
-prompts, datasets, evaluations. The overlap is useful, but it is also where the
-risk lives.
+A Langfuse score is not a policy signal.
 
-A Langfuse trace is not automatically the same thing as a Footnote trace.
-A Langfuse score is not automatically a Footnote policy signal.
-A Langfuse prompt version is not automatically a safe replacement for Footnote's
+A Langfuse prompt version is not automatically a safe replacement for Footnote
 prompt resolution.
 
-Footnote's backend should remain the place where those meanings are decided.
-Langfuse can receive a mirrored view of some runtime metadata, but it should not
-become the source of truth for public trace retrieval, user-facing provenance,
-incident records, Execution Contract behavior, or cost accounting.
+Langfuse should not replace:
 
-Put simply: Langfuse can help maintainers inspect runs. Footnote still owns the
-run.
-
----
-
-## Current Code Alignment
-
-This proposal assumes the current architecture and should be read with a few
-repo realities in mind:
-
-- Footnote already has optional observability-related wiring for VoltAgent
-  tracing configuration. This proposal is not introducing the first
-  observability seam in the repo. It is proposing a separate backend-owned
-  shadow exporter for Footnote runtime metadata.
-- The durable public trace key today is `responseId`. The current trace store
-  and public trace routes are keyed around that concept. This proposal should
-  not invent a second first-class "trace ID" concept unless the architecture
-  changes later.
-- Planner metadata affects execution today, but planner is not yet a first-class
-  workflow step in current workflow lineage. Planner influence is recorded in
-  `metadata.execution[]` and related metadata surfaces alongside workflow
-  lineage.
-- Backend is already the authority for LLM cost recording. Any export to
-  Langfuse should mirror that backend-owned value, not replace it.
-- Footnote does not currently have a broad, general-purpose user consent model.
-  There is incident-specific consent metadata (`consentedAt`) in incident
-  records, but this proposal should not imply that Langfuse integration plugs
-  into a wider consent framework that does not yet exist.
-
-These constraints are part of the proposal, not editorial footnotes.
-
----
-
-## The Boundary We Should Keep
-
-The boundary is simple.
-
-Langfuse can inspect runs. It should not decide what a run means.
-
-That means Langfuse should not replace:
-
-- Footnote trace storage,
 - public trace retrieval,
-- response metadata assembly,
-- workflow semantics,
-- provenance labels,
-- steerability semantics,
-- incident storage and audit,
-- pseudonymization boundaries,
-- backend cost recording,
-- or Execution Contract behavior.
-
-It also should not become the place where policy-sensitive prompt layers are
-edited outside normal repo review.
-
-Observability tools can quietly become authority layers if a project stops
-treating them as mirrors. That is the failure mode to avoid here.
-
-If Langfuse is added, it should stay optional shadow telemetry: useful, narrow,
-and removable.
-
----
-
-## Why Langfuse Fits The Narrow Use Case
-
-Langfuse fits best as operator-side observability.
-
-The strongest fit is not the user-facing trace page. Footnote already has that,
-and it should remain Footnote-owned.
-
-The stronger fit is the maintainer view across many runs. That may include:
-
-- finding fallback-heavy runs,
-- comparing `fast`, `balanced`, and `grounded` patterns,
-- spotting expensive provider paths,
-- gathering examples for evals,
-- or checking whether a prompt or workflow change helped in practice.
-
-Langfuse also has practical integration paths through JS/TS SDKs and API-based
-instrumentation. That gives Footnote options.
-
-The first pass should still avoid broad auto-instrumentation. Footnote already
-has meaningful backend-owned metadata. A small explicit exporter is easier to
-review, easier to test, and easier to remove.
-
-Langfuse also has a self-hosting path, which is important for Footnote. But it
-is not lightweight. It adds real infrastructure and operational cost. That
-means Langfuse should not become part of Footnote's default self-hosted stack.
-It should stay optional for operators who decide the extra visibility is worth
-it.
-
----
-
-## What Langfuse Should Not Own
-
-Langfuse should not own Footnote's public product truth.
-
-Footnote should keep ownership of:
-
-- trace storage and retrieval,
 - response metadata,
 - workflow lineage,
-- planner influence metadata,
 - provenance labels,
-- steerability semantics,
 - incident and audit records,
-- pseudonymization,
-- privacy and retention decisions around export,
+- pseudonymization boundaries,
 - backend cost recording,
 - Execution Contract behavior,
-- and policy-sensitive prompt layers.
+- or policy-sensitive prompt layers.
 
-Some of that metadata may later be mirrored to Langfuse. But mirroring is not
-ownership.
+Some metadata can be mirrored. Mirroring is not ownership.
 
-If a user asks what happened for one answer, Footnote should answer from
-Footnote data.
+---
 
-If a maintainer wants to compare many runs, Langfuse may help.
+## Current Repo Fit
 
-That split is the proposal.
+The repo already has a few seams that make this plausible.
+
+Footnote has durable trace storage and public trace routes keyed around
+`responseId`. It already records workflow and planner metadata. It already
+treats backend cost recording as authoritative. It also has some optional
+observability-related wiring around VoltAgent tracing.
+
+That means Langfuse does not need to be pushed into request handling as a new
+authority layer.
+
+The clean fit is a backend-owned exporter that runs after Footnote has
+assembled the metadata it already owns.
+
+One important caveat: Footnote does not currently have a broad user consent
+model. Incident records have incident-specific consent metadata, but that is
+not the same thing as a general consent framework for observability export.
+This proposal should not pretend that framework exists.
+
+One more current-state caveat: planner metadata affects execution today, but
+planner is not yet a first-class workflow step in workflow lineage.
 
 ---
 
 ## Privacy Default
 
-The default export should be conservative.
-
-LLM traces can contain sensitive user text, assistant output, tool results,
-prompt details, provider responses, local paths, secrets, and internal
-metadata. Exporting all of that by default to an optional observability system
-would be a poor fit for Footnote's privacy posture.
-
 The first version should export metadata only.
 
-That likely means things like:
+That can include things like:
 
-- Footnote `responseId`,
+- `responseId`,
 - workflow mode,
-- workflow step kinds and termination reason,
-- planner status if available,
-- evaluator/tool status if available,
+- workflow step kinds,
+- termination reason,
+- planner status,
+- evaluator or tool status,
 - provider and model,
 - duration,
 - token usage,
 - backend-recorded cost,
-- and redacted tags useful for debugging.
+- and redacted debugging tags.
 
-The first version should not export:
+It should not export raw user messages, assistant messages, full prompts, raw
+planner payloads, provider responses, incident details, trace tokens, secrets,
+local paths, or unbounded tool output.
 
-- raw user messages,
-- raw assistant messages,
-- full prompts,
-- raw planner payloads,
-- raw provider responses,
-- incident details,
-- trace API tokens or service secrets,
-- local filesystem paths,
-- or unbounded tool outputs.
+If content export is added later, it should be an explicit opt-in. The default
+should remain off.
 
-If content export is added later, it should be an explicit opt-in with an
-unambiguous config flag. The default should remain `false`.
-
-That is not paranoia. It is basic hygiene.
+That is not a nice-to-have. It is the difference between observability and a
+privacy foot-gun.
 
 ---
 
-## How We Should Try It
+## How To Try It
 
-The first step should be documentation, not code.
+Start with documentation and config, not runtime export.
 
-We should add a short architecture or proposal note that states the stance
-clearly:
+The first implementation pass should add the configuration shape and the
+redaction/export policy. That gives maintainers a place to review the boundary
+before data starts moving.
 
-- Langfuse is optional shadow telemetry.
-- Footnote remains the source of truth.
-- Export is metadata-only by default.
-- Langfuse is disabled by default.
-- Export failures fail open.
-- Raw content export is opt-in.
-- Prompt management is not part of the first pass.
-- Incidents, provenance, workflow authority, and cost stay Footnote-owned.
+A later pass can add the exporter. It should be small, backend-owned, and
+isolated behind an internal interface. Langfuse SDK calls should not spread
+through handlers and services.
 
-After that, add configuration without exporting anything yet. The config should
-be deliberately boring: enabled flag, base URL, public/secret keys, content
-export flag, and maybe an environment or sampling guard if needed.
+When enabled, the exporter should run after Footnote has produced its own
+response metadata. If Langfuse is down, slow, misconfigured, unreachable, or
+throws SDK errors, Footnote should continue normally.
 
-Only then should we add a small shadow exporter.
+After that, test it against a local or development Langfuse instance and ask
+boring practical questions:
 
-That exporter should run after Footnote has already assembled the metadata it
-would own anyway. It should mirror a minimal safe payload to Langfuse when
-enabled. If Langfuse is down, slow, unreachable, misconfigured, or throws SDK
-errors, Footnote should continue normally.
+- Does it make fallback-heavy runs easier to find?
+- Does it help compare workflow modes?
+- Does it make cost patterns easier to inspect?
+- Does it help collect eval examples?
+- Do maintainers actually use it?
 
-The integration should sit behind a small internal interface. Langfuse SDK
-calls should not spread through handlers and services.
-
-If the experiment proves useful, we can ask practical maintainer questions:
-
-- Can we find fallback-heavy runs more easily?
-- Can we compare workflow modes in a useful way?
-- Can we inspect cost patterns without inventing a second cost authority?
-- Can we collect better eval examples?
-- Does this materially help maintainers?
-
-If not, the feature should stay experimental or be removed. The integration
-should earn its keep.
+If not, keep it experimental or remove it.
 
 ---
 
-## Evaluation Work Later
+## What Comes Later
 
-Langfuse evaluation workflows may be useful after shadow observability proves
-itself.
+Langfuse eval workflows may be useful after shadow export proves itself.
+Selected runs could become datasets, experiments, or scored examples.
 
-That could mean selected runs being copied into datasets, experiments, or score
-tracking for prompt/model changes.
+Those scores should stay advisory unless Footnote explicitly decides otherwise.
 
-The important boundary is that eval results remain advisory unless Footnote
-explicitly decides otherwise later.
-
-A Langfuse score should not silently become policy.
-
-If eval results ever influence production behavior, that should be a separate
-proposal and a separate authority decision.
+Prompt management is also later. Footnote prompts are not just strings; some
+carry policy, review posture, provenance expectations, and product meaning. If
+Langfuse prompt management is tested, start with non-governance prompt
+segments. Keep policy, safety, provenance, and review-sensitive prompt layers
+in the repo unless a later proposal changes that boundary.
 
 ---
 
-## Prompt Experiments Later
+## When This Becomes A Bad Idea
 
-Langfuse prompt management is also a later possibility, not a first step.
+This experiment should stop or stay parked if the value does not justify the
+weight.
 
-Footnote's prompts are not just strings. Some prompt layers carry policy,
-review posture, provenance expectations, and product meaning. Moving those
-layers into an external prompt UI too early would blur review and deployment
-boundaries.
+Warning signs:
 
-If prompt management is tested later, start with non-governance prompt segments.
-
-Keep policy, safety, provenance, and review-sensitive prompt layers in-repo
-unless a later proposal explicitly changes that boundary.
-
----
-
-## What Would Make This A Bad Idea
-
-This integration is not automatically worth it just because Langfuse is useful.
-
-It becomes a bad idea if:
-
-- the infrastructure cost is too high for the value returned,
-- maintainers do not actually use it,
-- raw content starts leaking by default,
-- Langfuse labels start replacing Footnote's provenance language,
-- SDK details spread through backend code,
+- maintainers do not use it,
+- the infra cost is too high,
+- raw content starts exporting by default,
+- Langfuse labels start replacing Footnote provenance language,
+- SDK details leak across backend code,
 - prompt management sneaks in before the boundary is clear,
-- or self-hosting Footnote starts feeling incomplete without a separate
-  observability stack.
+- or self-hosting Footnote starts to feel incomplete without Langfuse.
 
-Those are not reasons to reject the experiment now. They are the conditions to
-watch closely if the experiment begins.
+The point is to learn whether the extra visibility is worth it. If it is not,
+delete the integration. Do not let it become permanent just because it exists.
 
 ---
 
-## What This Proposal Does And Does Not Say
+## What This Proposal Says
 
-### This proposal does say
-
-This proposal says Langfuse is worth exploring as optional maintainer/operator
+This proposal says Langfuse is worth trying as optional maintainer/operator
 tooling.
-
-It may help with cross-run observability, debugging, evaluation collection, and
-operational visibility.
 
 It should start as a metadata-only mirror of Footnote-owned execution data.
 
-It should be disabled by default and fail open.
+It should be disabled by default, fail open, and remain removable.
 
-### This proposal does not say
+It does not say Langfuse should replace Footnote traces, provenance, incidents,
+cost accounting, prompt review, consent, or the default self-hosted stack.
 
-It does not say Langfuse should replace Footnote traces.
-
-It does not say Langfuse should own provenance.
-
-It does not say Langfuse should own incidents or audit records.
-
-It does not say Langfuse should own cost accounting.
-
-It does not say prompt management should move to Langfuse.
-
-It does not say Langfuse should become part of Footnote's default self-hosted
-stack.
-
-It does not say user content should be exported by default.
-
-Those would be different decisions.
+Those would be separate decisions.
 
 ---
 
 ## Proposed Direction
 
-Footnote should try Langfuse as optional shadow observability.
+Proceed with a narrow Langfuse experiment:
 
-The first implementation should be narrow:
+1. Document the stance.
+2. Add config and export policy.
+3. Add a small metadata-only shadow exporter.
+4. Test against a local or development Langfuse instance.
+5. Keep it only if it helps maintainers.
 
-- config first,
-- metadata-only export,
-- disabled by default,
-- fail-open,
-- no raw content by default,
-- no prompt management,
-- no incident replacement,
-- no provenance replacement,
-- no cost authority replacement.
-
-If that proves useful, the integration can later grow into evaluation support
-and carefully scoped prompt experiments.
-
-The point is to get maintainer/operator benefits without letting an
-observability tool become Footnote's source of truth.
+No raw content by default. No prompt management in the first pass. No
+replacement of Footnote trace/provenance semantics.
 
 ---
 


### PR DESCRIPTION
## Summary

This PR adds a maintainer-facing proposal for trying Langfuse as optional shadow observability in Footnote.

## What changed

- Added `docs/proposals/proposal_langfuse_shadow_observability.md`
- Framed Langfuse as an optional, metadata-only, fail-open shadow exporter rather than a replacement for Footnote tracing
- Reworked the proposal to read as a Footnote maintainer note instead of a vendor integration RFC
- Aligned the proposal with current repo semantics around `responseId`, backend cost authority, planner/workflow boundaries, and the lack of a broad consent framework for observability export

## Why these changes were made

The task for this branch was to investigate what Langfuse could add to Footnote, where it overlaps with existing systems, what tradeoffs it brings, and how well it fits Footnote's current ethos and architecture.

The resulting proposal keeps that investigation narrow and practical. It argues for a limited experiment that may help maintainers inspect patterns across many runs without letting Langfuse become a new authority for provenance, workflow meaning, prompt review, incidents, or cost accounting.

## Important implementation details

- The proposal treats Footnote as the source of truth for execution, workflow, provenance, incidents, pseudonymization, and backend-recorded cost
- It keeps the first pass metadata-only by default and explicitly fail-open
- It calls out current repo details that matter to a future implementation, including:
  - `responseId` as the durable public trace key
  - backend-owned cost recording
  - planner metadata not being a first-class workflow step in the main chat path today
  - incident-specific consent metadata not being the same thing as a general observability-export consent model
- It keeps prompt management, eval-driven behavior changes, and any adaptive workflow use as later follow-up work rather than part of the initial proposal

This PR was written using [Vibe Kanban](https://vibekanban.com)