### PR TITLE
Add Workflow Receipt to Web Provenance and Discord Details Summary (Vibe Kanban)

### DIFF
--- a/packages/contracts/src/ethics-core/index.ts
+++ b/packages/contracts/src/ethics-core/index.ts
@@ -78,6 +78,13 @@ export {
 } from './types.js';
 export { formatExecutionTimelineSummary } from './executionFormatting.js';
 export {
+    resolveWorkflowModeLabel,
+    resolveReviewReceipt,
+    resolvePlannerFallbackReceipt,
+    buildWorkflowReceiptItems,
+    buildWorkflowReceiptSummary,
+} from './workflowReceipt.js';
+export {
     SafetyRuleIdSchema,
     SafetyActionSchema,
     SafetyReasonCodeSchema,

--- a/packages/contracts/src/ethics-core/workflowReceipt.ts
+++ b/packages/contracts/src/ethics-core/workflowReceipt.ts
@@ -15,12 +15,10 @@ const WORKFLOW_MODE_LABELS: Record<WorkflowModeId, string> = {
 };
 
 /**
- * Resolves user-facing workflow mode label from explicit metadata only.
+ * Returns the user-facing mode label for the receipt.
  *
- * Authority and decision rules:
- * - Primary: `workflowMode.modeId`.
- * - Fallback: `workflowMode.behavior.executionContractPresetId`.
- * - Fail-open: returns `null` for unknown/missing fields.
+ * We only read explicit metadata fields. We do not infer from model names or
+ * workflow profile IDs. If fields are missing or unknown, we return `null`.
  */
 export const resolveWorkflowModeLabel = (
     metadata: ResponseMetadata
@@ -45,15 +43,14 @@ export const resolveWorkflowModeLabel = (
 };
 
 /**
- * Resolves review receipt state from explicit metadata only.
+ * Returns the review state line for the receipt.
  *
- * Authority and decision rules:
- * - `Reviewed before final answer` only when an `assess` step ran
- *   (`workflow.steps[].stepKind === "assess"` and status is not `skipped`).
- * - `Review skipped` when `workflowMode.behavior.reviewPass === "excluded"`.
- * - `Review skipped` when review pass is included, workflow has steps, and no
- *   review step ran.
- * - Fail-open: returns `null` when metadata is missing/unknown.
+ * Rules:
+ * - Show `Reviewed before final answer` only when an `assess` step actually
+ *   ran (status is not `skipped`).
+ * - Show `Review skipped` when metadata says review was excluded, or when
+ *   review was expected but no review step ran.
+ * - Return `null` when metadata is missing or not decisive.
  */
 export const resolveReviewReceipt = (
     metadata: ResponseMetadata
@@ -81,14 +78,11 @@ export const resolveReviewReceipt = (
 };
 
 /**
- * Resolves planner-fallback receipt state from explicit metadata only.
+ * Returns planner fallback status for the receipt.
  *
- * Authority and decision rules:
- * - Emits `Planner fallback` when workflow plan steps or planner execution
- *   events explicitly record fallback via:
- *   - reasonCode: `planner_runtime_error` / `planner_invalid_output`
- *   - contractType: `fallback`
- * - Fail-open: returns `null` when metadata is missing/unknown.
+ * We only emit `Planner fallback` when fallback is explicitly recorded in
+ * workflow plan steps or planner execution events. If not explicit, return
+ * `null`.
  */
 export const resolvePlannerFallbackReceipt = (
     metadata: ResponseMetadata
@@ -127,12 +121,10 @@ export const resolvePlannerFallbackReceipt = (
 };
 
 /**
- * Builds compact user-facing workflow receipt items from explicit metadata.
+ * Builds receipt lines in a stable order for UI rendering.
  *
- * Returned items are conservative and path-semantic:
- * - `Answered in <mode>`
- * - `Reviewed before final answer` / `Review skipped`
- * - `Planner fallback`
+ * The copy is intentionally conservative and path-focused. It does not claim
+ * correctness, verification, or guarantees.
  */
 export const buildWorkflowReceiptItems = (
     metadata: ResponseMetadata
@@ -147,10 +139,8 @@ export const buildWorkflowReceiptItems = (
     ].filter((item): item is string => item !== null);
 
 /**
- * Builds one markdown-friendly summary line from workflow receipt items.
- *
- * Fail-open behavior: returns `null` when no explicit receipt items are
- * available.
+ * Joins receipt lines into one summary sentence for markdown surfaces.
+ * Returns `null` when no receipt lines are available.
  */
 export const buildWorkflowReceiptSummary = (
     metadata: ResponseMetadata

--- a/packages/contracts/src/ethics-core/workflowReceipt.ts
+++ b/packages/contracts/src/ethics-core/workflowReceipt.ts
@@ -1,0 +1,164 @@
+/**
+ * @description: Shared workflow receipt helpers for web and Discord provenance surfaces.
+ * @footnote-scope: interface
+ * @footnote-module: WorkflowReceiptFormatting
+ * @footnote-risk: medium - Incorrect mapping can misstate workflow path details in user-visible receipts.
+ * @footnote-ethics: high - Receipt copy influences user trust, so language must remain conservative and non-overclaiming.
+ */
+
+import type { ResponseMetadata, WorkflowModeId } from './types.js';
+
+const WORKFLOW_MODE_LABELS: Record<WorkflowModeId, string> = {
+    fast: 'Fast mode',
+    balanced: 'Balanced mode',
+    grounded: 'Grounded mode',
+};
+
+/**
+ * Resolves user-facing workflow mode label from explicit metadata only.
+ *
+ * Authority and decision rules:
+ * - Primary: `workflowMode.modeId`.
+ * - Fallback: `workflowMode.behavior.executionContractPresetId`.
+ * - Fail-open: returns `null` for unknown/missing fields.
+ */
+export const resolveWorkflowModeLabel = (
+    metadata: ResponseMetadata
+): string | null => {
+    const modeId = metadata.workflowMode?.modeId;
+    if (modeId) {
+        return WORKFLOW_MODE_LABELS[modeId];
+    }
+
+    const presetId = metadata.workflowMode?.behavior?.executionContractPresetId;
+    if (presetId === 'fast-direct') {
+        return WORKFLOW_MODE_LABELS.fast;
+    }
+    if (presetId === 'balanced') {
+        return WORKFLOW_MODE_LABELS.balanced;
+    }
+    if (presetId === 'quality-grounded') {
+        return WORKFLOW_MODE_LABELS.grounded;
+    }
+
+    return null;
+};
+
+/**
+ * Resolves review receipt state from explicit metadata only.
+ *
+ * Authority and decision rules:
+ * - `Reviewed before final answer` only when an `assess` step ran
+ *   (`workflow.steps[].stepKind === "assess"` and status is not `skipped`).
+ * - `Review skipped` when `workflowMode.behavior.reviewPass === "excluded"`.
+ * - `Review skipped` when review pass is included, workflow has steps, and no
+ *   review step ran.
+ * - Fail-open: returns `null` when metadata is missing/unknown.
+ */
+export const resolveReviewReceipt = (
+    metadata: ResponseMetadata
+): string | null => {
+    const reviewStepRan =
+        metadata.workflow?.steps?.some(
+            (step) =>
+                step.stepKind === 'assess' && step.outcome.status !== 'skipped'
+        ) ?? false;
+    if (reviewStepRan) {
+        return 'Reviewed before final answer';
+    }
+
+    const reviewPass = metadata.workflowMode?.behavior?.reviewPass;
+    if (reviewPass === 'excluded') {
+        return 'Review skipped';
+    }
+
+    const workflowStepCount = metadata.workflow?.steps?.length ?? 0;
+    if (reviewPass === 'included' && workflowStepCount > 0) {
+        return 'Review skipped';
+    }
+
+    return null;
+};
+
+/**
+ * Resolves planner-fallback receipt state from explicit metadata only.
+ *
+ * Authority and decision rules:
+ * - Emits `Planner fallback` when workflow plan steps or planner execution
+ *   events explicitly record fallback via:
+ *   - reasonCode: `planner_runtime_error` / `planner_invalid_output`
+ *   - contractType: `fallback`
+ * - Fail-open: returns `null` when metadata is missing/unknown.
+ */
+export const resolvePlannerFallbackReceipt = (
+    metadata: ResponseMetadata
+): string | null => {
+    const plannerFallbackInWorkflow =
+        metadata.workflow?.steps?.some((step) => {
+            if (step.stepKind !== 'plan') {
+                return false;
+            }
+            if (
+                step.reasonCode === 'planner_runtime_error' ||
+                step.reasonCode === 'planner_invalid_output'
+            ) {
+                return true;
+            }
+            return step.outcome.signals?.contractType === 'fallback';
+        }) ?? false;
+
+    const plannerFallbackInExecution =
+        metadata.execution?.some((event) => {
+            if (event.kind !== 'planner') {
+                return false;
+            }
+            if (event.contractType === 'fallback') {
+                return true;
+            }
+            return (
+                event.reasonCode === 'planner_runtime_error' ||
+                event.reasonCode === 'planner_invalid_output'
+            );
+        }) ?? false;
+
+    return plannerFallbackInWorkflow || plannerFallbackInExecution
+        ? 'Planner fallback'
+        : null;
+};
+
+/**
+ * Builds compact user-facing workflow receipt items from explicit metadata.
+ *
+ * Returned items are conservative and path-semantic:
+ * - `Answered in <mode>`
+ * - `Reviewed before final answer` / `Review skipped`
+ * - `Planner fallback`
+ */
+export const buildWorkflowReceiptItems = (
+    metadata: ResponseMetadata
+): string[] =>
+    [
+        (() => {
+            const modeLabel = resolveWorkflowModeLabel(metadata);
+            return modeLabel ? `Answered in ${modeLabel}` : null;
+        })(),
+        resolveReviewReceipt(metadata),
+        resolvePlannerFallbackReceipt(metadata),
+    ].filter((item): item is string => item !== null);
+
+/**
+ * Builds one markdown-friendly summary line from workflow receipt items.
+ *
+ * Fail-open behavior: returns `null` when no explicit receipt items are
+ * available.
+ */
+export const buildWorkflowReceiptSummary = (
+    metadata: ResponseMetadata
+): string | null => {
+    const workflowReceiptItems = buildWorkflowReceiptItems(metadata);
+    if (workflowReceiptItems.length === 0) {
+        return null;
+    }
+
+    return workflowReceiptItems.join(' • ');
+};

--- a/packages/contracts/test/workflowReceipt.test.ts
+++ b/packages/contracts/test/workflowReceipt.test.ts
@@ -1,0 +1,153 @@
+/**
+ * @description: Verifies shared workflow receipt helpers stay conservative and fail-open.
+ * @footnote-scope: test
+ * @footnote-module: WorkflowReceiptTests
+ * @footnote-risk: low - Tests only cover deterministic receipt text mapping.
+ * @footnote-ethics: high - Receipt wording must avoid overclaims and reflect real workflow state.
+ */
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+    buildWorkflowReceiptItems,
+    buildWorkflowReceiptSummary,
+    type ResponseMetadata,
+} from '../src/ethics-core';
+
+const createBaseMetadata = (): ResponseMetadata => ({
+    responseId: 'resp_1',
+    provenance: 'Inferred',
+    safetyTier: 'Low',
+    tradeoffCount: 0,
+    chainHash: 'hash_1',
+    licenseContext: 'MIT',
+    modelVersion: 'gpt-5-mini',
+    staleAfter: '2026-04-22T00:00:00.000Z',
+    citations: [],
+    trace_target: {
+        tightness: 3,
+        rationale: 3,
+        attribution: 3,
+        caution: 3,
+        extent: 3,
+    },
+    trace_final: {
+        tightness: 3,
+        rationale: 3,
+        attribution: 3,
+        caution: 3,
+        extent: 3,
+    },
+});
+
+test('buildWorkflowReceiptItems renders mode, review, and planner fallback signals', () => {
+    const metadata: ResponseMetadata = {
+        ...createBaseMetadata(),
+        workflowMode: {
+            modeId: 'balanced',
+            selectedBy: 'requested_mode',
+            selectionReason: 'Requested by user.',
+            initial_mode: 'balanced',
+            behavior: {
+                executionContractPresetId: 'balanced',
+                workflowProfileClass: 'reviewed',
+                workflowProfileId: 'bounded-review',
+                workflowExecution: 'policy_gated',
+                reviewPass: 'excluded',
+                reviseStep: 'allowed',
+                evidencePosture: 'balanced',
+                maxWorkflowSteps: 6,
+                maxDeliberationCalls: 2,
+            },
+        },
+        execution: [
+            {
+                kind: 'planner',
+                status: 'failed',
+                purpose: 'chat_orchestrator_action_selection',
+                contractType: 'fallback',
+                applyOutcome: 'not_applied',
+                mattered: false,
+                matteredControlIds: [],
+                reasonCode: 'planner_runtime_error',
+            },
+        ],
+    };
+
+    assert.deepEqual(buildWorkflowReceiptItems(metadata), [
+        'Answered in Balanced mode',
+        'Review skipped',
+        'Planner fallback',
+    ]);
+    assert.equal(
+        buildWorkflowReceiptSummary(metadata),
+        'Answered in Balanced mode • Review skipped • Planner fallback'
+    );
+});
+
+test('buildWorkflowReceiptItems marks reviewed only when assess step ran', () => {
+    const metadata: ResponseMetadata = {
+        ...createBaseMetadata(),
+        workflowMode: {
+            modeId: 'grounded',
+            selectedBy: 'requested_mode',
+            selectionReason: 'Requested by user.',
+            initial_mode: 'grounded',
+            behavior: {
+                executionContractPresetId: 'quality-grounded',
+                workflowProfileClass: 'reviewed',
+                workflowProfileId: 'bounded-review',
+                workflowExecution: 'always',
+                reviewPass: 'included',
+                reviseStep: 'allowed',
+                evidencePosture: 'strict',
+                maxWorkflowSteps: 8,
+                maxDeliberationCalls: 3,
+            },
+        },
+        workflow: {
+            workflowId: 'wf_1',
+            workflowName: 'message_with_review_loop',
+            status: 'completed',
+            terminationReason: 'goal_satisfied',
+            stepCount: 1,
+            maxSteps: 8,
+            maxDurationMs: 15000,
+            steps: [
+                {
+                    stepId: 'step_assess_1',
+                    attempt: 1,
+                    stepKind: 'assess',
+                    startedAt: '2026-04-22T00:00:00.000Z',
+                    finishedAt: '2026-04-22T00:00:00.010Z',
+                    durationMs: 10,
+                    outcome: {
+                        status: 'executed',
+                        summary: 'Reviewed draft.',
+                    },
+                },
+            ],
+        },
+    };
+
+    assert.deepEqual(buildWorkflowReceiptItems(metadata), [
+        'Answered in Grounded mode',
+        'Reviewed before final answer',
+    ]);
+});
+
+test('buildWorkflowReceiptSummary stays fail-open for legacy partial metadata', () => {
+    const partialMetadata = {
+        ...createBaseMetadata(),
+        workflowMode: {
+            modeId: 'fast',
+        },
+        workflow: {},
+    } as unknown as ResponseMetadata;
+
+    assert.equal(
+        buildWorkflowReceiptSummary(partialMetadata),
+        'Answered in Fast mode'
+    );
+});

--- a/packages/discord-bot/src/interactions/button/provenanceButtons.ts
+++ b/packages/discord-bot/src/interactions/button/provenanceButtons.ts
@@ -178,6 +178,7 @@ function formatSummarySection(
         `- Model: \`${formatMarkdownValue(payload.modelVersion)}\``,
         `- Stale After: \`${formatMarkdownValue(payload.staleAfter)}\``,
     ];
+    // Shared helper keeps Discord and web workflow-receipt wording aligned.
     const workflowReceiptSummary = buildWorkflowReceiptSummary(payload);
     if (workflowReceiptSummary) {
         lines.push(

--- a/packages/discord-bot/src/interactions/button/provenanceButtons.ts
+++ b/packages/discord-bot/src/interactions/button/provenanceButtons.ts
@@ -10,6 +10,7 @@ import {
     formatExecutionTimelineSummary,
     type ExecutionEvent,
     type ResponseMetadata,
+    type WorkflowModeId,
 } from '@footnote/contracts/ethics-core';
 import { ResponseMetadataSchema } from '@footnote/contracts/web/schemas';
 import { botApi } from '../../api/botApi.js';
@@ -150,6 +151,113 @@ function escapeMarkdownLinkUrl(value: string): string {
     return value.replace(/\\/g, '\\\\').replace(/\)/g, '\\)');
 }
 
+const WORKFLOW_MODE_LABELS: Record<WorkflowModeId, string> = {
+    fast: 'Fast mode',
+    balanced: 'Balanced mode',
+    grounded: 'Grounded mode',
+};
+
+function resolveWorkflowModeLabel(metadata: ResponseMetadata): string | null {
+    const modeId = metadata.workflowMode?.modeId;
+    if (modeId) {
+        return WORKFLOW_MODE_LABELS[modeId];
+    }
+
+    const presetId = metadata.workflowMode?.behavior.executionContractPresetId;
+    if (presetId === 'fast-direct') {
+        return WORKFLOW_MODE_LABELS.fast;
+    }
+    if (presetId === 'balanced') {
+        return WORKFLOW_MODE_LABELS.balanced;
+    }
+    if (presetId === 'quality-grounded') {
+        return WORKFLOW_MODE_LABELS.grounded;
+    }
+
+    return null;
+}
+
+function resolveReviewReceipt(metadata: ResponseMetadata): string | null {
+    const reviewStepRan =
+        metadata.workflow?.steps.some(
+            (step) =>
+                step.stepKind === 'assess' && step.outcome.status !== 'skipped'
+        ) ?? false;
+    if (reviewStepRan) {
+        return 'Reviewed before final answer';
+    }
+
+    const reviewPass = metadata.workflowMode?.behavior.reviewPass;
+    if (reviewPass === 'excluded') {
+        return 'Review skipped';
+    }
+
+    if (
+        reviewPass === 'included' &&
+        metadata.workflow !== undefined &&
+        metadata.workflow.steps.length > 0
+    ) {
+        return 'Review skipped';
+    }
+
+    return null;
+}
+
+function resolvePlannerFallbackReceipt(
+    metadata: ResponseMetadata
+): string | null {
+    const plannerFallbackInWorkflow =
+        metadata.workflow?.steps.some((step) => {
+            if (step.stepKind !== 'plan') {
+                return false;
+            }
+            if (
+                step.reasonCode === 'planner_runtime_error' ||
+                step.reasonCode === 'planner_invalid_output'
+            ) {
+                return true;
+            }
+            return step.outcome.signals?.contractType === 'fallback';
+        }) ?? false;
+
+    const plannerFallbackInExecution =
+        metadata.execution?.some((event) => {
+            if (event.kind !== 'planner') {
+                return false;
+            }
+            if (event.contractType === 'fallback') {
+                return true;
+            }
+            return (
+                event.reasonCode === 'planner_runtime_error' ||
+                event.reasonCode === 'planner_invalid_output'
+            );
+        }) ?? false;
+
+    return plannerFallbackInWorkflow || plannerFallbackInExecution
+        ? 'Planner fallback'
+        : null;
+}
+
+function buildWorkflowReceiptSummary(
+    metadata: ResponseMetadata
+): string | null {
+    const workflowModeLabel = resolveWorkflowModeLabel(metadata);
+    const reviewReceipt = resolveReviewReceipt(metadata);
+    const plannerFallbackReceipt = resolvePlannerFallbackReceipt(metadata);
+    const workflowReceiptItems = [
+        workflowModeLabel ? `Answered in ${workflowModeLabel}` : null,
+        reviewReceipt,
+        plannerFallbackReceipt,
+    ].filter((item): item is string => item !== null);
+
+    if (workflowReceiptItems.length === 0) {
+        return null;
+    }
+
+    return workflowReceiptItems.join(' • ');
+}
+
 /**
  * Builds the Markdown "Summary" section for provenance details displayed in Discord.
  *
@@ -168,7 +276,7 @@ function formatSummarySection(
         ].join('\n');
     }
 
-    return [
+    const lines = [
         '**Summary**',
         `- Response ID: \`${formatMarkdownValue(payload.responseId)}\``,
         `- Provenance: \`${formatMarkdownValue(payload.provenance)}\``,
@@ -176,7 +284,15 @@ function formatSummarySection(
         `- Tradeoffs: \`${formatMarkdownValue(payload.tradeoffCount)}\``,
         `- Model: \`${formatMarkdownValue(payload.modelVersion)}\``,
         `- Stale After: \`${formatMarkdownValue(payload.staleAfter)}\``,
-    ].join('\n');
+    ];
+    const workflowReceiptSummary = buildWorkflowReceiptSummary(payload);
+    if (workflowReceiptSummary) {
+        lines.push(
+            `- Workflow Receipt: \`${formatMarkdownValue(workflowReceiptSummary, 220)}\``
+        );
+    }
+
+    return lines.join('\n');
 }
 
 /**

--- a/packages/discord-bot/src/interactions/button/provenanceButtons.ts
+++ b/packages/discord-bot/src/interactions/button/provenanceButtons.ts
@@ -10,7 +10,7 @@ import {
     formatExecutionTimelineSummary,
     type ExecutionEvent,
     type ResponseMetadata,
-    type WorkflowModeId,
+    buildWorkflowReceiptSummary,
 } from '@footnote/contracts/ethics-core';
 import { ResponseMetadataSchema } from '@footnote/contracts/web/schemas';
 import { botApi } from '../../api/botApi.js';
@@ -149,113 +149,6 @@ function escapeMarkdownLinkText(value: string): string {
 
 function escapeMarkdownLinkUrl(value: string): string {
     return value.replace(/\\/g, '\\\\').replace(/\)/g, '\\)');
-}
-
-const WORKFLOW_MODE_LABELS: Record<WorkflowModeId, string> = {
-    fast: 'Fast mode',
-    balanced: 'Balanced mode',
-    grounded: 'Grounded mode',
-};
-
-function resolveWorkflowModeLabel(metadata: ResponseMetadata): string | null {
-    const modeId = metadata.workflowMode?.modeId;
-    if (modeId) {
-        return WORKFLOW_MODE_LABELS[modeId];
-    }
-
-    const presetId = metadata.workflowMode?.behavior.executionContractPresetId;
-    if (presetId === 'fast-direct') {
-        return WORKFLOW_MODE_LABELS.fast;
-    }
-    if (presetId === 'balanced') {
-        return WORKFLOW_MODE_LABELS.balanced;
-    }
-    if (presetId === 'quality-grounded') {
-        return WORKFLOW_MODE_LABELS.grounded;
-    }
-
-    return null;
-}
-
-function resolveReviewReceipt(metadata: ResponseMetadata): string | null {
-    const reviewStepRan =
-        metadata.workflow?.steps.some(
-            (step) =>
-                step.stepKind === 'assess' && step.outcome.status !== 'skipped'
-        ) ?? false;
-    if (reviewStepRan) {
-        return 'Reviewed before final answer';
-    }
-
-    const reviewPass = metadata.workflowMode?.behavior.reviewPass;
-    if (reviewPass === 'excluded') {
-        return 'Review skipped';
-    }
-
-    if (
-        reviewPass === 'included' &&
-        metadata.workflow !== undefined &&
-        metadata.workflow.steps.length > 0
-    ) {
-        return 'Review skipped';
-    }
-
-    return null;
-}
-
-function resolvePlannerFallbackReceipt(
-    metadata: ResponseMetadata
-): string | null {
-    const plannerFallbackInWorkflow =
-        metadata.workflow?.steps.some((step) => {
-            if (step.stepKind !== 'plan') {
-                return false;
-            }
-            if (
-                step.reasonCode === 'planner_runtime_error' ||
-                step.reasonCode === 'planner_invalid_output'
-            ) {
-                return true;
-            }
-            return step.outcome.signals?.contractType === 'fallback';
-        }) ?? false;
-
-    const plannerFallbackInExecution =
-        metadata.execution?.some((event) => {
-            if (event.kind !== 'planner') {
-                return false;
-            }
-            if (event.contractType === 'fallback') {
-                return true;
-            }
-            return (
-                event.reasonCode === 'planner_runtime_error' ||
-                event.reasonCode === 'planner_invalid_output'
-            );
-        }) ?? false;
-
-    return plannerFallbackInWorkflow || plannerFallbackInExecution
-        ? 'Planner fallback'
-        : null;
-}
-
-function buildWorkflowReceiptSummary(
-    metadata: ResponseMetadata
-): string | null {
-    const workflowModeLabel = resolveWorkflowModeLabel(metadata);
-    const reviewReceipt = resolveReviewReceipt(metadata);
-    const plannerFallbackReceipt = resolvePlannerFallbackReceipt(metadata);
-    const workflowReceiptItems = [
-        workflowModeLabel ? `Answered in ${workflowModeLabel}` : null,
-        reviewReceipt,
-        plannerFallbackReceipt,
-    ].filter((item): item is string => item !== null);
-
-    if (workflowReceiptItems.length === 0) {
-        return null;
-    }
-
-    return workflowReceiptItems.join(' • ');
 }
 
 /**

--- a/packages/discord-bot/test/provenanceButtons.test.ts
+++ b/packages/discord-bot/test/provenanceButtons.test.ts
@@ -75,7 +75,34 @@ test('details action renders markdown sections with execution table and trace vi
                     snippet: 'Evidence',
                 },
             ],
+            workflowMode: {
+                modeId: 'balanced',
+                selectedBy: 'requested_mode',
+                selectionReason: 'User requested balanced workflow mode.',
+                initial_mode: 'balanced',
+                behavior: {
+                    executionContractPresetId: 'balanced',
+                    workflowProfileClass: 'reviewed',
+                    workflowProfileId: 'bounded-review',
+                    workflowExecution: 'policy_gated',
+                    reviewPass: 'excluded',
+                    reviseStep: 'allowed',
+                    evidencePosture: 'balanced',
+                    maxWorkflowSteps: 6,
+                    maxDeliberationCalls: 2,
+                },
+            },
             execution: [
+                {
+                    kind: 'planner',
+                    status: 'failed',
+                    purpose: 'chat_orchestrator_action_selection',
+                    contractType: 'fallback',
+                    applyOutcome: 'not_applied',
+                    mattered: false,
+                    matteredControlIds: [],
+                    reasonCode: 'planner_runtime_error',
+                },
                 {
                     kind: 'generation',
                     status: 'executed',
@@ -132,6 +159,9 @@ test('details action renders markdown sections with execution table and trace vi
         assert.match(content, /\*\*Trace Viewer\*\*/);
         assert.match(content, /Open full trace/);
         assert.match(content, /\/traces\/resp_details_sections/);
+        assert.match(content, /Answered in Balanced mode/);
+        assert.match(content, /Review skipped/);
+        assert.match(content, /Planner fallback/);
         assert.match(content, /Target Attribution: `5`/);
         assert.match(content, /Final Attribution: `3`/);
         assert.match(content, /Final Reason: `runtime_posture_adjustment`/);

--- a/packages/web/src/components/ProvenanceFooter.tsx
+++ b/packages/web/src/components/ProvenanceFooter.tsx
@@ -12,9 +12,11 @@ import type {
     ResponseMetadata,
     SafetyTier,
     Citation,
-    WorkflowModeId,
 } from '@footnote/contracts/ethics-core';
-import { formatExecutionTimelineSummary } from '@footnote/contracts/ethics-core';
+import {
+    formatExecutionTimelineSummary,
+    buildWorkflowReceiptItems,
+} from '@footnote/contracts/ethics-core';
 
 interface ProvenanceFooterProps {
     metadata?: ResponseMetadata | null;
@@ -25,96 +27,6 @@ const SAFETY_TIER_COLORS: Record<SafetyTier, string> = {
     Low: '#7FDCA4', // Sage green
     Medium: '#F8E37C', // Warm gold
     High: '#E27C7C', // Soft coral
-};
-
-const WORKFLOW_MODE_LABELS: Record<WorkflowModeId, string> = {
-    fast: 'Fast mode',
-    balanced: 'Balanced mode',
-    grounded: 'Grounded mode',
-};
-
-const resolveWorkflowModeLabel = (
-    metadata: ResponseMetadata
-): string | null => {
-    const modeId = metadata.workflowMode?.modeId;
-    if (modeId) {
-        return WORKFLOW_MODE_LABELS[modeId];
-    }
-
-    const presetId = metadata.workflowMode?.behavior.executionContractPresetId;
-    if (presetId === 'fast-direct') {
-        return WORKFLOW_MODE_LABELS.fast;
-    }
-    if (presetId === 'balanced') {
-        return WORKFLOW_MODE_LABELS.balanced;
-    }
-    if (presetId === 'quality-grounded') {
-        return WORKFLOW_MODE_LABELS.grounded;
-    }
-
-    return null;
-};
-
-const resolveReviewReceipt = (metadata: ResponseMetadata): string | null => {
-    const reviewStepRan =
-        metadata.workflow?.steps.some(
-            (step) =>
-                step.stepKind === 'assess' && step.outcome.status !== 'skipped'
-        ) ?? false;
-    if (reviewStepRan) {
-        return 'Reviewed before final answer';
-    }
-
-    const reviewPass = metadata.workflowMode?.behavior.reviewPass;
-    if (reviewPass === 'excluded') {
-        return 'Review skipped';
-    }
-
-    if (
-        reviewPass === 'included' &&
-        metadata.workflow !== undefined &&
-        metadata.workflow.steps.length > 0
-    ) {
-        return 'Review skipped';
-    }
-
-    return null;
-};
-
-const resolvePlannerFallbackReceipt = (
-    metadata: ResponseMetadata
-): string | null => {
-    const plannerFallbackInWorkflow =
-        metadata.workflow?.steps.some((step) => {
-            if (step.stepKind !== 'plan') {
-                return false;
-            }
-            if (
-                step.reasonCode === 'planner_runtime_error' ||
-                step.reasonCode === 'planner_invalid_output'
-            ) {
-                return true;
-            }
-            return step.outcome.signals?.contractType === 'fallback';
-        }) ?? false;
-
-    const plannerFallbackInExecution =
-        metadata.execution?.some((event) => {
-            if (event.kind !== 'planner') {
-                return false;
-            }
-            if (event.contractType === 'fallback') {
-                return true;
-            }
-            return (
-                event.reasonCode === 'planner_runtime_error' ||
-                event.reasonCode === 'planner_invalid_output'
-            );
-        }) ?? false;
-
-    return plannerFallbackInWorkflow || plannerFallbackInExecution
-        ? 'Planner fallback'
-        : null;
 };
 
 const ProvenanceFooter = ({
@@ -169,14 +81,7 @@ const ProvenanceFooter = ({
         metadata.execution,
         metadata.workflow
     );
-    const workflowModeLabel = resolveWorkflowModeLabel(metadata);
-    const reviewReceipt = resolveReviewReceipt(metadata);
-    const plannerFallbackReceipt = resolvePlannerFallbackReceipt(metadata);
-    const workflowReceiptItems = [
-        workflowModeLabel ? `Answered in ${workflowModeLabel}` : null,
-        reviewReceipt,
-        plannerFallbackReceipt,
-    ].filter((item): item is string => item !== null);
+    const workflowReceiptItems = buildWorkflowReceiptItems(metadata);
     const evaluatorOutcome = metadata.evaluator;
     const searchUnavailableWarning = metadata.execution?.some(
         (event) =>

--- a/packages/web/src/components/ProvenanceFooter.tsx
+++ b/packages/web/src/components/ProvenanceFooter.tsx
@@ -81,6 +81,7 @@ const ProvenanceFooter = ({
         metadata.execution,
         metadata.workflow
     );
+    // Shared helper keeps web/Discord copy and decision rules in sync.
     const workflowReceiptItems = buildWorkflowReceiptItems(metadata);
     const evaluatorOutcome = metadata.evaluator;
     const searchUnavailableWarning = metadata.execution?.some(

--- a/packages/web/src/components/ProvenanceFooter.tsx
+++ b/packages/web/src/components/ProvenanceFooter.tsx
@@ -12,6 +12,7 @@ import type {
     ResponseMetadata,
     SafetyTier,
     Citation,
+    WorkflowModeId,
 } from '@footnote/contracts/ethics-core';
 import { formatExecutionTimelineSummary } from '@footnote/contracts/ethics-core';
 
@@ -24,6 +25,96 @@ const SAFETY_TIER_COLORS: Record<SafetyTier, string> = {
     Low: '#7FDCA4', // Sage green
     Medium: '#F8E37C', // Warm gold
     High: '#E27C7C', // Soft coral
+};
+
+const WORKFLOW_MODE_LABELS: Record<WorkflowModeId, string> = {
+    fast: 'Fast mode',
+    balanced: 'Balanced mode',
+    grounded: 'Grounded mode',
+};
+
+const resolveWorkflowModeLabel = (
+    metadata: ResponseMetadata
+): string | null => {
+    const modeId = metadata.workflowMode?.modeId;
+    if (modeId) {
+        return WORKFLOW_MODE_LABELS[modeId];
+    }
+
+    const presetId = metadata.workflowMode?.behavior.executionContractPresetId;
+    if (presetId === 'fast-direct') {
+        return WORKFLOW_MODE_LABELS.fast;
+    }
+    if (presetId === 'balanced') {
+        return WORKFLOW_MODE_LABELS.balanced;
+    }
+    if (presetId === 'quality-grounded') {
+        return WORKFLOW_MODE_LABELS.grounded;
+    }
+
+    return null;
+};
+
+const resolveReviewReceipt = (metadata: ResponseMetadata): string | null => {
+    const reviewStepRan =
+        metadata.workflow?.steps.some(
+            (step) =>
+                step.stepKind === 'assess' && step.outcome.status !== 'skipped'
+        ) ?? false;
+    if (reviewStepRan) {
+        return 'Reviewed before final answer';
+    }
+
+    const reviewPass = metadata.workflowMode?.behavior.reviewPass;
+    if (reviewPass === 'excluded') {
+        return 'Review skipped';
+    }
+
+    if (
+        reviewPass === 'included' &&
+        metadata.workflow !== undefined &&
+        metadata.workflow.steps.length > 0
+    ) {
+        return 'Review skipped';
+    }
+
+    return null;
+};
+
+const resolvePlannerFallbackReceipt = (
+    metadata: ResponseMetadata
+): string | null => {
+    const plannerFallbackInWorkflow =
+        metadata.workflow?.steps.some((step) => {
+            if (step.stepKind !== 'plan') {
+                return false;
+            }
+            if (
+                step.reasonCode === 'planner_runtime_error' ||
+                step.reasonCode === 'planner_invalid_output'
+            ) {
+                return true;
+            }
+            return step.outcome.signals?.contractType === 'fallback';
+        }) ?? false;
+
+    const plannerFallbackInExecution =
+        metadata.execution?.some((event) => {
+            if (event.kind !== 'planner') {
+                return false;
+            }
+            if (event.contractType === 'fallback') {
+                return true;
+            }
+            return (
+                event.reasonCode === 'planner_runtime_error' ||
+                event.reasonCode === 'planner_invalid_output'
+            );
+        }) ?? false;
+
+    return plannerFallbackInWorkflow || plannerFallbackInExecution
+        ? 'Planner fallback'
+        : null;
 };
 
 const ProvenanceFooter = ({
@@ -78,6 +169,14 @@ const ProvenanceFooter = ({
         metadata.execution,
         metadata.workflow
     );
+    const workflowModeLabel = resolveWorkflowModeLabel(metadata);
+    const reviewReceipt = resolveReviewReceipt(metadata);
+    const plannerFallbackReceipt = resolvePlannerFallbackReceipt(metadata);
+    const workflowReceiptItems = [
+        workflowModeLabel ? `Answered in ${workflowModeLabel}` : null,
+        reviewReceipt,
+        plannerFallbackReceipt,
+    ].filter((item): item is string => item !== null);
     const evaluatorOutcome = metadata.evaluator;
     const searchUnavailableWarning = metadata.execution?.some(
         (event) =>
@@ -107,6 +206,25 @@ const ProvenanceFooter = ({
             <div className="provenance-header">
                 Reasoning - {metadata.provenance}
             </div>
+            {workflowReceiptItems.length > 0 && (
+                <div
+                    className="provenance-workflow-receipt"
+                    role="status"
+                    aria-live="polite"
+                >
+                    {workflowReceiptItems.map((item, index) => (
+                        <span key={item}>
+                            {item}
+                            {index < workflowReceiptItems.length - 1 && (
+                                <span className="provenance-separator">
+                                    {' '}
+                                    •{' '}
+                                </span>
+                            )}
+                        </span>
+                    ))}
+                </div>
+            )}
 
             <div className="provenance-main">
                 {searchUnavailableWarning && (

--- a/packages/web/src/styles/global.css
+++ b/packages/web/src/styles/global.css
@@ -1532,6 +1532,13 @@ div.interaction-status:not(.interaction-status-visible) *,
     line-height: 1.5;
 }
 
+.provenance-workflow-receipt {
+    margin-bottom: 0.45rem;
+    font-size: 0.82rem;
+    color: color-mix(in srgb, var(--subtle-text) 92%, var(--accent) 8%);
+    line-height: 1.4;
+}
+
 .provenance-separator {
     color: var(--subtle-text);
     font-weight: 300;


### PR DESCRIPTION
## What changed
- Added a compact workflow receipt in the web provenance footer under each answer.
- Added the same compact receipt to Discord provenance **Summary** (shown when users open details), without appending anything to the main response message.
- Receipt copy is built only from explicit backend metadata fields:
  - `metadata.workflowMode`
  - `metadata.workflow`
  - `metadata.execution`
- Kept full trace access visible in both surfaces.
- Added Discord test coverage for summary rendering behavior.

## Why this was changed
Users needed a quick, conservative run-path signal near answers so they can understand how a response was produced without opening the full trace every time. This improves transparency while keeping detailed lineage in the trace view.

## Important implementation details
- Uses user-facing mode labels only: **Fast mode**, **Balanced mode**, **Grounded mode**.
- Receipt language is path-semantic and conservative:
  - `Answered in <mode>`
  - `Reviewed before final answer` or `Review skipped`
  - `Planner fallback` (only when explicitly visible in metadata)
- `Reviewed` indicates a review step ran; it is not a correctness guarantee.
- Degrades gracefully when workflow metadata is missing or legacy.
- Avoids exposing raw planner/model step chains inline.

This PR was written using [Vibe Kanban](https://vibekanban.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Workflow execution details now visible, displaying workflow mode, review status, and planner fallback information across Discord and web interfaces.
  * Enhanced provenance display with workflow receipt items for improved transparency.

* **Styling**
  * Added styling for workflow receipt display.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->