### PR TITLE
Normalize review runtime metadata for UI status labels (Vibe Kanban)

### DIFF
--- a/packages/backend/src/services/openaiService/metadata.ts
+++ b/packages/backend/src/services/openaiService/metadata.ts
@@ -19,6 +19,7 @@ import type {
     ToolInvocationReasonCode,
     TraceAxisScore,
 } from '@footnote/contracts/ethics-core';
+import { deriveReviewRuntimeSummary } from '@footnote/contracts/ethics-core';
 import { runtimeConfig } from '../../config.js';
 import { logger } from '../../utils/logger.js';
 import {
@@ -330,6 +331,11 @@ const buildResponseMetadata = (
     const generationEventModel = execution
         .filter((event) => event.kind === 'generation')
         .at(-1)?.model;
+    const reviewRuntime = deriveReviewRuntimeSummary({
+        workflow: runtimeContext.workflow,
+        workflowMode: runtimeContext.workflowMode,
+        execution,
+    });
 
     return {
         responseId,
@@ -356,6 +362,7 @@ const buildResponseMetadata = (
         ...(runtimeContext.workflow !== undefined && {
             workflow: runtimeContext.workflow,
         }),
+        reviewRuntime,
         ...(runtimeContext.workflowMode !== undefined && {
             workflowMode: runtimeContext.workflowMode,
         }),

--- a/packages/backend/test/openaiService.metadata.test.ts
+++ b/packages/backend/test/openaiService.metadata.test.ts
@@ -845,3 +845,230 @@ test('buildResponseMetadata includes totalDurationMs when runtime context provid
 
     assert.equal(metadata.totalDurationMs, 1234);
 });
+
+test('buildResponseMetadata defaults reviewRuntime to not_reviewed when no review path metadata exists', () => {
+    const metadata = buildResponseMetadata(
+        baseAssistantMetadata(),
+        baseRuntimeContext()
+    );
+
+    assert.deepEqual(metadata.reviewRuntime, {
+        label: 'not_reviewed',
+    });
+});
+
+test('buildResponseMetadata sets reviewRuntime to reviewed_no_revision when assess executed without revise', () => {
+    const metadata = buildResponseMetadata(
+        baseAssistantMetadata(),
+        baseRuntimeContext({
+            workflow: {
+                workflowId: 'wf_1',
+                workflowName: 'message_with_review_loop',
+                status: 'completed',
+                terminationReason: 'goal_satisfied',
+                stepCount: 2,
+                maxSteps: 4,
+                maxDurationMs: 12000,
+                steps: [
+                    {
+                        stepId: 'step_generate_1',
+                        attempt: 1,
+                        stepKind: 'generate',
+                        startedAt: '2026-04-22T00:00:00.000Z',
+                        finishedAt: '2026-04-22T00:00:00.010Z',
+                        durationMs: 10,
+                        outcome: {
+                            status: 'executed',
+                            summary: 'Generated initial draft response.',
+                        },
+                    },
+                    {
+                        stepId: 'step_assess_1',
+                        attempt: 1,
+                        stepKind: 'assess',
+                        startedAt: '2026-04-22T00:00:00.011Z',
+                        finishedAt: '2026-04-22T00:00:00.021Z',
+                        durationMs: 10,
+                        outcome: {
+                            status: 'executed',
+                            summary: 'Assessment step evaluated draft quality.',
+                            signals: {
+                                reviewDecision: 'finalize',
+                                reviewReason:
+                                    'Draft is ready for final response.',
+                            },
+                        },
+                    },
+                ],
+            },
+        })
+    );
+
+    assert.deepEqual(metadata.reviewRuntime, {
+        label: 'reviewed_no_revision',
+    });
+});
+
+test('buildResponseMetadata sets reviewRuntime to revised when revise step executed', () => {
+    const metadata = buildResponseMetadata(
+        baseAssistantMetadata(),
+        baseRuntimeContext({
+            workflow: {
+                workflowId: 'wf_2',
+                workflowName: 'message_with_review_loop',
+                status: 'completed',
+                terminationReason: 'goal_satisfied',
+                stepCount: 3,
+                maxSteps: 6,
+                maxDurationMs: 15000,
+                steps: [
+                    {
+                        stepId: 'step_generate_1',
+                        attempt: 1,
+                        stepKind: 'generate',
+                        startedAt: '2026-04-22T00:00:00.000Z',
+                        finishedAt: '2026-04-22T00:00:00.010Z',
+                        durationMs: 10,
+                        outcome: {
+                            status: 'executed',
+                            summary: 'Generated initial draft response.',
+                        },
+                    },
+                    {
+                        stepId: 'step_assess_1',
+                        attempt: 1,
+                        stepKind: 'assess',
+                        startedAt: '2026-04-22T00:00:00.011Z',
+                        finishedAt: '2026-04-22T00:00:00.021Z',
+                        durationMs: 10,
+                        outcome: {
+                            status: 'executed',
+                            summary: 'Assessment step evaluated draft quality.',
+                            signals: {
+                                reviewDecision: 'revise',
+                                reviewReason:
+                                    'One revision improves specificity.',
+                            },
+                        },
+                    },
+                    {
+                        stepId: 'step_revise_1',
+                        attempt: 1,
+                        stepKind: 'revise',
+                        startedAt: '2026-04-22T00:00:00.022Z',
+                        finishedAt: '2026-04-22T00:00:00.032Z',
+                        durationMs: 10,
+                        outcome: {
+                            status: 'executed',
+                            summary: 'Revision step produced improved draft.',
+                        },
+                    },
+                ],
+            },
+        })
+    );
+
+    assert.deepEqual(metadata.reviewRuntime, {
+        label: 'revised',
+    });
+});
+
+test('buildResponseMetadata sets reviewRuntime to skipped when review pass was expected but no assess step executed', () => {
+    const metadata = buildResponseMetadata(
+        baseAssistantMetadata(),
+        baseRuntimeContext({
+            workflowMode: {
+                modeId: 'grounded',
+                selectedBy: 'requested_mode',
+                selectionReason: 'Requested by user.',
+                initial_mode: 'grounded',
+                behavior: {
+                    executionContractPresetId: 'quality-grounded',
+                    workflowProfileClass: 'reviewed',
+                    workflowProfileId: 'bounded-review',
+                    workflowExecution: 'always',
+                    reviewPass: 'included',
+                    reviseStep: 'allowed',
+                    evidencePosture: 'strict',
+                    maxWorkflowSteps: 8,
+                    maxDeliberationCalls: 3,
+                },
+            },
+            workflow: {
+                workflowId: 'wf_3',
+                workflowName: 'message_with_review_loop',
+                status: 'degraded',
+                terminationReason: 'budget_exhausted_steps',
+                stepCount: 1,
+                maxSteps: 1,
+                maxDurationMs: 5000,
+                steps: [
+                    {
+                        stepId: 'step_generate_1',
+                        attempt: 1,
+                        stepKind: 'generate',
+                        startedAt: '2026-04-22T00:00:00.000Z',
+                        finishedAt: '2026-04-22T00:00:00.010Z',
+                        durationMs: 10,
+                        outcome: {
+                            status: 'executed',
+                            summary: 'Generated initial draft response.',
+                        },
+                    },
+                ],
+            },
+        })
+    );
+
+    assert.deepEqual(metadata.reviewRuntime, {
+        label: 'skipped',
+    });
+});
+
+test('buildResponseMetadata sets reviewRuntime to fallback when fail-open fallback path was recorded', () => {
+    const metadata = buildResponseMetadata(
+        baseAssistantMetadata(),
+        baseRuntimeContext({
+            workflow: {
+                workflowId: 'wf_4',
+                workflowName: 'message_with_review_loop',
+                status: 'degraded',
+                terminationReason: 'executor_error_fail_open',
+                stepCount: 2,
+                maxSteps: 4,
+                maxDurationMs: 12000,
+                steps: [
+                    {
+                        stepId: 'step_generate_1',
+                        attempt: 1,
+                        stepKind: 'generate',
+                        startedAt: '2026-04-22T00:00:00.000Z',
+                        finishedAt: '2026-04-22T00:00:00.010Z',
+                        durationMs: 10,
+                        outcome: {
+                            status: 'executed',
+                            summary: 'Generated initial draft response.',
+                        },
+                    },
+                    {
+                        stepId: 'step_assess_1',
+                        attempt: 1,
+                        stepKind: 'assess',
+                        reasonCode: 'generation_runtime_error',
+                        startedAt: '2026-04-22T00:00:00.011Z',
+                        finishedAt: '2026-04-22T00:00:00.021Z',
+                        durationMs: 10,
+                        outcome: {
+                            status: 'failed',
+                            summary: 'Assessment failed.',
+                        },
+                    },
+                ],
+            },
+        })
+    );
+
+    assert.deepEqual(metadata.reviewRuntime, {
+        label: 'fallback',
+    });
+});

--- a/packages/contracts/src/ethics-core/index.ts
+++ b/packages/contracts/src/ethics-core/index.ts
@@ -54,6 +54,8 @@ export type {
     WorkflowModeEvidencePosture,
     WorkflowModeBehavior,
     WorkflowModeDecision,
+    ReviewRuntimeLabel,
+    ReviewRuntimeSummary,
     SteerabilityControlId,
     SteerabilityControlSource,
     SteerabilityImpactTarget,
@@ -75,8 +77,10 @@ export {
     WORKFLOW_STEP_KINDS,
     WORKFLOW_TERMINATION_REASONS,
     BOUNDED_REVIEW_ASSESS_DECISIONS,
+    REVIEW_RUNTIME_LABELS,
 } from './types.js';
 export { formatExecutionTimelineSummary } from './executionFormatting.js';
+export { deriveReviewRuntimeSummary } from './reviewRuntime.js';
 export {
     resolveWorkflowModeLabel,
     resolveReviewReceipt,

--- a/packages/contracts/src/ethics-core/reviewRuntime.ts
+++ b/packages/contracts/src/ethics-core/reviewRuntime.ts
@@ -1,0 +1,115 @@
+/**
+ * @description: Normalizes review-runtime path signals into a compact label
+ * for UI rendering without inferring semantics from raw workflow steps.
+ * @footnote-scope: interface
+ * @footnote-module: ReviewRuntimeSummary
+ * @footnote-risk: medium - Incorrect label mapping can misstate what runtime path executed.
+ * @footnote-ethics: high - Review labels influence user trust, so semantics must stay conservative and path-only.
+ */
+
+import type { ResponseMetadata, ReviewRuntimeSummary } from './types.js';
+
+/**
+ * Returns true when planner fallback was explicitly recorded in workflow
+ * lineage or planner execution events.
+ */
+const hasPlannerFallbackSignal = (
+    metadata: Pick<ResponseMetadata, 'workflow' | 'execution'>
+): boolean => {
+    const plannerFallbackInWorkflow =
+        metadata.workflow?.steps?.some((step) => {
+            if (step.stepKind !== 'plan') {
+                return false;
+            }
+            if (
+                step.reasonCode === 'planner_runtime_error' ||
+                step.reasonCode === 'planner_invalid_output'
+            ) {
+                return true;
+            }
+            return step.outcome.signals?.contractType === 'fallback';
+        }) ?? false;
+
+    const plannerFallbackInExecution =
+        metadata.execution?.some((event) => {
+            if (event.kind !== 'planner') {
+                return false;
+            }
+            if (event.contractType === 'fallback') {
+                return true;
+            }
+            return (
+                event.reasonCode === 'planner_runtime_error' ||
+                event.reasonCode === 'planner_invalid_output'
+            );
+        }) ?? false;
+
+    return plannerFallbackInWorkflow || plannerFallbackInExecution;
+};
+
+/**
+ * Returns true when runtime explicitly recorded fail-open generation fallback.
+ */
+const hasInternalGenerationFallbackSignal = (
+    metadata: Pick<ResponseMetadata, 'execution'>
+): boolean =>
+    metadata.execution?.some(
+        (event) =>
+            event.kind === 'generation' &&
+            (event.profileId === 'workflow_internal_fallback' ||
+                event.effectiveProfileId === 'workflow_internal_fallback')
+    ) ?? false;
+
+/**
+ * Derives a conservative, path-semantics-only review runtime summary for UI.
+ *
+ * Label semantics:
+ * - not_reviewed: no bounded review pass was observed.
+ * - reviewed_no_revision: assess step executed and no revise step executed.
+ * - revised: review pass executed and at least one revise step executed.
+ * - skipped: review pass was expected but did not execute.
+ * - fallback: fail-open/fallback path was explicitly recorded.
+ */
+export const deriveReviewRuntimeSummary = (
+    metadata: Pick<ResponseMetadata, 'workflow' | 'workflowMode' | 'execution'>
+): ReviewRuntimeSummary => {
+    const assessExecuted =
+        metadata.workflow?.steps?.some(
+            (step) =>
+                step.stepKind === 'assess' && step.outcome.status === 'executed'
+        ) ?? false;
+    const assessSkipped =
+        metadata.workflow?.steps?.some(
+            (step) =>
+                step.stepKind === 'assess' && step.outcome.status === 'skipped'
+        ) ?? false;
+    const reviseExecuted =
+        metadata.workflow?.steps?.some(
+            (step) =>
+                step.stepKind === 'revise' && step.outcome.status === 'executed'
+        ) ?? false;
+    const reviewPass = metadata.workflowMode?.behavior?.reviewPass;
+    const workflowHasAnyStep = (metadata.workflow?.steps?.length ?? 0) > 0;
+    const fallbackObserved =
+        metadata.workflow?.terminationReason === 'executor_error_fail_open' ||
+        hasPlannerFallbackSignal(metadata) ||
+        hasInternalGenerationFallbackSignal(metadata);
+
+    if (fallbackObserved) {
+        return { label: 'fallback' };
+    }
+
+    if (reviseExecuted) {
+        return { label: 'revised' };
+    }
+
+    if (assessExecuted) {
+        return { label: 'reviewed_no_revision' };
+    }
+
+    if (assessSkipped || (reviewPass === 'included' && workflowHasAnyStep)) {
+        return { label: 'skipped' };
+    }
+
+    return { label: 'not_reviewed' };
+};

--- a/packages/contracts/src/ethics-core/types.ts
+++ b/packages/contracts/src/ethics-core/types.ts
@@ -501,6 +501,28 @@ export type WorkflowModeDecision = {
 };
 
 /**
+ * Canonical review-runtime labels for UI rendering.
+ * Labels describe execution path semantics only, not answer quality.
+ */
+export const REVIEW_RUNTIME_LABELS = [
+    'not_reviewed',
+    'reviewed_no_revision',
+    'revised',
+    'skipped',
+    'fallback',
+] as const;
+
+export type ReviewRuntimeLabel = (typeof REVIEW_RUNTIME_LABELS)[number];
+
+/**
+ * Compact normalized review-runtime summary for UI surfaces.
+ * This is backend-derived so UI does not infer semantics from raw steps.
+ */
+export type ReviewRuntimeSummary = {
+    label: ReviewRuntimeLabel;
+};
+
+/**
  * Canonical steerability control ids tracked in response metadata.
  * These remain backend-owned/operator-facing until user controls are exposed.
  */
@@ -686,6 +708,7 @@ export type ResponseMetadata = {
     provenanceAssessment?: ProvenanceAssessment; // Classification-method disclosure for provenance, including conflicts and limitations.
     execution?: ExecutionEvent[]; // Structural execution record (evaluator/tool/generation events).
     workflow?: WorkflowRecord; // Optional workflow record of bounded multi-step execution; includes planner lineage via plan steps.
+    reviewRuntime?: ReviewRuntimeSummary; // Normalized review-runtime summary for UI labels (path semantics only).
     workflowMode?: WorkflowModeDecision; // Execution-policy routing decision and behavior mapping.
     steerabilityControls?: SteerabilityControls; // Control-influence records explaining which controls shaped execution/output.
     evaluator?: EvaluatorOutcome; // Deterministic evaluator decision captured before breaker enforcement.

--- a/packages/contracts/src/ethics-core/workflowReceipt.ts
+++ b/packages/contracts/src/ethics-core/workflowReceipt.ts
@@ -7,6 +7,7 @@
  */
 
 import type { ResponseMetadata, WorkflowModeId } from './types.js';
+import { deriveReviewRuntimeSummary } from './reviewRuntime.js';
 
 const WORKFLOW_MODE_LABELS: Record<WorkflowModeId, string> = {
     fast: 'Fast mode',
@@ -46,32 +47,26 @@ export const resolveWorkflowModeLabel = (
  * Returns the review state line for the receipt.
  *
  * Rules:
- * - Show `Reviewed before final answer` only when an `assess` step actually
- *   ran (status is not `skipped`).
- * - Show `Review skipped` when metadata says review was excluded, or when
- *   review was expected but no review step ran.
- * - Return `null` when metadata is missing or not decisive.
+ * - Prefer backend-provided normalized reviewRuntime labels.
+ * - Fall back to deterministic derivation only for legacy traces.
+ * - Keep copy conservative and path-focused.
  */
 export const resolveReviewReceipt = (
     metadata: ResponseMetadata
 ): string | null => {
-    const reviewStepRan =
-        metadata.workflow?.steps?.some(
-            (step) =>
-                step.stepKind === 'assess' && step.outcome.status !== 'skipped'
-        ) ?? false;
-    if (reviewStepRan) {
+    const reviewRuntime =
+        metadata.reviewRuntime ?? deriveReviewRuntimeSummary(metadata);
+    if (reviewRuntime.label === 'reviewed_no_revision') {
         return 'Reviewed before final answer';
     }
-
-    const reviewPass = metadata.workflowMode?.behavior?.reviewPass;
-    if (reviewPass === 'excluded') {
+    if (reviewRuntime.label === 'revised') {
+        return 'Reviewed and revised before final answer';
+    }
+    if (reviewRuntime.label === 'skipped') {
         return 'Review skipped';
     }
-
-    const workflowStepCount = metadata.workflow?.steps?.length ?? 0;
-    if (reviewPass === 'included' && workflowStepCount > 0) {
-        return 'Review skipped';
+    if (reviewRuntime.label === 'fallback') {
+        return 'Review fallback';
     }
 
     return null;

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -20,6 +20,8 @@ export type {
     ExecutionReasonCode,
     ToolInvocationName,
     ToolInvocationReasonCode,
+    ReviewRuntimeLabel,
+    ReviewRuntimeSummary,
     ToolInvocationIntent,
     ToolInvocationRequest,
     ToolExecutionContext,
@@ -40,7 +42,10 @@ export type {
     TrustGraphMetadata,
     ResponseMetadata,
 } from './ethics-core/index.js';
-export { formatExecutionTimelineSummary } from './ethics-core/index.js';
+export {
+    formatExecutionTimelineSummary,
+    deriveReviewRuntimeSummary,
+} from './ethics-core/index.js';
 export {
     SafetyRuleIdSchema,
     SafetyActionSchema,

--- a/packages/contracts/src/web/schemas.ts
+++ b/packages/contracts/src/web/schemas.ts
@@ -9,6 +9,7 @@
 import { z } from 'zod';
 import {
     BOUNDED_REVIEW_ASSESS_DECISIONS,
+    REVIEW_RUNTIME_LABELS,
     WORKFLOW_STEP_KINDS,
     WORKFLOW_STEP_STATUSES,
     WORKFLOW_TERMINATION_REASONS,
@@ -493,6 +494,14 @@ const WorkflowRecordSchema = z
     })
     .strict();
 
+const ReviewRuntimeLabelSchema = z.enum(REVIEW_RUNTIME_LABELS);
+
+const ReviewRuntimeSummarySchema = z
+    .object({
+        label: ReviewRuntimeLabelSchema,
+    })
+    .strict();
+
 const TrustGraphProvenanceReasonCodeSchema = z.enum([
     'external_scope_validation_failed',
     'adapter_scope_mismatch',
@@ -727,6 +736,7 @@ const responseMetadataShape = {
     provenanceAssessment: ProvenanceAssessmentSchema.optional(),
     execution: z.array(ExecutionEventSchema).optional(),
     workflow: WorkflowRecordSchema.optional(),
+    reviewRuntime: ReviewRuntimeSummarySchema.optional(),
     workflowMode: WorkflowModeDecisionSchema.optional(),
     steerabilityControls: SteerabilityControlsSchema.optional(),
     evaluator: EvaluatorOutcomeSchema.optional(),

--- a/packages/contracts/test/webSchemas.test.ts
+++ b/packages/contracts/test/webSchemas.test.ts
@@ -429,6 +429,28 @@ test('ResponseMetadataSchema accepts workflow lineage metadata', () => {
     assert.equal(parsed.success, true);
 });
 
+test('ResponseMetadataSchema accepts normalized review runtime summary labels', () => {
+    const parsed = ResponseMetadataSchema.safeParse({
+        ...baseMetadata,
+        reviewRuntime: {
+            label: 'reviewed_no_revision',
+        },
+    });
+
+    assert.equal(parsed.success, true);
+});
+
+test('ResponseMetadataSchema rejects unknown normalized review runtime labels', () => {
+    const parsed = ResponseMetadataSchema.safeParse({
+        ...baseMetadata,
+        reviewRuntime: {
+            label: 'approved',
+        },
+    });
+
+    assert.equal(parsed.success, false);
+});
+
 test('ResponseMetadataSchema accepts structured steerability controls metadata', () => {
     const parsed = ResponseMetadataSchema.safeParse({
         ...baseMetadata,

--- a/packages/contracts/test/workflowReceipt.test.ts
+++ b/packages/contracts/test/workflowReceipt.test.ts
@@ -73,16 +73,19 @@ test('buildWorkflowReceiptItems renders mode, review, and planner fallback signa
                 reasonCode: 'planner_runtime_error',
             },
         ],
+        reviewRuntime: {
+            label: 'fallback',
+        },
     };
 
     assert.deepEqual(buildWorkflowReceiptItems(metadata), [
         'Answered in Balanced mode',
-        'Review skipped',
+        'Review fallback',
         'Planner fallback',
     ]);
     assert.equal(
         buildWorkflowReceiptSummary(metadata),
-        'Answered in Balanced mode • Review skipped • Planner fallback'
+        'Answered in Balanced mode • Review fallback • Planner fallback'
     );
 });
 
@@ -137,6 +140,19 @@ test('buildWorkflowReceiptItems marks reviewed only when assess step ran', () =>
     ]);
 });
 
+test('buildWorkflowReceiptItems reports revised label from normalized review runtime summary', () => {
+    const metadata: ResponseMetadata = {
+        ...createBaseMetadata(),
+        reviewRuntime: {
+            label: 'revised',
+        },
+    };
+
+    assert.deepEqual(buildWorkflowReceiptItems(metadata), [
+        'Reviewed and revised before final answer',
+    ]);
+});
+
 test('buildWorkflowReceiptSummary stays fail-open for legacy partial metadata', () => {
     const partialMetadata = {
         ...createBaseMetadata(),
@@ -150,4 +166,55 @@ test('buildWorkflowReceiptSummary stays fail-open for legacy partial metadata', 
         buildWorkflowReceiptSummary(partialMetadata),
         'Answered in Fast mode'
     );
+});
+
+test('buildWorkflowReceiptItems falls back to deterministic review derivation for legacy traces without reviewRuntime', () => {
+    const metadata: ResponseMetadata = {
+        ...createBaseMetadata(),
+        workflowMode: {
+            modeId: 'grounded',
+            selectedBy: 'requested_mode',
+            selectionReason: 'Requested by user.',
+            initial_mode: 'grounded',
+            behavior: {
+                executionContractPresetId: 'quality-grounded',
+                workflowProfileClass: 'reviewed',
+                workflowProfileId: 'bounded-review',
+                workflowExecution: 'always',
+                reviewPass: 'included',
+                reviseStep: 'allowed',
+                evidencePosture: 'strict',
+                maxWorkflowSteps: 2,
+                maxDeliberationCalls: 1,
+            },
+        },
+        workflow: {
+            workflowId: 'wf_legacy_1',
+            workflowName: 'message_with_review_loop',
+            status: 'degraded',
+            terminationReason: 'budget_exhausted_steps',
+            stepCount: 1,
+            maxSteps: 2,
+            maxDurationMs: 5000,
+            steps: [
+                {
+                    stepId: 'step_generate_1',
+                    attempt: 1,
+                    stepKind: 'generate',
+                    startedAt: '2026-04-22T00:00:00.000Z',
+                    finishedAt: '2026-04-22T00:00:00.010Z',
+                    durationMs: 10,
+                    outcome: {
+                        status: 'executed',
+                        summary: 'Generated initial draft response.',
+                    },
+                },
+            ],
+        },
+    };
+
+    assert.deepEqual(buildWorkflowReceiptItems(metadata), [
+        'Answered in Grounded mode',
+        'Review skipped',
+    ]);
 });

--- a/packages/discord-bot/test/provenanceButtons.test.ts
+++ b/packages/discord-bot/test/provenanceButtons.test.ts
@@ -160,7 +160,7 @@ test('details action renders markdown sections with execution table and trace vi
         assert.match(content, /Open full trace/);
         assert.match(content, /\/traces\/resp_details_sections/);
         assert.match(content, /Answered in Balanced mode/);
-        assert.match(content, /Review skipped/);
+        assert.match(content, /Review fallback/);
         assert.match(content, /Planner fallback/);
         assert.match(content, /Target Attribution: `5`/);
         assert.match(content, /Final Attribution: `3`/);


### PR DESCRIPTION
## Summary
This PR adds a single normalized review runtime summary in response metadata so UI surfaces can render review status labels without inferring semantics from raw workflow steps.

## Why
Previously, UI paths had to infer review state from low-level lineage details (for example, assess/revise steps and fallback signals). That made label rendering brittle and risked inconsistent interpretation. This change provides one conservative, metadata-backed source of truth focused on runtime path semantics only.

## What changed
- Added a new normalized eviewRuntime summary to response metadata.
- Introduced canonical labels:
  - 
ot_reviewed
  - eviewed_no_revision
  - evised
  - skipped
  - allback
- Added shared derivation logic in contracts to compute the summary from workflow, workflow mode, and execution signals.
- Emitted eviewRuntime from backend metadata assembly so new traces carry the normalized value directly.
- Extended web contract schemas and exported types to include the new summary.
- Updated workflow receipt rendering to prefer eviewRuntime and fall back to deterministic derivation for legacy traces.
- Updated related tests across backend, contracts, and discord surfaces.

## Implementation details
- The summary is intentionally path-semantic only: it describes what ran/stopped, not correctness or quality.
- Fallback handling is conservative and includes explicit fail-open/fallback signals.
- Backward compatibility is preserved by deriving labels when eviewRuntime is missing in older traces.
- No workflow execution behavior was changed (no replanning or lifecycle expansion).

This PR was written using [Vibe Kanban](https://vibekanban.com)