### PR TITLE
Clarify Trace run outcomes and explicit stop/fallback signals (Vibe Kanban)

### DIFF
--- a/packages/web/src/pages/TracePage.tsx
+++ b/packages/web/src/pages/TracePage.tsx
@@ -23,6 +23,7 @@ import type {
 } from '@footnote/contracts/ethics-core';
 import { api, isApiClientError } from '../utils/api';
 import { createScopedLogger } from '../utils/logger';
+import { buildRunOutcomeSummary } from '../utils/traceOutcome';
 // Define the actual server response metadata structure
 type ServerMetadata = GetTraceResponse & {
     timestamp?: string;
@@ -571,6 +572,7 @@ const TracePage = (): JSX.Element => {
     const sourceSummary = getSourceSummary(traceData);
     const safetySummary = getSafetySummary(traceData, safetyLabel);
     const workflowSummary = getWorkflowSummary(traceData);
+    const runOutcomeSummary = buildRunOutcomeSummary(traceData);
     const summarySignals: SummarySignal[] = [
         {
             label: 'Mode',
@@ -620,6 +622,29 @@ const TracePage = (): JSX.Element => {
                     This page summarizes how this answer was produced and where
                     you can inspect evidence next.
                 </p>
+                {runOutcomeSummary && (
+                    <>
+                        <p>
+                            <strong>Run outcome:</strong>{' '}
+                            {runOutcomeSummary.headline}
+                        </p>
+                        <p>{runOutcomeSummary.explanation}</p>
+                        {runOutcomeSummary.reasonCode && (
+                            <p>
+                                <strong>Recorded reason:</strong>{' '}
+                                <code>{runOutcomeSummary.reasonCode}</code>
+                            </p>
+                        )}
+                        {runOutcomeSummary.secondaryReasonCode && (
+                            <p>
+                                <strong>Additional signal:</strong>{' '}
+                                <code>
+                                    {runOutcomeSummary.secondaryReasonCode}
+                                </code>
+                            </p>
+                        )}
+                    </>
+                )}
                 <p>
                     <strong>Provenance label:</strong> {provenance}
                 </p>

--- a/packages/web/src/pages/TracePage.tsx
+++ b/packages/web/src/pages/TracePage.tsx
@@ -23,7 +23,10 @@ import type {
 } from '@footnote/contracts/ethics-core';
 import { api, isApiClientError } from '../utils/api';
 import { createScopedLogger } from '../utils/logger';
-import { buildRunOutcomeSummary } from '../utils/traceOutcome';
+import {
+    buildRunOutcomeSummary,
+    type RunOutcomeSummary,
+} from '../utils/traceOutcome';
 // Define the actual server response metadata structure
 type ServerMetadata = GetTraceResponse & {
     timestamp?: string;
@@ -309,6 +312,35 @@ const SAFETY_TIER_COLORS: Record<string, string> = {
     high: '#E27C7C', // High safety tier - soft coral
 };
 
+const renderRunOutcomeSummary = (
+    runOutcomeSummary: RunOutcomeSummary | null
+): JSX.Element | null => {
+    if (!runOutcomeSummary) {
+        return null;
+    }
+
+    return (
+        <>
+            <p>
+                <strong>Run outcome:</strong> {runOutcomeSummary.headline}
+            </p>
+            <p>{runOutcomeSummary.explanation}</p>
+            {runOutcomeSummary.reasonCode && (
+                <p>
+                    <strong>Recorded reason:</strong>{' '}
+                    <code>{runOutcomeSummary.reasonCode}</code>
+                </p>
+            )}
+            {runOutcomeSummary.secondaryReasonCode && (
+                <p>
+                    <strong>Additional signal:</strong>{' '}
+                    <code>{runOutcomeSummary.secondaryReasonCode}</code>
+                </p>
+            )}
+        </>
+    );
+};
+
 const TracePage = (): JSX.Element => {
     const { responseId } = useParams<{ responseId: string }>();
     const [loadingState, setLoadingState] = useState<LoadingState>('loading');
@@ -423,6 +455,10 @@ const TracePage = (): JSX.Element => {
         };
     }, [responseId]);
 
+    const traceRunOutcomeSummary = traceData
+        ? buildRunOutcomeSummary(traceData)
+        : null;
+
     if (loadingState === 'loading') {
         return (
             <section className="interaction-status" aria-live="polite">
@@ -494,6 +530,7 @@ const TracePage = (): JSX.Element => {
                         </header>
                         <article className="card" aria-label="Trace summary">
                             <h2>Summary</h2>
+                            {renderRunOutcomeSummary(traceRunOutcomeSummary)}
                             <p>
                                 <strong>Model:</strong>{' '}
                                 {traceData.model || 'Unspecified'}
@@ -572,7 +609,7 @@ const TracePage = (): JSX.Element => {
     const sourceSummary = getSourceSummary(traceData);
     const safetySummary = getSafetySummary(traceData, safetyLabel);
     const workflowSummary = getWorkflowSummary(traceData);
-    const runOutcomeSummary = buildRunOutcomeSummary(traceData);
+    const runOutcomeSummary = traceRunOutcomeSummary;
     const summarySignals: SummarySignal[] = [
         {
             label: 'Mode',
@@ -622,29 +659,7 @@ const TracePage = (): JSX.Element => {
                     This page summarizes how this answer was produced and where
                     you can inspect evidence next.
                 </p>
-                {runOutcomeSummary && (
-                    <>
-                        <p>
-                            <strong>Run outcome:</strong>{' '}
-                            {runOutcomeSummary.headline}
-                        </p>
-                        <p>{runOutcomeSummary.explanation}</p>
-                        {runOutcomeSummary.reasonCode && (
-                            <p>
-                                <strong>Recorded reason:</strong>{' '}
-                                <code>{runOutcomeSummary.reasonCode}</code>
-                            </p>
-                        )}
-                        {runOutcomeSummary.secondaryReasonCode && (
-                            <p>
-                                <strong>Additional signal:</strong>{' '}
-                                <code>
-                                    {runOutcomeSummary.secondaryReasonCode}
-                                </code>
-                            </p>
-                        )}
-                    </>
-                )}
+                {renderRunOutcomeSummary(runOutcomeSummary)}
                 <p>
                     <strong>Provenance label:</strong> {provenance}
                 </p>

--- a/packages/web/src/utils/traceOutcome.test.ts
+++ b/packages/web/src/utils/traceOutcome.test.ts
@@ -1,0 +1,147 @@
+/**
+ * @description: Verifies trace run-outcome summary mapping from workflow and execution metadata.
+ * @footnote-scope: test
+ * @footnote-module: TraceOutcomeSummaryTests
+ * @footnote-risk: low - Tests validate read-only summary derivation logic.
+ * @footnote-ethics: medium - Ensures UI outcome copy stays aligned with backend-owned runtime facts.
+ */
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import type {
+    ExecutionEvent,
+    ResponseMetadata,
+    WorkflowRecord,
+} from '@footnote/contracts/ethics-core';
+import { buildRunOutcomeSummary } from './traceOutcome.js';
+
+const createWorkflow = (
+    terminationReason: WorkflowRecord['terminationReason']
+): WorkflowRecord => ({
+    workflowId: 'wf_123',
+    workflowName: 'bounded-review',
+    status: terminationReason === 'goal_satisfied' ? 'completed' : 'degraded',
+    terminationReason,
+    stepCount: 0,
+    maxSteps: 4,
+    maxDurationMs: 5000,
+    steps: [],
+});
+
+const createSource = ({
+    workflow,
+    execution,
+}: {
+    workflow?: ResponseMetadata['workflow'];
+    execution?: ResponseMetadata['execution'];
+}) => ({
+    workflow,
+    execution,
+});
+
+test('buildRunOutcomeSummary returns completed for goal_satisfied termination', () => {
+    const summary = buildRunOutcomeSummary(
+        createSource({
+            workflow: createWorkflow('goal_satisfied'),
+        })
+    );
+    assert.equal(summary?.category, 'completed');
+    assert.equal(summary?.reasonCode, 'goal_satisfied');
+});
+
+test('buildRunOutcomeSummary returns stopped for workflow budget limits', () => {
+    const summary = buildRunOutcomeSummary(
+        createSource({
+            workflow: createWorkflow('budget_exhausted_steps'),
+        })
+    );
+    assert.equal(summary?.category, 'stopped');
+    assert.equal(summary?.reasonCode, 'budget_exhausted_steps');
+});
+
+test('buildRunOutcomeSummary preserves fallback signal when stop reason exists', () => {
+    const summary = buildRunOutcomeSummary(
+        createSource({
+            workflow: createWorkflow('budget_exhausted_steps'),
+            execution: [
+                {
+                    kind: 'tool',
+                    toolName: 'web_search',
+                    status: 'executed',
+                    reasonCode: 'search_rerouted_to_fallback_profile',
+                },
+            ],
+        })
+    );
+    assert.equal(summary?.category, 'stopped');
+    assert.equal(summary?.reasonCode, 'budget_exhausted_steps');
+    assert.equal(
+        summary?.secondaryReasonCode,
+        'search_rerouted_to_fallback_profile'
+    );
+});
+
+test('buildRunOutcomeSummary returns fallback for explicit reroute reason', () => {
+    const execution: ExecutionEvent[] = [
+        {
+            kind: 'tool',
+            toolName: 'web_search',
+            status: 'executed',
+            reasonCode: 'search_rerouted_to_fallback_profile',
+        },
+    ];
+    const summary = buildRunOutcomeSummary(
+        createSource({
+            execution,
+        })
+    );
+    assert.equal(summary?.category, 'fell_back');
+    assert.equal(summary?.reasonCode, 'search_rerouted_to_fallback_profile');
+});
+
+test('buildRunOutcomeSummary returns skipped for explicit skipped reason', () => {
+    const execution: ExecutionEvent[] = [
+        {
+            kind: 'tool',
+            toolName: 'web_search',
+            status: 'skipped',
+            reasonCode: 'search_not_supported_by_selected_profile',
+        },
+    ];
+    const summary = buildRunOutcomeSummary(
+        createSource({
+            execution,
+        })
+    );
+    assert.equal(summary?.category, 'skipped');
+    assert.equal(
+        summary?.reasonCode,
+        'search_not_supported_by_selected_profile'
+    );
+});
+
+test('buildRunOutcomeSummary returns unknown for metadata without canonical reason', () => {
+    const execution: ExecutionEvent[] = [
+        {
+            kind: 'tool',
+            toolName: 'web_search',
+            status: 'executed',
+        },
+    ];
+    const summary = buildRunOutcomeSummary(
+        createSource({
+            execution,
+        })
+    );
+    assert.equal(summary?.category, 'unknown');
+});
+
+test('buildRunOutcomeSummary returns null when trace has no workflow or execution metadata', () => {
+    const summary = buildRunOutcomeSummary(
+        createSource({
+            workflow: undefined,
+            execution: undefined,
+        })
+    );
+    assert.equal(summary, null);
+});

--- a/packages/web/src/utils/traceOutcome.test.ts
+++ b/packages/web/src/utils/traceOutcome.test.ts
@@ -34,7 +34,10 @@ const createSource = ({
 }: {
     workflow?: ResponseMetadata['workflow'];
     execution?: ResponseMetadata['execution'];
-}) => ({
+}): {
+    workflow?: ResponseMetadata['workflow'];
+    execution?: ResponseMetadata['execution'];
+} => ({
     workflow,
     execution,
 });
@@ -47,6 +50,11 @@ test('buildRunOutcomeSummary returns completed for goal_satisfied termination', 
     );
     assert.equal(summary?.category, 'completed');
     assert.equal(summary?.reasonCode, 'goal_satisfied');
+    assert.equal(summary?.headline, 'Completed');
+    assert.equal(
+        summary?.explanation,
+        'Workflow reached its goal-satisfied termination path.'
+    );
 });
 
 test('buildRunOutcomeSummary returns stopped for workflow budget limits', () => {
@@ -57,6 +65,11 @@ test('buildRunOutcomeSummary returns stopped for workflow budget limits', () => 
     );
     assert.equal(summary?.category, 'stopped');
     assert.equal(summary?.reasonCode, 'budget_exhausted_steps');
+    assert.equal(summary?.headline, 'Stopped');
+    assert.equal(
+        summary?.explanation,
+        'Workflow stopped after reaching the configured step budget.'
+    );
 });
 
 test('buildRunOutcomeSummary preserves fallback signal when stop reason exists', () => {
@@ -79,6 +92,11 @@ test('buildRunOutcomeSummary preserves fallback signal when stop reason exists',
         summary?.secondaryReasonCode,
         'search_rerouted_to_fallback_profile'
     );
+    assert.equal(summary?.headline, 'Stopped');
+    assert.equal(
+        summary?.explanation,
+        'Workflow stopped after reaching the configured step budget. A fallback signal was also recorded (search_rerouted_to_fallback_profile).'
+    );
 });
 
 test('buildRunOutcomeSummary returns fallback for explicit reroute reason', () => {
@@ -97,6 +115,37 @@ test('buildRunOutcomeSummary returns fallback for explicit reroute reason', () =
     );
     assert.equal(summary?.category, 'fell_back');
     assert.equal(summary?.reasonCode, 'search_rerouted_to_fallback_profile');
+    assert.equal(summary?.headline, 'Fell back');
+    assert.equal(
+        summary?.explanation,
+        'Search execution was rerouted to a fallback profile.'
+    );
+});
+
+test('buildRunOutcomeSummary returns fallback without synthetic reason code for planner contract fallback', () => {
+    const execution: ExecutionEvent[] = [
+        {
+            kind: 'planner',
+            status: 'executed',
+            purpose: 'chat_orchestrator_action_selection',
+            contractType: 'fallback',
+            applyOutcome: 'applied',
+            mattered: false,
+            matteredControlIds: [],
+        },
+    ];
+    const summary = buildRunOutcomeSummary(
+        createSource({
+            execution,
+        })
+    );
+    assert.equal(summary?.category, 'fell_back');
+    assert.equal(summary?.reasonCode, undefined);
+    assert.equal(summary?.headline, 'Fell back');
+    assert.equal(
+        summary?.explanation,
+        'Fallback planner-contract metadata is present in this trace.'
+    );
 });
 
 test('buildRunOutcomeSummary returns skipped for explicit skipped reason', () => {
@@ -118,6 +167,11 @@ test('buildRunOutcomeSummary returns skipped for explicit skipped reason', () =>
         summary?.reasonCode,
         'search_not_supported_by_selected_profile'
     );
+    assert.equal(summary?.headline, 'Skipped');
+    assert.equal(
+        summary?.explanation,
+        'A search step was skipped because the selected profile does not support search.'
+    );
 });
 
 test('buildRunOutcomeSummary returns unknown for metadata without canonical reason', () => {
@@ -134,6 +188,11 @@ test('buildRunOutcomeSummary returns unknown for metadata without canonical reas
         })
     );
     assert.equal(summary?.category, 'unknown');
+    assert.equal(summary?.headline, 'Outcome not fully recorded');
+    assert.equal(
+        summary?.explanation,
+        'Execution metadata exists, but no canonical completion, stop, skip, or fallback reason was recorded.'
+    );
 });
 
 test('buildRunOutcomeSummary returns null when trace has no workflow or execution metadata', () => {

--- a/packages/web/src/utils/traceOutcome.ts
+++ b/packages/web/src/utils/traceOutcome.ts
@@ -1,0 +1,216 @@
+/**
+ * @description: Derives a conservative, backend-signal-only run outcome summary for trace rendering.
+ * @footnote-scope: utility
+ * @footnote-module: TraceOutcomeSummary
+ * @footnote-risk: medium - Misclassification could mislead operators about runtime path semantics.
+ * @footnote-ethics: high - Outcome summaries influence user trust in transparency and governance behavior.
+ */
+
+import type {
+    ExecutionEvent,
+    ResponseMetadata,
+    WorkflowRecord,
+    WorkflowTerminationReason,
+} from '@footnote/contracts/ethics-core';
+
+type RunOutcomeCategory =
+    | 'completed'
+    | 'stopped'
+    | 'skipped'
+    | 'fell_back'
+    | 'unknown';
+
+export type RunOutcomeSummary = {
+    category: RunOutcomeCategory;
+    headline: string;
+    explanation: string;
+    reasonCode?: string;
+    secondaryReasonCode?: string;
+};
+
+type TraceOutcomeSource = Pick<ResponseMetadata, 'workflow' | 'execution'>;
+
+const STOP_REASON_EXPLANATIONS: Record<WorkflowTerminationReason, string> = {
+    goal_satisfied: 'Workflow reached its goal-satisfied termination path.',
+    budget_exhausted_steps:
+        'Workflow stopped after reaching the configured step budget.',
+    budget_exhausted_tokens:
+        'Workflow stopped after reaching the configured token budget.',
+    budget_exhausted_time:
+        'Workflow stopped after reaching the configured time budget.',
+    transition_blocked_by_policy:
+        'Workflow stopped because a policy transition check blocked the next step.',
+    max_tool_calls_reached:
+        'Workflow stopped after reaching the configured tool-call limit.',
+    max_deliberation_calls_reached:
+        'Workflow stopped after reaching the configured deliberation-call limit.',
+    executor_error_fail_open:
+        'Workflow recorded an executor error and terminated in fail-open mode.',
+};
+
+const FALLBACK_REASON_EXPLANATIONS: Record<string, string> = {
+    search_rerouted_to_fallback_profile:
+        'Search execution was rerouted to a fallback profile.',
+    planner_contract_fallback:
+        'Planner execution used the fallback contract path.',
+};
+
+const SKIPPED_REASON_EXPLANATIONS: Record<string, string> = {
+    search_not_supported_by_selected_profile:
+        'A search step was skipped because the selected profile does not support search.',
+    tool_not_requested:
+        'A tool step was skipped because no tool was requested.',
+    tool_not_used:
+        'A tool step was skipped because requested tool usage was not applied.',
+    search_reroute_not_permitted_by_selection_source:
+        'Search reroute was skipped because selection-source policy did not permit rerouting.',
+    search_reroute_no_tool_capable_fallback_available:
+        'Search reroute was skipped because no tool-capable fallback profile was available.',
+    tool_unavailable:
+        'A tool step was skipped because the tool was unavailable.',
+};
+
+const STOPPED_EXECUTION_REASON_EXPLANATIONS: Record<string, string> = {
+    planner_runtime_error: 'Planner execution failed at runtime.',
+    planner_invalid_output:
+        'Planner output was invalid and could not be applied directly.',
+    evaluator_runtime_error: 'Evaluator execution failed at runtime.',
+    generation_runtime_error: 'Generation execution failed at runtime.',
+    tool_execution_error: 'A tool execution failed at runtime.',
+    tool_timeout: 'A tool execution timed out.',
+    tool_http_error: 'A tool execution failed with an HTTP error.',
+    tool_network_error: 'A tool execution failed with a network error.',
+    tool_invalid_response: 'A tool execution returned an invalid response.',
+};
+
+const isFallbackPlannerEvent = (event: ExecutionEvent): boolean =>
+    event.kind === 'planner' && event.contractType === 'fallback';
+
+const isFallbackPlanStep = (workflow: WorkflowRecord | undefined): boolean =>
+    (workflow?.steps ?? []).some(
+        (step) =>
+            step.stepKind === 'plan' &&
+            step.outcome.signals?.contractType === 'fallback'
+    );
+
+const isKnownFallbackReason = (reasonCode: string): boolean =>
+    reasonCode === 'search_rerouted_to_fallback_profile';
+
+const isKnownSkippedReason = (reasonCode: string): boolean =>
+    reasonCode in SKIPPED_REASON_EXPLANATIONS;
+
+const isKnownStoppedExecutionReason = (reasonCode: string): boolean =>
+    reasonCode in STOPPED_EXECUTION_REASON_EXPLANATIONS;
+
+export const buildRunOutcomeSummary = (
+    source: TraceOutcomeSource
+): RunOutcomeSummary | null => {
+    const workflow = source.workflow;
+    const execution = source.execution ?? [];
+
+    const terminationReason = workflow?.terminationReason;
+    const fallbackReasonCodes = new Set<string>();
+    const skippedReasonCodes = new Set<string>();
+    const failedReasonCodes = new Set<string>();
+
+    for (const event of execution) {
+        if (event.status === 'skipped' && event.reasonCode) {
+            skippedReasonCodes.add(event.reasonCode);
+        }
+        if (event.status === 'failed' && event.reasonCode) {
+            failedReasonCodes.add(event.reasonCode);
+        }
+        if (event.reasonCode && isKnownFallbackReason(event.reasonCode)) {
+            fallbackReasonCodes.add(event.reasonCode);
+        }
+        if (isFallbackPlannerEvent(event)) {
+            fallbackReasonCodes.add('planner_contract_fallback');
+        }
+    }
+
+    if (isFallbackPlanStep(workflow)) {
+        fallbackReasonCodes.add('planner_contract_fallback');
+    }
+
+    const primaryFallbackReason = Array.from(fallbackReasonCodes)[0];
+    const primarySkippedReason =
+        Array.from(skippedReasonCodes).find(isKnownSkippedReason);
+    const primaryFailedReason = Array.from(failedReasonCodes).find(
+        isKnownStoppedExecutionReason
+    );
+    const hasExecutedGeneration = execution.some(
+        (event) => event.kind === 'generation' && event.status === 'executed'
+    );
+
+    if (terminationReason && terminationReason !== 'goal_satisfied') {
+        const stopExplanation =
+            STOP_REASON_EXPLANATIONS[terminationReason] ??
+            'Workflow terminated before a goal-satisfied completion path.';
+        const fallbackSuffix = primaryFallbackReason
+            ? ` A fallback signal was also recorded (${primaryFallbackReason}).`
+            : '';
+        return {
+            category: 'stopped',
+            headline: 'Stopped',
+            explanation: `${stopExplanation}${fallbackSuffix}`,
+            reasonCode: terminationReason,
+            secondaryReasonCode: primaryFallbackReason,
+        };
+    }
+
+    if (primaryFallbackReason) {
+        return {
+            category: 'fell_back',
+            headline: 'Fell back',
+            explanation:
+                FALLBACK_REASON_EXPLANATIONS[primaryFallbackReason] ??
+                'Fallback path signals are present in execution metadata.',
+            reasonCode: primaryFallbackReason,
+        };
+    }
+
+    if (primarySkippedReason) {
+        return {
+            category: 'skipped',
+            headline: 'Skipped',
+            explanation:
+                SKIPPED_REASON_EXPLANATIONS[primarySkippedReason] ??
+                'One or more steps were skipped by runtime policy or capability constraints.',
+            reasonCode: primarySkippedReason,
+        };
+    }
+
+    if (terminationReason === 'goal_satisfied' || hasExecutedGeneration) {
+        return {
+            category: 'completed',
+            headline: 'Completed',
+            explanation:
+                terminationReason === 'goal_satisfied'
+                    ? STOP_REASON_EXPLANATIONS.goal_satisfied
+                    : 'Execution reached a generation step without an explicit workflow termination record.',
+            reasonCode: terminationReason,
+        };
+    }
+
+    if (primaryFailedReason) {
+        return {
+            category: 'stopped',
+            headline: 'Stopped',
+            explanation:
+                STOPPED_EXECUTION_REASON_EXPLANATIONS[primaryFailedReason] ??
+                'Runtime failure signals were recorded in execution metadata.',
+            reasonCode: primaryFailedReason,
+        };
+    }
+
+    if (workflow || execution.length > 0) {
+        return {
+            category: 'unknown',
+            headline: 'Outcome not fully recorded',
+            explanation:
+                'Execution metadata exists, but no canonical completion, stop, skip, or fallback reason was recorded.',
+        };
+    }
+
+    return null;
+};

--- a/packages/web/src/utils/traceOutcome.ts
+++ b/packages/web/src/utils/traceOutcome.ts
@@ -51,8 +51,6 @@ const STOP_REASON_EXPLANATIONS: Record<WorkflowTerminationReason, string> = {
 const FALLBACK_REASON_EXPLANATIONS: Record<string, string> = {
     search_rerouted_to_fallback_profile:
         'Search execution was rerouted to a fallback profile.',
-    planner_contract_fallback:
-        'Planner execution used the fallback contract path.',
 };
 
 const SKIPPED_REASON_EXPLANATIONS: Record<string, string> = {
@@ -90,7 +88,7 @@ const isFallbackPlanStep = (workflow: WorkflowRecord | undefined): boolean =>
     (workflow?.steps ?? []).some(
         (step) =>
             step.stepKind === 'plan' &&
-            step.outcome.signals?.contractType === 'fallback'
+            step.outcome?.signals?.contractType === 'fallback'
     );
 
 const isKnownFallbackReason = (reasonCode: string): boolean =>
@@ -102,6 +100,25 @@ const isKnownSkippedReason = (reasonCode: string): boolean =>
 const isKnownStoppedExecutionReason = (reasonCode: string): boolean =>
     reasonCode in STOPPED_EXECUTION_REASON_EXPLANATIONS;
 
+/**
+ * Derives a conservative run-outcome summary for trace presentation.
+ *
+ * This is an exported UI-boundary formatter for workflow/provenance metadata.
+ * It only uses backend-authored execution/workflow facts and never invents
+ * new backend reason codes.
+ *
+ * Behavior:
+ * - Returns a concrete `RunOutcomeSummary` when outcome signals are present.
+ * - Returns an `unknown` summary when metadata exists but no definitive path
+ *   can be derived.
+ * - Returns `null` when neither workflow nor execution metadata is present.
+ *
+ * Decision assumptions:
+ * - `workflow.terminationReason` is treated as the highest-authority stop/completion signal.
+ * - Explicit runtime failures outrank inferred completion from generation.
+ * - Planner `contractType === "fallback"` is surfaced as fallback posture
+ *   without exposing synthesized reason-code strings.
+ */
 export const buildRunOutcomeSummary = (
     source: TraceOutcomeSource
 ): RunOutcomeSummary | null => {
@@ -112,6 +129,7 @@ export const buildRunOutcomeSummary = (
     const fallbackReasonCodes = new Set<string>();
     const skippedReasonCodes = new Set<string>();
     const failedReasonCodes = new Set<string>();
+    let hasPlannerFallbackSignal = false;
 
     for (const event of execution) {
         if (event.status === 'skipped' && event.reasonCode) {
@@ -124,12 +142,12 @@ export const buildRunOutcomeSummary = (
             fallbackReasonCodes.add(event.reasonCode);
         }
         if (isFallbackPlannerEvent(event)) {
-            fallbackReasonCodes.add('planner_contract_fallback');
+            hasPlannerFallbackSignal = true;
         }
     }
 
     if (isFallbackPlanStep(workflow)) {
-        fallbackReasonCodes.add('planner_contract_fallback');
+        hasPlannerFallbackSignal = true;
     }
 
     const primaryFallbackReason = Array.from(fallbackReasonCodes)[0];
@@ -146,9 +164,12 @@ export const buildRunOutcomeSummary = (
         const stopExplanation =
             STOP_REASON_EXPLANATIONS[terminationReason] ??
             'Workflow terminated before a goal-satisfied completion path.';
-        const fallbackSuffix = primaryFallbackReason
-            ? ` A fallback signal was also recorded (${primaryFallbackReason}).`
-            : '';
+        const fallbackSuffix =
+            primaryFallbackReason !== undefined
+                ? ` A fallback signal was also recorded (${primaryFallbackReason}).`
+                : hasPlannerFallbackSignal
+                  ? ' A fallback planner-contract signal was also recorded.'
+                  : '';
         return {
             category: 'stopped',
             headline: 'Stopped',
@@ -158,13 +179,16 @@ export const buildRunOutcomeSummary = (
         };
     }
 
-    if (primaryFallbackReason) {
+    if (primaryFallbackReason !== undefined || hasPlannerFallbackSignal) {
+        const explanation =
+            primaryFallbackReason !== undefined
+                ? (FALLBACK_REASON_EXPLANATIONS[primaryFallbackReason] ??
+                  'Fallback path signals are present in execution metadata.')
+                : 'Fallback planner-contract metadata is present in this trace.';
         return {
             category: 'fell_back',
             headline: 'Fell back',
-            explanation:
-                FALLBACK_REASON_EXPLANATIONS[primaryFallbackReason] ??
-                'Fallback path signals are present in execution metadata.',
+            explanation,
             reasonCode: primaryFallbackReason,
         };
     }
@@ -180,14 +204,11 @@ export const buildRunOutcomeSummary = (
         };
     }
 
-    if (terminationReason === 'goal_satisfied' || hasExecutedGeneration) {
+    if (terminationReason === 'goal_satisfied') {
         return {
             category: 'completed',
             headline: 'Completed',
-            explanation:
-                terminationReason === 'goal_satisfied'
-                    ? STOP_REASON_EXPLANATIONS.goal_satisfied
-                    : 'Execution reached a generation step without an explicit workflow termination record.',
+            explanation: STOP_REASON_EXPLANATIONS.goal_satisfied,
             reasonCode: terminationReason,
         };
     }
@@ -200,6 +221,16 @@ export const buildRunOutcomeSummary = (
                 STOPPED_EXECUTION_REASON_EXPLANATIONS[primaryFailedReason] ??
                 'Runtime failure signals were recorded in execution metadata.',
             reasonCode: primaryFailedReason,
+        };
+    }
+
+    if (hasExecutedGeneration) {
+        return {
+            category: 'completed',
+            headline: 'Completed',
+            explanation:
+                'Execution reached a generation step without an explicit workflow termination record.',
+            reasonCode: terminationReason,
         };
     }
 


### PR DESCRIPTION
## What changed
- Added a canonical run-outcome summary to the Trace page so each trace can show one primary path outcome when metadata supports it.
- Introduced `buildRunOutcomeSummary` in `packages/web/src/utils/traceOutcome.ts` to derive outcome display data from backend-owned workflow/execution records.
- Wired the summary into `packages/web/src/pages/TracePage.tsx` under the "What happened" section, including primary `reasonCode` and an additional signal when both stop and fallback metadata are present.
- Added unit tests in `packages/web/src/utils/traceOutcome.test.ts` for completed, stopped, skipped, fallback, unknown, and legacy-empty metadata paths.

## Why this was changed
The task required the Trace page to clearly explain why a run completed, stopped, skipped, or fell back, without adding new backend behavior or inventing UI-only reason categories. This update makes that path semantics explicit while keeping wording conservative and metadata-driven.

## Important implementation details
- Outcome derivation uses only explicit backend-owned facts:
  - `workflow.terminationReason`
  - execution event `status` and `reasonCode`
  - planner fallback contract signals already present in workflow/execution metadata
- The mapper is intentionally fail-open for older traces:
  - returns `null` when no workflow/execution metadata exists
  - returns an `unknown` summary when metadata exists but does not include a canonical reason
- Fallback/limit/runtime signals are surfaced as recorded reason codes; the UI does not synthesize new categories beyond conservative presentation labels.
- Technical payload remains in existing detailed sections; this change adds a top-level summary only.

This PR was written using [Vibe Kanban](https://vibekanban.com)