### PR TITLE
Prepare workflow tool-step migration seams and weather parity coverage

### DIFF
--- a/docs/architecture/workflow.md
+++ b/docs/architecture/workflow.md
@@ -131,15 +131,15 @@ The current chat path looks like this:
 1. `chatOrchestrator` receives and normalizes the request.
 2. The Execution Contract sets the allowed behavior and limits.
 3. The backend resolves workflow mode and profile.
-4. Planner runs once in `chatOrchestrator` before generation.
+4. Planner runs once in `chatOrchestrator` before workflow execution and generation.
 5. Planner output goes through surface policy, capability policy, and tool
    policy.
 6. `chatService` runs either direct generation or the bounded review loop.
 7. Response metadata records mode, planner influence, workflow lineage, cost,
    and trace or provenance fields.
 
-Planner affects execution today, but workflow engine timing does not fully own
-planner execution yet.
+Planner affects execution today, but planner timing still runs before the main
+workflow-engine execution path.
 
 Planner lineage can appear in workflow metadata as a `plan` step when that
 metadata exists for the run. That is a lineage bridge, not a change in planner
@@ -329,14 +329,14 @@ enforces legality and limits. Adapters connect the profile to runtime calls.
 
 Use this split when ownership is unclear:
 
-| Concern             | Engine core                                                          | Workflow profile                                                             | Adapters and callers                                                  |
-| ------------------- | -------------------------------------------------------------------- | ---------------------------------------------------------------------------- | --------------------------------------------------------------------- |
-| Step legality       | owns the canonical legality check before execution                   | declares intended flow and policy toggles                                    | supplies policy, but must not bypass legality checks                  |
-| Limits              | owns hard-stop checks and stop-reason mapping                        | declares default budgets within the shared limits model                      | passes config and surfaces the final result                           |
-| Workflow state      | owns step count, token totals, current step, and lineage progression | declares expected step shape                                                 | treats engine-produced workflow state as authoritative                |
-| Step execution      | owns the orchestration envelope and step recording rules             | defines step-specific semantics such as review parsing                       | builds requests and calls runtimes or providers                       |
-| Termination reasons | owns canonical termination reasons                                   | can request stop, but cannot invent new canonical reasons                    | persists and returns engine-assigned reasons unchanged                |
-| Fail-open behavior  | owns degraded fail-open workflow behavior                            | can define recoverable profile behavior, but not canonical fail-open meaning | must not block the user response on telemetry or persistence failures |
+| Concern             | Engine core                                                                                         | Workflow profile                                                             | Adapters and callers                                                  |
+| ------------------- | --------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------- | --------------------------------------------------------------------- |
+| Step legality       | owns the canonical legality check before execution                                                  | declares intended flow and policy toggles                                    | supplies policy, but must not bypass legality checks                  |
+| Limits              | owns hard-stop checks and stop-reason mapping                                                       | declares default budgets within the shared limits model                      | passes config and surfaces the final result                           |
+| Workflow state      | owns step count, token totals, current step, and lineage progression                                | declares expected step shape                                                 | treats engine-produced workflow state as authoritative                |
+| Step execution      | owns bounded-review concrete step execution today (`generate`, `assess`, `revise`) and step records | defines step-specific semantics such as review parsing                       | builds requests and calls runtimes or providers                       |
+| Termination reasons | owns canonical termination reasons                                                                  | can request stop, but cannot invent new canonical reasons                    | persists and returns engine-assigned reasons unchanged                |
+| Fail-open behavior  | owns degraded fail-open workflow behavior                                                           | can define recoverable profile behavior, but not canonical fail-open meaning | must not block the user response on telemetry or persistence failures |
 
 If a workflow bug looks like "who decided that?", start with this table.
 
@@ -356,8 +356,18 @@ The shared workflow vocabulary includes `plan`, `tool`, `generate`, `assess`,
 `revise`, and `finalize`.
 
 `plan` and `tool` are part of the vocabulary, but they are not the main
-current chat loop. Planner lineage may be attached to metadata, while planner
-timing still lives in orchestration today.
+current chat loop.
+
+Today:
+
+- planner timing still lives in `chatOrchestrator` before workflow execution
+- concrete tool execution still lives in `chatOrchestrator` and `toolRegistry`
+- workflow metadata can still include bridged planner lineage
+
+Recent helpers like `buildToolClarificationResponse` and
+`buildToolExecutionEvent` are migration seams for future workflow-owned tool
+steps. They are not evidence that tool execution already moved into
+`workflowEngine`.
 
 ## Step records
 

--- a/docs/status/workflow-engine-rollout-status.md
+++ b/docs/status/workflow-engine-rollout-status.md
@@ -19,10 +19,21 @@ Status: `pending`
 The workflow engine already knows about `tool` as a step kind and already has
 limit support such as `maxToolCalls`.
 
-What is still missing is first-class tool-step execution in the main chat
-workflow path. The bounded chat workflow still runs `generate`, `assess`, and
-`revise`. It does not yet run concrete workflow `tool` steps with recorded
-call attempts and execution shape.
+What is still missing is workflow-engine-owned tool-step execution in the main
+chat path.
+
+Today concrete `weather_forecast` execution still lives in
+`chatOrchestrator` and `toolRegistry`. The bounded workflow execution in the
+engine still runs concrete `generate`, `assess`, and `revise` steps.
+
+Recent prep work added migration seams such as:
+
+- `buildToolClarificationResponse` for clarification response assembly
+- `buildToolExecutionEvent` for standardized tool execution event mapping
+- parity tests that pin current orchestrator-owned weather behavior
+
+That prep improves migration safety, but it does not mean tool execution has
+moved into `workflowEngine`.
 
 The remaining goal is:
 
@@ -36,9 +47,9 @@ Status: `pending`
 
 Planner still runs before workflow execution in `chatOrchestrator`.
 
-Today the runtime can attach planner lineage into the workflow record so the
-trace can show that planner mattered. That is useful, but it is not the same
-thing as planner being a true workflow-owned executed step.
+Today the runtime can attach planner lineage into the workflow record so traces
+can show that planner mattered. That bridge is useful, but planner timing and
+execution are still not workflow-engine-owned.
 
 The remaining goal is:
 

--- a/packages/backend/src/services/chatOrchestrator.ts
+++ b/packages/backend/src/services/chatOrchestrator.ts
@@ -10,11 +10,7 @@ import type {
     PostChatResponse,
     ChatConversationMessage,
 } from '@footnote/contracts/web';
-import type {
-    SafetyTier,
-    ToolExecutionContext,
-    ToolExecutionEvent,
-} from '@footnote/contracts/ethics-core';
+import type { SafetyTier } from '@footnote/contracts/ethics-core';
 import { renderConversationPromptLayers } from './prompts/conversationPromptLayers.js';
 import {
     createChatService,
@@ -40,7 +36,6 @@ import {
     type PlannerFallbackReason,
     type PlannerSelectionSource,
 } from './plannerFallbackTelemetryRollup.js';
-import type { ResponseMetadataRuntimeContext } from './openaiService.js';
 import { resolveExecutionContract } from './executionContractResolver.js';
 import { resolveWorkflowModeDecision } from './workflowProfileRegistry.js';
 import { buildSteerabilityControls } from './steerabilityControls.js';
@@ -50,6 +45,7 @@ import {
     executeSelectedTool,
     resolveToolSelection,
 } from './tools/toolRegistry.js';
+import { buildToolClarificationResponse } from './tools/toolClarificationResponse.js';
 import { runtimeConfig } from '../config.js';
 import { logger } from '../utils/logger.js';
 import type { IncidentAlertRouter } from './incidentAlerts.js';
@@ -188,90 +184,6 @@ export const createChatOrchestrator = ({
         defaultModel: plannerProfile.providerModel,
         recordUsage,
     });
-
-    const handleToolClarification = (input: {
-        toolContext: ToolExecutionContext;
-        conversationSnapshot: string;
-        modelVersion: string;
-        generationProfile: {
-            profileId: string;
-            originalProfileId?: string;
-            effectiveProfileId?: string;
-            provider: string;
-            model: string;
-        };
-        plannerExecutionContext: NonNullable<
-            ResponseMetadataRuntimeContext['executionContext']
-        >['planner'];
-        evaluatorExecutionContext?: EvaluatorExecutionContext;
-    }): PostChatResponse => {
-        const {
-            toolContext,
-            conversationSnapshot,
-            modelVersion,
-            generationProfile,
-            plannerExecutionContext,
-            evaluatorExecutionContext,
-        } = input;
-        const { clarification, toolName, status, durationMs } = toolContext;
-        const clarificationMessage = [
-            clarification?.question ?? 'Which location did you mean?',
-            '',
-            ...(clarification?.options ?? []).map(
-                (option, index) => `${index + 1}. ${option.label}`
-            ),
-            '',
-            'Please reply with your choice.',
-        ].join('\n');
-
-        const toolExecutionEvent: ToolExecutionEvent = {
-            kind: 'tool',
-            toolName,
-            status,
-            clarification,
-            durationMs,
-        };
-
-        const metadata = buildResponseMetadata(
-            {
-                model: modelVersion,
-                citations: [],
-            },
-            {
-                modelVersion,
-                conversationSnapshot,
-                executionContext: {
-                    planner: plannerExecutionContext,
-                    evaluator: evaluatorExecutionContext,
-                    generation: {
-                        status: 'skipped',
-                        profileId: generationProfile.profileId,
-                        originalProfileId: generationProfile.originalProfileId,
-                        effectiveProfileId:
-                            generationProfile.effectiveProfileId,
-                        provider: generationProfile.provider,
-                        model: generationProfile.model,
-                    },
-                    tool: toolContext,
-                },
-            }
-        );
-
-        return {
-            action: 'message',
-            message: clarificationMessage,
-            modality: 'text',
-            metadata: {
-                ...metadata,
-                execution: [
-                    ...(metadata.execution ?? []).filter(
-                        (event) => event.kind !== 'tool'
-                    ),
-                    toolExecutionEvent,
-                ],
-            },
-        };
-    };
 
     /**
      * Runs one chat request end-to-end.
@@ -688,54 +600,61 @@ export const createChatOrchestrator = ({
                         toolExecutionContext.clarification.options.length,
                 }
             );
-            return handleToolClarification({
+            return buildToolClarificationResponse({
                 toolContext: toolExecutionContext,
-                conversationSnapshot: JSON.stringify({
-                    request: normalizedRequest,
-                    planner: {
-                        action: executionPlan.action,
-                        modality: executionPlan.modality,
-                        profileId: executionPlan.profileId,
-                        safetyTier: executionPlan.safetyTier,
-                        generation: executionPlan.generation,
-                        toolIntent,
-                        toolRequest: toolRequestContext,
-                        ...(surfacePolicy && { surfacePolicy }),
+                metadataContext: {
+                    modelVersion: selectedResponseProfile.providerModel,
+                    conversationSnapshot: JSON.stringify({
+                        request: normalizedRequest,
+                        planner: {
+                            action: executionPlan.action,
+                            modality: executionPlan.modality,
+                            profileId: executionPlan.profileId,
+                            safetyTier: executionPlan.safetyTier,
+                            generation: executionPlan.generation,
+                            toolIntent,
+                            toolRequest: toolRequestContext,
+                            ...(surfacePolicy && { surfacePolicy }),
+                        },
+                        executionContract: {
+                            policyId: resolvedExecutionContract.policyId,
+                            policyVersion:
+                                resolvedExecutionContract.policyVersion,
+                        },
+                        clarification: {
+                            toolName: toolExecutionContext.toolName,
+                            reasonCode:
+                                toolExecutionContext.clarification.reasonCode,
+                        },
+                    }),
+                    executionContext: {
+                        planner: {
+                            status: plannerExecution.status,
+                            reasonCode: plannerExecution.reasonCode,
+                            purpose: plannerExecution.purpose,
+                            contractType: plannerExecution.contractType,
+                            applyOutcome: plannerApplyOutcome,
+                            mattered: plannerMattered,
+                            matteredControlIds: plannerMatteredControlIds,
+                            profileId: plannerProfile.id,
+                            originalProfileId: plannerProfile.id,
+                            effectiveProfileId: plannerProfile.id,
+                            provider: plannerProfile.provider,
+                            model: plannerProfile.providerModel,
+                            durationMs: plannerExecution.durationMs,
+                        },
+                        evaluator: evaluatorExecutionContext,
+                        generation: {
+                            status: 'executed',
+                            profileId: selectedResponseProfile.id,
+                            originalProfileId: originalSelectedProfileId,
+                            effectiveProfileId: effectiveSelectedProfileId,
+                            provider: selectedResponseProfile.provider,
+                            model: selectedResponseProfile.providerModel,
+                        },
                     },
-                    executionContract: {
-                        policyId: resolvedExecutionContract.policyId,
-                        policyVersion: resolvedExecutionContract.policyVersion,
-                    },
-                    clarification: {
-                        toolName: toolExecutionContext.toolName,
-                        reasonCode:
-                            toolExecutionContext.clarification.reasonCode,
-                    },
-                }),
-                modelVersion: selectedResponseProfile.providerModel,
-                generationProfile: {
-                    profileId: selectedResponseProfile.id,
-                    originalProfileId: originalSelectedProfileId,
-                    effectiveProfileId: effectiveSelectedProfileId,
-                    provider: selectedResponseProfile.provider,
-                    model: selectedResponseProfile.providerModel,
                 },
-                plannerExecutionContext: {
-                    status: plannerExecution.status,
-                    reasonCode: plannerExecution.reasonCode,
-                    purpose: plannerExecution.purpose,
-                    contractType: plannerExecution.contractType,
-                    applyOutcome: plannerApplyOutcome,
-                    mattered: plannerMattered,
-                    matteredControlIds: plannerMatteredControlIds,
-                    profileId: plannerProfile.id,
-                    originalProfileId: plannerProfile.id,
-                    effectiveProfileId: plannerProfile.id,
-                    provider: plannerProfile.provider,
-                    model: plannerProfile.providerModel,
-                    durationMs: plannerExecution.durationMs,
-                },
-                evaluatorExecutionContext,
+                buildResponseMetadata,
             });
         }
 

--- a/packages/backend/src/services/chatOrchestrator.ts
+++ b/packages/backend/src/services/chatOrchestrator.ts
@@ -46,6 +46,8 @@ import {
     resolveToolSelection,
 } from './tools/toolRegistry.js';
 import { buildToolClarificationResponse } from './tools/toolClarificationResponse.js';
+import { buildWeatherToolFailureResponse } from './tools/weatherToolFailureResponse.js';
+import { resolveWeatherClarificationContinuation } from './tools/weatherClarificationContinuation.js';
 import { runtimeConfig } from '../config.js';
 import { logger } from '../utils/logger.js';
 import type { IncidentAlertRouter } from './incidentAlerts.js';
@@ -202,6 +204,8 @@ export const createChatOrchestrator = ({
             request,
             chatOrchestratorLogger
         );
+        const clarificationContinuation =
+            resolveWeatherClarificationContinuation(normalizedRequest);
         let evaluatorExecutionContext: EvaluatorExecutionContext | undefined;
         const notifyBreakerEvent = (input: {
             responseId: string | null;
@@ -350,6 +354,16 @@ export const createChatOrchestrator = ({
                 ? { verbosity: requestGeneration.verbosity }
                 : {}),
         };
+        if (clarificationContinuation.kind === 'resolved') {
+            generationForExecution = {
+                ...generationForExecution,
+                toolIntent: {
+                    toolName: 'weather_forecast',
+                    requested: true,
+                    input: clarificationContinuation.selectedOption.input,
+                },
+            };
+        }
         const toolPolicyDecision = applySingleToolPolicy(
             generationForExecution
         );
@@ -586,6 +600,146 @@ export const createChatOrchestrator = ({
         const toolResultMessage = toolExecution.toolResultMessage;
         toolExecutionContext =
             toolExecution.toolExecutionContext ?? toolExecutionContext;
+
+        if (
+            clarificationContinuation.kind === 'unresolved' &&
+            clarificationContinuation.pending.options.length > 0
+        ) {
+            return buildToolClarificationResponse({
+                toolContext: {
+                    toolName: 'weather_forecast',
+                    status: 'executed',
+                    clarification: {
+                        reasonCode: 'ambiguous_location',
+                        question: clarificationContinuation.pending.question,
+                        options: clarificationContinuation.pending.options.map(
+                            (option) => ({
+                                id: option.id,
+                                label: option.label,
+                                value: {
+                                    toolName: 'weather_forecast',
+                                    input: option.input,
+                                },
+                            })
+                        ),
+                    },
+                },
+                metadataContext: {
+                    modelVersion: selectedResponseProfile.providerModel,
+                    conversationSnapshot: JSON.stringify({
+                        request: normalizedRequest,
+                        planner: {
+                            action: executionPlan.action,
+                            modality: executionPlan.modality,
+                            profileId: executionPlan.profileId,
+                            safetyTier: executionPlan.safetyTier,
+                            generation: executionPlan.generation,
+                            toolIntent,
+                            toolRequest: toolRequestContext,
+                            ...(surfacePolicy && { surfacePolicy }),
+                        },
+                        executionContract: {
+                            policyId: resolvedExecutionContract.policyId,
+                            policyVersion:
+                                resolvedExecutionContract.policyVersion,
+                        },
+                        clarification: {
+                            toolName: 'weather_forecast',
+                            reasonCode: 'ambiguous_location',
+                        },
+                    }),
+                    executionContext: {
+                        planner: {
+                            status: plannerExecution.status,
+                            reasonCode: plannerExecution.reasonCode,
+                            purpose: plannerExecution.purpose,
+                            contractType: plannerExecution.contractType,
+                            applyOutcome: plannerApplyOutcome,
+                            mattered: plannerMattered,
+                            matteredControlIds: plannerMatteredControlIds,
+                            profileId: plannerProfile.id,
+                            originalProfileId: plannerProfile.id,
+                            effectiveProfileId: plannerProfile.id,
+                            provider: plannerProfile.provider,
+                            model: plannerProfile.providerModel,
+                            durationMs: plannerExecution.durationMs,
+                        },
+                        evaluator: evaluatorExecutionContext,
+                        generation: {
+                            status: 'executed',
+                            profileId: selectedResponseProfile.id,
+                            originalProfileId: originalSelectedProfileId,
+                            effectiveProfileId: effectiveSelectedProfileId,
+                            provider: selectedResponseProfile.provider,
+                            model: selectedResponseProfile.providerModel,
+                        },
+                    },
+                },
+                buildResponseMetadata,
+            });
+        }
+
+        if (
+            toolExecutionContext?.toolName === 'weather_forecast' &&
+            toolExecutionContext.status === 'failed'
+        ) {
+            return buildWeatherToolFailureResponse({
+                toolContext: toolExecutionContext,
+                metadataContext: {
+                    modelVersion: selectedResponseProfile.providerModel,
+                    conversationSnapshot: JSON.stringify({
+                        request: normalizedRequest,
+                        planner: {
+                            action: executionPlan.action,
+                            modality: executionPlan.modality,
+                            profileId: executionPlan.profileId,
+                            safetyTier: executionPlan.safetyTier,
+                            generation: executionPlan.generation,
+                            toolIntent,
+                            toolRequest: toolRequestContext,
+                            ...(surfacePolicy && { surfacePolicy }),
+                        },
+                        executionContract: {
+                            policyId: resolvedExecutionContract.policyId,
+                            policyVersion:
+                                resolvedExecutionContract.policyVersion,
+                        },
+                        toolFailure: {
+                            toolName: toolExecutionContext.toolName,
+                            reasonCode: toolExecutionContext.reasonCode,
+                        },
+                    }),
+                    executionContext: {
+                        planner: {
+                            status: plannerExecution.status,
+                            reasonCode: plannerExecution.reasonCode,
+                            purpose: plannerExecution.purpose,
+                            contractType: plannerExecution.contractType,
+                            applyOutcome: plannerApplyOutcome,
+                            mattered: plannerMattered,
+                            matteredControlIds: plannerMatteredControlIds,
+                            profileId: plannerProfile.id,
+                            originalProfileId: plannerProfile.id,
+                            effectiveProfileId: plannerProfile.id,
+                            provider: plannerProfile.provider,
+                            model: plannerProfile.providerModel,
+                            durationMs: plannerExecution.durationMs,
+                        },
+                        evaluator: evaluatorExecutionContext,
+                        generation: {
+                            status: 'executed',
+                            profileId: selectedResponseProfile.id,
+                            originalProfileId: originalSelectedProfileId,
+                            effectiveProfileId: effectiveSelectedProfileId,
+                            provider: selectedResponseProfile.provider,
+                            model: selectedResponseProfile.providerModel,
+                        },
+                    },
+                },
+                latestUserInput: normalizedRequest.latestUserInput,
+                buildResponseMetadata,
+            });
+        }
 
         if (
             toolExecutionContext?.clarification &&

--- a/packages/backend/src/services/tools/toolClarificationResponse.ts
+++ b/packages/backend/src/services/tools/toolClarificationResponse.ts
@@ -1,0 +1,99 @@
+/**
+ * @description: Assembles clarification responses for executed tool outcomes that require user disambiguation.
+ * Keeps metadata shaping for clarification replies consistent and reusable across orchestration surfaces.
+ * @footnote-scope: utility
+ * @footnote-module: ToolClarificationResponse
+ * @footnote-risk: low - This helper only formats a clarification reply and metadata envelope.
+ * @footnote-ethics: medium - Clarification metadata must accurately signal skipped generation and tool context for traceability.
+ */
+import type { PostChatResponse } from '@footnote/contracts/web';
+import type {
+    ResponseMetadata,
+    ToolExecutionContext,
+    ToolExecutionEvent,
+} from '@footnote/contracts/ethics-core';
+import type {
+    AssistantResponseMetadata,
+    ResponseMetadataRuntimeContext,
+} from '../openaiService.js';
+
+type ToolClarificationMetadataContext = Omit<
+    ResponseMetadataRuntimeContext,
+    'executionContext'
+> & {
+    executionContext: NonNullable<
+        ResponseMetadataRuntimeContext['executionContext']
+    > & {
+        generation: NonNullable<
+            NonNullable<
+                ResponseMetadataRuntimeContext['executionContext']
+            >['generation']
+        >;
+    };
+};
+
+export const buildToolClarificationResponse = ({
+    toolContext,
+    metadataContext,
+    buildResponseMetadata,
+}: {
+    toolContext: ToolExecutionContext;
+    metadataContext: ToolClarificationMetadataContext;
+    buildResponseMetadata: (
+        assistantMetadata: AssistantResponseMetadata,
+        runtimeContext: ResponseMetadataRuntimeContext
+    ) => ResponseMetadata;
+}): PostChatResponse => {
+    const clarificationMessage = [
+        toolContext.clarification?.question ?? 'Which location did you mean?',
+        '',
+        ...(toolContext.clarification?.options ?? []).map(
+            (option, index) => `${index + 1}. ${option.label}`
+        ),
+        '',
+        'Please reply with your choice.',
+    ].join('\n');
+
+    const metadataWithSkippedGenerationContext: ResponseMetadataRuntimeContext =
+        {
+            ...metadataContext,
+            executionContext: {
+                ...metadataContext.executionContext,
+                generation: {
+                    ...metadataContext.executionContext?.generation,
+                    status: 'skipped',
+                },
+                tool: toolContext,
+            },
+        };
+
+    const metadata = buildResponseMetadata(
+        {
+            model: metadataContext.modelVersion,
+            citations: [],
+        },
+        metadataWithSkippedGenerationContext
+    );
+    const toolExecutionEvent: ToolExecutionEvent = {
+        kind: 'tool',
+        toolName: toolContext.toolName,
+        status: toolContext.status,
+        clarification: toolContext.clarification,
+        durationMs: toolContext.durationMs,
+    };
+
+    return {
+        action: 'message',
+        message: clarificationMessage,
+        modality: 'text',
+        metadata: {
+            ...metadata,
+            execution: [
+                ...(metadata.execution ?? []).filter(
+                    (event) => event.kind !== 'tool'
+                ),
+                toolExecutionEvent,
+            ],
+        },
+    };
+};

--- a/packages/backend/src/services/tools/toolClarificationResponse.ts
+++ b/packages/backend/src/services/tools/toolClarificationResponse.ts
@@ -10,12 +10,12 @@ import type { PostChatResponse } from '@footnote/contracts/web';
 import type {
     ResponseMetadata,
     ToolExecutionContext,
-    ToolExecutionEvent,
 } from '@footnote/contracts/ethics-core';
 import type {
     AssistantResponseMetadata,
     ResponseMetadataRuntimeContext,
 } from '../openaiService.js';
+import { buildToolExecutionEvent } from './toolExecutionEvents.js';
 
 type ToolClarificationMetadataContext = Omit<
     ResponseMetadataRuntimeContext,
@@ -74,13 +74,7 @@ export const buildToolClarificationResponse = ({
         },
         metadataWithSkippedGenerationContext
     );
-    const toolExecutionEvent: ToolExecutionEvent = {
-        kind: 'tool',
-        toolName: toolContext.toolName,
-        status: toolContext.status,
-        clarification: toolContext.clarification,
-        durationMs: toolContext.durationMs,
-    };
+    const toolExecutionEvent = buildToolExecutionEvent(toolContext);
 
     return {
         action: 'message',

--- a/packages/backend/src/services/tools/toolExecutionEvents.ts
+++ b/packages/backend/src/services/tools/toolExecutionEvents.ts
@@ -1,0 +1,29 @@
+/**
+ * @description: Builds serializable tool execution events from runtime tool execution context.
+ * Keeps tool execution metadata construction explicit and reusable across orchestration surfaces.
+ * @footnote-scope: utility
+ * @footnote-module: ToolExecutionEvents
+ * @footnote-risk: low - This helper only maps context fields into execution-event shape.
+ * @footnote-ethics: medium - Tool execution events inform provenance and operator-visible trace narratives.
+ */
+import type {
+    ToolExecutionContext,
+    ToolExecutionEvent,
+} from '@footnote/contracts/ethics-core';
+
+export const buildToolExecutionEvent = (
+    toolContext: ToolExecutionContext
+): ToolExecutionEvent => ({
+    kind: 'tool',
+    toolName: toolContext.toolName,
+    status: toolContext.status,
+    ...(toolContext.reasonCode !== undefined && {
+        reasonCode: toolContext.reasonCode,
+    }),
+    ...(toolContext.durationMs !== undefined && {
+        durationMs: toolContext.durationMs,
+    }),
+    ...(toolContext.clarification !== undefined && {
+        clarification: toolContext.clarification,
+    }),
+});

--- a/packages/backend/src/services/tools/weatherClarificationContinuation.ts
+++ b/packages/backend/src/services/tools/weatherClarificationContinuation.ts
@@ -1,0 +1,294 @@
+/**
+ * @description: Resolves user follow-up replies against prior weather clarification lists.
+ * Converts plain-text clarification options back into deterministic weather tool inputs.
+ * @footnote-scope: utility
+ * @footnote-module: WeatherClarificationContinuation
+ * @footnote-risk: medium - Incorrect matching can select the wrong place and fetch the wrong forecast.
+ * @footnote-ethics: medium - Follow-up resolution affects user trust, so ambiguous matches fail open to re-ask.
+ */
+import type { PostChatRequest } from '@footnote/contracts/web';
+import type { WeatherForecastRequest } from '../openMeteoForecastTool.js';
+
+type ParsedClarificationOption = {
+    id: string;
+    label: string;
+    input: WeatherForecastRequest;
+};
+
+export type PendingWeatherClarification = {
+    question: string;
+    options: ParsedClarificationOption[];
+};
+
+type ClarificationResolution =
+    | {
+          kind: 'resolved';
+          selectedOption: ParsedClarificationOption;
+          pending: PendingWeatherClarification;
+      }
+    | {
+          kind: 'unresolved';
+          pending: PendingWeatherClarification;
+      }
+    | {
+          kind: 'none';
+      };
+
+const ORDINAL_MAP: Record<string, number> = {
+    first: 1,
+    second: 2,
+    third: 3,
+    fourth: 4,
+    fifth: 5,
+};
+
+const US_STATE_ALIASES: Record<string, string[]> = {
+    AL: ['alabama'],
+    AK: ['alaska'],
+    AZ: ['arizona'],
+    AR: ['arkansas'],
+    CA: ['california'],
+    CO: ['colorado'],
+    CT: ['connecticut'],
+    DE: ['delaware'],
+    FL: ['florida'],
+    GA: ['georgia'],
+    HI: ['hawaii'],
+    ID: ['idaho'],
+    IL: ['illinois'],
+    IN: ['indiana'],
+    IA: ['iowa'],
+    KS: ['kansas'],
+    KY: ['kentucky'],
+    LA: ['louisiana'],
+    ME: ['maine'],
+    MD: ['maryland'],
+    MA: ['massachusetts'],
+    MI: ['michigan'],
+    MN: ['minnesota'],
+    MS: ['mississippi'],
+    MO: ['missouri'],
+    MT: ['montana'],
+    NE: ['nebraska'],
+    NV: ['nevada'],
+    NH: ['new hampshire'],
+    NJ: ['new jersey'],
+    NM: ['new mexico'],
+    NY: ['new york'],
+    NC: ['north carolina'],
+    ND: ['north dakota'],
+    OH: ['ohio'],
+    OK: ['oklahoma'],
+    OR: ['oregon'],
+    PA: ['pennsylvania'],
+    RI: ['rhode island'],
+    SC: ['south carolina'],
+    SD: ['south dakota'],
+    TN: ['tennessee'],
+    TX: ['texas'],
+    UT: ['utah'],
+    VT: ['vermont'],
+    VA: ['virginia'],
+    WA: ['washington'],
+    WV: ['west virginia'],
+    WI: ['wisconsin'],
+    WY: ['wyoming'],
+    DC: ['district of columbia', 'washington dc'],
+};
+
+const normalizeText = (value: string): string =>
+    value
+        .toLowerCase()
+        .replace(/[^a-z0-9\s]/g, ' ')
+        .replace(/\s+/g, ' ')
+        .trim();
+
+const tryParseNumberSelection = (value: string): number | undefined => {
+    const numberMatch = value.match(/\b([1-9][0-9]?)\b/);
+    if (numberMatch && numberMatch[1]) {
+        return Number(numberMatch[1]);
+    }
+
+    for (const [ordinal, index] of Object.entries(ORDINAL_MAP)) {
+        if (value.includes(ordinal)) {
+            return index;
+        }
+    }
+
+    return undefined;
+};
+
+const inferCountryCode = (labelParts: string[]): string | undefined => {
+    const tail = labelParts.at(-1)?.trim().toUpperCase();
+    if (!tail || !/^[A-Z]{2}$/.test(tail)) {
+        return undefined;
+    }
+    return tail;
+};
+
+const toWeatherInputFromLabel = (label: string): WeatherForecastRequest => {
+    const parts = label
+        .split(',')
+        .map((part) => part.trim())
+        .filter((part) => part.length > 0);
+    const countryCode = inferCountryCode(parts);
+    const coreParts =
+        countryCode !== undefined ? parts.slice(0, parts.length - 1) : parts;
+    const query = coreParts.length > 0 ? coreParts.join(', ') : label.trim();
+    return {
+        location: {
+            type: 'place_query',
+            query,
+            ...(countryCode !== undefined && { countryCode }),
+        },
+    };
+};
+
+const parseClarificationFromAssistantMessage = (
+    content: string
+): PendingWeatherClarification | null => {
+    if (!content.includes('Please reply with your choice.')) {
+        return null;
+    }
+
+    const options: ParsedClarificationOption[] = [];
+    const optionPattern = /^\s*(\d+)\.\s+(.+?)\s*$/gm;
+    let match: RegExpExecArray | null = optionPattern.exec(content);
+    while (match) {
+        const indexText = match[1];
+        const label = match[2]?.trim();
+        if (indexText && label) {
+            options.push({
+                id: `option-${indexText}`,
+                label,
+                input: toWeatherInputFromLabel(label),
+            });
+        }
+        match = optionPattern.exec(content);
+    }
+
+    if (options.length === 0) {
+        return null;
+    }
+
+    return {
+        question: 'Which location did you mean?',
+        options,
+    };
+};
+
+const findPendingWeatherClarification = (
+    conversation: PostChatRequest['conversation']
+): PendingWeatherClarification | null => {
+    for (let index = conversation.length - 1; index >= 0; index -= 1) {
+        const message = conversation[index];
+        if (!message || message.role !== 'assistant') {
+            continue;
+        }
+
+        const parsed = parseClarificationFromAssistantMessage(message.content);
+        if (parsed) {
+            return parsed;
+        }
+    }
+
+    return null;
+};
+
+const normalizeStateTokens = (userText: string): Set<string> => {
+    const normalized = normalizeText(userText);
+    const tokens = new Set<string>();
+    for (const [abbr, names] of Object.entries(US_STATE_ALIASES)) {
+        if (normalized.includes(abbr.toLowerCase())) {
+            tokens.add(abbr.toLowerCase());
+        }
+        if (names.some((name) => normalized.includes(name))) {
+            tokens.add(abbr.toLowerCase());
+        }
+    }
+    return tokens;
+};
+
+const matchOptionByText = (
+    userText: string,
+    options: ParsedClarificationOption[]
+): ParsedClarificationOption | null => {
+    const normalizedUserText = normalizeText(userText);
+    if (normalizedUserText.length === 0) {
+        return null;
+    }
+
+    const directMatches = options.filter((option) =>
+        normalizeText(option.label).includes(normalizedUserText)
+    );
+    if (directMatches.length === 1) {
+        return directMatches[0] ?? null;
+    }
+
+    const stateTokens = normalizeStateTokens(userText);
+    if (stateTokens.size > 0) {
+        const stateMatches = options.filter((option) => {
+            const normalizedLabel = normalizeText(option.label);
+            for (const token of stateTokens) {
+                const aliases = US_STATE_ALIASES[token.toUpperCase()] ?? [];
+                if (
+                    normalizedLabel.includes(token) ||
+                    aliases.some((alias) =>
+                        normalizedLabel.includes(normalizeText(alias))
+                    )
+                ) {
+                    return true;
+                }
+            }
+            return false;
+        });
+        if (stateMatches.length === 1) {
+            return stateMatches[0] ?? null;
+        }
+    }
+
+    return null;
+};
+
+export const resolveWeatherClarificationContinuation = (
+    request: PostChatRequest
+): ClarificationResolution => {
+    const pending = findPendingWeatherClarification(request.conversation);
+    if (!pending) {
+        return { kind: 'none' };
+    }
+
+    const normalizedInput = normalizeText(request.latestUserInput);
+    const numericChoice = tryParseNumberSelection(normalizedInput);
+    if (
+        numericChoice !== undefined &&
+        numericChoice >= 1 &&
+        numericChoice <= pending.options.length
+    ) {
+        const selectedOption = pending.options[numericChoice - 1];
+        if (selectedOption) {
+            return {
+                kind: 'resolved',
+                selectedOption,
+                pending,
+            };
+        }
+    }
+
+    const textMatch = matchOptionByText(
+        request.latestUserInput,
+        pending.options
+    );
+    if (textMatch) {
+        return {
+            kind: 'resolved',
+            selectedOption: textMatch,
+            pending,
+        };
+    }
+
+    return {
+        kind: 'unresolved',
+        pending,
+    };
+};

--- a/packages/backend/src/services/tools/weatherToolFailureResponse.ts
+++ b/packages/backend/src/services/tools/weatherToolFailureResponse.ts
@@ -1,0 +1,102 @@
+/**
+ * @description: Builds deterministic user-facing tool failure replies without speculative generated content.
+ * Keeps fail-open messaging explicit when backend tools cannot provide reliable data.
+ * @footnote-scope: utility
+ * @footnote-module: WeatherToolFailureResponse
+ * @footnote-risk: low - This helper only formats fallback text and metadata for failed tool calls.
+ * @footnote-ethics: high - Prevents fabricated tool-backed claims by making failure states explicit.
+ */
+import type { PostChatResponse } from '@footnote/contracts/web';
+import type {
+    ResponseMetadata,
+    ToolExecutionContext,
+    ToolExecutionEvent,
+} from '@footnote/contracts/ethics-core';
+import type {
+    AssistantResponseMetadata,
+    ResponseMetadataRuntimeContext,
+} from '../openaiService.js';
+
+type ToolFailureMetadataContext = Omit<
+    ResponseMetadataRuntimeContext,
+    'executionContext'
+> & {
+    executionContext: NonNullable<
+        ResponseMetadataRuntimeContext['executionContext']
+    > & {
+        generation: NonNullable<
+            NonNullable<
+                ResponseMetadataRuntimeContext['executionContext']
+            >['generation']
+        >;
+    };
+};
+
+export const buildWeatherToolFailureResponse = ({
+    toolContext,
+    metadataContext,
+    latestUserInput,
+    buildResponseMetadata,
+}: {
+    toolContext: ToolExecutionContext;
+    metadataContext: ToolFailureMetadataContext;
+    latestUserInput: string;
+    buildResponseMetadata: (
+        assistantMetadata: AssistantResponseMetadata,
+        runtimeContext: ResponseMetadataRuntimeContext
+    ) => ResponseMetadata;
+}): PostChatResponse => {
+    const sanitizedInput = latestUserInput.trim();
+    const locationHint =
+        sanitizedInput.length > 0
+            ? ` for "${sanitizedInput}"`
+            : ' for that location';
+    const failureMessage = [
+        `I couldn't fetch live weather${locationHint}.`,
+        "I don't want to guess.",
+        'Please try a more specific location like "City, State" or a ZIP code.',
+    ].join(' ');
+
+    const metadataWithSkippedGenerationContext: ResponseMetadataRuntimeContext =
+        {
+            ...metadataContext,
+            executionContext: {
+                ...metadataContext.executionContext,
+                generation: {
+                    ...metadataContext.executionContext?.generation,
+                    status: 'skipped',
+                },
+                tool: toolContext,
+            },
+        };
+
+    const metadata = buildResponseMetadata(
+        {
+            model: metadataContext.modelVersion,
+            citations: [],
+        },
+        metadataWithSkippedGenerationContext
+    );
+    const toolExecutionEvent: ToolExecutionEvent = {
+        kind: 'tool',
+        toolName: toolContext.toolName,
+        status: toolContext.status,
+        reasonCode: toolContext.reasonCode,
+        durationMs: toolContext.durationMs,
+    };
+
+    return {
+        action: 'message',
+        message: failureMessage,
+        modality: 'text',
+        metadata: {
+            ...metadata,
+            execution: [
+                ...(metadata.execution ?? []).filter(
+                    (event) => event.kind !== 'tool'
+                ),
+                toolExecutionEvent,
+            ],
+        },
+    };
+};

--- a/packages/backend/src/services/workflowEngine.ts
+++ b/packages/backend/src/services/workflowEngine.ts
@@ -624,6 +624,8 @@ export const runBoundedReviewWorkflow = async ({
     captureUsage,
     plannerStepRecord,
 }: RunBoundedReviewWorkflowInput): Promise<RunBoundedReviewWorkflowResult> => {
+    // NOTE: Concrete tool execution is still orchestrator/registry-owned.
+    // This engine path currently executes only bounded review generation steps.
     const UNBOUNDED_LIMIT = UNBOUNDED_LIMIT_SENTINEL;
     const sanitizeNonNegativeInteger = (
         value: number,

--- a/packages/backend/test/toolClarificationResponse.test.ts
+++ b/packages/backend/test/toolClarificationResponse.test.ts
@@ -1,0 +1,129 @@
+/**
+ * @description: Verifies clarification response assembly keeps metadata and execution semantics stable.
+ * @footnote-scope: test
+ * @footnote-module: ToolClarificationResponseTests
+ * @footnote-risk: low - Narrow unit coverage for response shaping helper only.
+ * @footnote-ethics: medium - Clarification paths must clearly record skipped generation and tool context.
+ */
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import type {
+    ResponseMetadata,
+    ToolExecutionContext,
+} from '@footnote/contracts/ethics-core';
+import type { ResponseMetadataRuntimeContext } from '../src/services/openaiService.js';
+import { createMetadata } from './fixtures/responseMetadataFixture.js';
+import { buildToolClarificationResponse } from '../src/services/tools/toolClarificationResponse.js';
+
+test('buildToolClarificationResponse formats numbered options and preserves execution contexts', () => {
+    let capturedRuntimeContext: ResponseMetadataRuntimeContext | undefined;
+    const toolContext: ToolExecutionContext = {
+        toolName: 'weather_forecast',
+        status: 'executed',
+        clarification: {
+            reasonCode: 'ambiguous_location',
+            question: 'Which New York did you mean?',
+            options: [
+                {
+                    id: 'nyc',
+                    label: 'New York City, New York, United States',
+                },
+                {
+                    id: 'nys',
+                    label: 'New York State, United States',
+                },
+            ],
+        },
+        durationMs: 12,
+    };
+
+    const response = buildToolClarificationResponse({
+        toolContext,
+        metadataContext: {
+            modelVersion: 'gpt-5-mini',
+            conversationSnapshot: '{"request":"weather"}',
+            executionContext: {
+                planner: {
+                    status: 'executed',
+                    purpose: 'chat_orchestrator_action_selection',
+                    contractType: 'structured',
+                    applyOutcome: 'applied',
+                    mattered: true,
+                    matteredControlIds: ['tool_allowance'],
+                    profileId: 'planner',
+                    provider: 'openai',
+                    model: 'gpt-5-nano',
+                },
+                evaluator: {
+                    status: 'executed',
+                    outcome: {
+                        authorityLevel: 'observe',
+                        mode: 'observe_only',
+                        provenance: 'Inferred',
+                        safetyDecision: {
+                            action: 'allow',
+                            safetyTier: 'Low',
+                            ruleId: null,
+                        },
+                    },
+                },
+                generation: {
+                    status: 'executed',
+                    profileId: 'openai-text-medium',
+                    provider: 'openai',
+                    model: 'gpt-5-mini',
+                },
+            },
+        },
+        buildResponseMetadata: (_assistantMetadata, runtimeContext) => {
+            capturedRuntimeContext = runtimeContext;
+            return {
+                ...createMetadata(),
+                execution: [
+                    {
+                        kind: 'generation',
+                        status: 'skipped',
+                    },
+                    {
+                        kind: 'tool',
+                        toolName: 'old_tool',
+                        status: 'failed',
+                        reasonCode: 'tool_execution_error',
+                    },
+                ],
+            } satisfies ResponseMetadata;
+        },
+    });
+
+    assert.equal(response.action, 'message');
+    assert.equal(response.modality, 'text');
+    assert.match(response.message, /Which New York did you mean\?/);
+    assert.match(response.message, /1\. New York City/);
+    assert.match(response.message, /2\. New York State/);
+    assert.match(response.message, /Please reply with your choice\./);
+
+    assert.equal(
+        capturedRuntimeContext?.executionContext?.generation?.status,
+        'skipped'
+    );
+    assert.deepEqual(
+        capturedRuntimeContext?.executionContext?.planner?.profileId,
+        'planner'
+    );
+    assert.equal(
+        capturedRuntimeContext?.executionContext?.evaluator?.status,
+        'executed'
+    );
+
+    const toolEvents =
+        response.metadata.execution?.filter((event) => event.kind === 'tool') ??
+        [];
+    assert.equal(toolEvents.length, 1);
+    assert.equal(toolEvents[0]?.toolName, 'weather_forecast');
+    assert.equal(toolEvents[0]?.status, 'executed');
+    assert.equal(
+        toolEvents[0]?.clarification?.reasonCode,
+        'ambiguous_location'
+    );
+});

--- a/packages/backend/test/toolExecutionEvents.test.ts
+++ b/packages/backend/test/toolExecutionEvents.test.ts
@@ -1,0 +1,68 @@
+/**
+ * @description: Verifies deterministic mapping from tool execution context to tool execution events.
+ * @footnote-scope: test
+ * @footnote-module: ToolExecutionEventsTests
+ * @footnote-risk: low - Focused unit tests cover one mapping helper.
+ * @footnote-ethics: medium - Stable tool metadata improves trace clarity and governance visibility.
+ */
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import type { ToolExecutionContext } from '@footnote/contracts/ethics-core';
+import { buildToolExecutionEvent } from '../src/services/tools/toolExecutionEvents.js';
+
+test('buildToolExecutionEvent maps executed tool context to tool event', () => {
+    const context: ToolExecutionContext = {
+        toolName: 'weather_forecast',
+        status: 'executed',
+    };
+
+    assert.deepEqual(buildToolExecutionEvent(context), {
+        kind: 'tool',
+        toolName: 'weather_forecast',
+        status: 'executed',
+    });
+});
+
+test('buildToolExecutionEvent preserves failed reasonCode and durationMs', () => {
+    const context: ToolExecutionContext = {
+        toolName: 'weather_forecast',
+        status: 'failed',
+        reasonCode: 'tool_timeout',
+        durationMs: 347,
+    };
+
+    assert.deepEqual(buildToolExecutionEvent(context), {
+        kind: 'tool',
+        toolName: 'weather_forecast',
+        status: 'failed',
+        reasonCode: 'tool_timeout',
+        durationMs: 347,
+    });
+});
+
+test('buildToolExecutionEvent preserves clarification payload when present', () => {
+    const context: ToolExecutionContext = {
+        toolName: 'weather_forecast',
+        status: 'executed',
+        clarification: {
+            reasonCode: 'ambiguous_location',
+            question: 'Which New York did you mean?',
+            options: [
+                {
+                    id: 'nyc',
+                    label: 'New York City, New York, United States',
+                },
+            ],
+        },
+        durationMs: 9,
+    };
+
+    const event = buildToolExecutionEvent(context);
+    assert.equal(event.kind, 'tool');
+    assert.equal(event.toolName, 'weather_forecast');
+    assert.equal(event.status, 'executed');
+    assert.equal(event.durationMs, 9);
+    assert.equal(event.clarification?.reasonCode, 'ambiguous_location');
+    assert.equal(event.clarification?.options.length, 1);
+});

--- a/packages/backend/test/toolExecutionParity.test.ts
+++ b/packages/backend/test/toolExecutionParity.test.ts
@@ -1,0 +1,273 @@
+/**
+ * @description: Pins current orchestrator-owned weather tool behavior before workflow tool-step migration.
+ * @footnote-scope: test
+ * @footnote-module: ToolExecutionParityTests
+ * @footnote-risk: low - Focused parity checks with bounded test doubles.
+ * @footnote-ethics: medium - Preserves fail-open and clarification semantics that affect user trust and traceability.
+ */
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import type { GenerationRuntime } from '@footnote/agent-runtime';
+import type { PostChatRequest } from '@footnote/contracts/web';
+import { createMetadata } from './fixtures/responseMetadataFixture.js';
+import { runtimeConfig } from '../src/config.js';
+import { createChatOrchestrator } from '../src/services/chatOrchestrator.js';
+import {
+    buildResponseMetadata,
+    type ResponseMetadataRuntimeContext,
+} from '../src/services/openaiService.js';
+import type { WeatherForecastTool } from '../src/services/openMeteoForecastTool.js';
+
+const PLANNER_TOKEN_SENTINEL = 1200;
+
+const createChatRequest = (
+    overrides: Partial<PostChatRequest> = {}
+): PostChatRequest => ({
+    surface: 'discord',
+    trigger: { kind: 'direct' },
+    latestUserInput: 'What is the weather?',
+    conversation: [{ role: 'user', content: 'What is the weather?' }],
+    capabilities: {
+        canReact: true,
+        canGenerateImages: true,
+        canUseTts: true,
+    },
+    ...overrides,
+});
+
+const createGenerationRuntime = (
+    implementation: (
+        request: import('@footnote/agent-runtime').GenerationRequest
+    ) => Promise<import('@footnote/agent-runtime').GenerationResult>
+): GenerationRuntime => ({
+    kind: 'test-runtime',
+    generate: implementation,
+});
+
+const buildWeatherToolIntentPlannerOutput = (input: {
+    location:
+        | { type: 'lat_lon'; latitude: number; longitude: number }
+        | { query: string };
+}): string =>
+    JSON.stringify({
+        action: 'message',
+        modality: 'text',
+        requestedCapabilityProfile: 'expressive-generation',
+        safetyTier: 'Low',
+        reasoning: 'Use weather tool for this forecast question.',
+        generation: {
+            reasoningEffort: 'low',
+            verbosity: 'low',
+            temperament: {
+                tightness: 4,
+                rationale: 3,
+                attribution: 4,
+                caution: 3,
+                extent: 4,
+            },
+            toolIntent: {
+                toolName: 'weather_forecast',
+                requested: true,
+                input: {
+                    location: input.location,
+                },
+            },
+        },
+    });
+
+test('weather success keeps tool status executed and still runs generation', async () => {
+    let generationCalled = false;
+    let capturedExecutionContext:
+        | ResponseMetadataRuntimeContext['executionContext']
+        | undefined;
+    const weatherForecastTool: WeatherForecastTool = {
+        fetchForecast: async () => ({
+            toolName: 'weather_forecast',
+            status: 'ok',
+            request: {
+                location: {
+                    type: 'lat_lon',
+                    latitude: 39.7684,
+                    longitude: -86.1581,
+                },
+            },
+            location: {
+                name: 'Indianapolis, IN',
+            },
+            forecast: {
+                periods: [],
+            },
+            provenance: {
+                provider: 'open-meteo',
+                endpoint: 'mock',
+                requestedAt: '2026-01-01T00:00:00Z',
+            },
+        }),
+    };
+
+    const orchestrator = createChatOrchestrator({
+        generationRuntime: createGenerationRuntime(async (request) => {
+            if (request.maxOutputTokens === PLANNER_TOKEN_SENTINEL) {
+                return {
+                    text: buildWeatherToolIntentPlannerOutput({
+                        location: {
+                            type: 'lat_lon',
+                            latitude: 39.7684,
+                            longitude: -86.1581,
+                        },
+                    }),
+                    model: 'gpt-5-mini',
+                };
+            }
+            generationCalled = true;
+            return {
+                text: 'Generated weather reply',
+                model: request.model,
+                provenance: 'Inferred',
+                citations: [],
+            };
+        }),
+        storeTrace: async () => undefined,
+        buildResponseMetadata: (_assistantMetadata, runtimeContext) => {
+            capturedExecutionContext = runtimeContext.executionContext;
+            return createMetadata();
+        },
+        defaultModel: runtimeConfig.modelProfiles.defaultProfileId,
+        recordUsage: () => undefined,
+        weatherForecastTool,
+    });
+
+    const response = await orchestrator.runChat(createChatRequest());
+
+    assert.equal(response.action, 'message');
+    assert.equal(generationCalled, true);
+    assert.equal(capturedExecutionContext?.tool?.toolName, 'weather_forecast');
+    assert.equal(capturedExecutionContext?.tool?.status, 'executed');
+});
+
+test('weather failure preserves fail-open generation with failed tool status and reason code', async () => {
+    let capturedExecutionContext:
+        | ResponseMetadataRuntimeContext['executionContext']
+        | undefined;
+    const weatherForecastTool: WeatherForecastTool = {
+        fetchForecast: async () => {
+            throw new Error('weather upstream unavailable');
+        },
+    };
+
+    const orchestrator = createChatOrchestrator({
+        generationRuntime: createGenerationRuntime(async (request) => {
+            if (request.maxOutputTokens === PLANNER_TOKEN_SENTINEL) {
+                return {
+                    text: buildWeatherToolIntentPlannerOutput({
+                        location: {
+                            type: 'lat_lon',
+                            latitude: 39.7684,
+                            longitude: -86.1581,
+                        },
+                    }),
+                    model: 'gpt-5-mini',
+                };
+            }
+            return {
+                text: 'Fallback non-tool weather response',
+                model: request.model,
+                provenance: 'Inferred',
+                citations: [],
+            };
+        }),
+        storeTrace: async () => undefined,
+        buildResponseMetadata: (_assistantMetadata, runtimeContext) => {
+            capturedExecutionContext = runtimeContext.executionContext;
+            return createMetadata();
+        },
+        defaultModel: runtimeConfig.modelProfiles.defaultProfileId,
+        recordUsage: () => undefined,
+        weatherForecastTool,
+    });
+
+    const response = await orchestrator.runChat(createChatRequest());
+
+    assert.equal(response.action, 'message');
+    assert.equal(capturedExecutionContext?.tool?.toolName, 'weather_forecast');
+    assert.equal(capturedExecutionContext?.tool?.status, 'failed');
+    assert.equal(
+        capturedExecutionContext?.tool?.reasonCode,
+        'tool_execution_error'
+    );
+});
+
+test('weather clarification short-circuits generation and records skipped generation metadata', async () => {
+    let generationCalled = false;
+    const weatherForecastTool: WeatherForecastTool = {
+        fetchForecast: async () => ({
+            toolName: 'weather_forecast',
+            status: 'needs_clarification',
+            request: {
+                location: {
+                    type: 'place_query',
+                    query: 'New York',
+                },
+            },
+            clarification: {
+                reasonCode: 'ambiguous_location',
+                question: 'Which New York did you mean?',
+                options: [
+                    {
+                        id: 'nyc',
+                        label: 'New York City, New York, United States',
+                    },
+                ],
+            },
+            provenance: {
+                provider: 'open-meteo',
+                endpoint: 'mock',
+                requestedAt: '2026-01-01T00:00:00Z',
+            },
+        }),
+    };
+
+    const orchestrator = createChatOrchestrator({
+        generationRuntime: createGenerationRuntime(async (request) => {
+            if (request.maxOutputTokens === PLANNER_TOKEN_SENTINEL) {
+                return {
+                    text: buildWeatherToolIntentPlannerOutput({
+                        location: {
+                            query: 'New York',
+                        },
+                    }),
+                    model: 'gpt-5-mini',
+                };
+            }
+            generationCalled = true;
+            return {
+                text: 'should not be generated',
+                model: request.model,
+                provenance: 'Inferred',
+                citations: [],
+            };
+        }),
+        storeTrace: async () => undefined,
+        buildResponseMetadata,
+        defaultModel: runtimeConfig.modelProfiles.defaultProfileId,
+        recordUsage: () => undefined,
+        weatherForecastTool,
+    });
+
+    const response = await orchestrator.runChat(createChatRequest());
+
+    assert.equal(response.action, 'message');
+    assert.equal(generationCalled, false);
+    assert.match(response.message, /Which New York did you mean\?/);
+    const toolEvent = response.metadata.execution?.find(
+        (event) => event.kind === 'tool'
+    );
+    assert.equal(toolEvent?.toolName, 'weather_forecast');
+    assert.equal(toolEvent?.status, 'executed');
+    assert.equal(toolEvent?.clarification?.reasonCode, 'ambiguous_location');
+    const generationEvent = response.metadata.execution?.find(
+        (event) => event.kind === 'generation'
+    );
+    assert.equal(generationEvent?.status, 'skipped');
+});

--- a/packages/backend/test/workflowEngine.test.ts
+++ b/packages/backend/test/workflowEngine.test.ts
@@ -1111,7 +1111,7 @@ test('runBoundedReviewWorkflow does not emit concrete tool steps in current engi
             enableRevision: true,
         },
         captureUsage: (generationResult) => ({
-            model: generationResult.model,
+            model: generationResult.model ?? 'gpt-5-mini',
             promptTokens: generationResult.usage?.promptTokens ?? 0,
             completionTokens: generationResult.usage?.completionTokens ?? 0,
             totalTokens: generationResult.usage?.totalTokens ?? 0,

--- a/packages/backend/test/workflowEngine.test.ts
+++ b/packages/backend/test/workflowEngine.test.ts
@@ -1050,3 +1050,82 @@ test('buildPlannerStepRecord does not include raw or noisy planner internals', (
         false
     );
 });
+
+test('runBoundedReviewWorkflow does not emit concrete tool steps in current engine-owned review path', async () => {
+    const generationRuntime: GenerationRuntime = {
+        kind: 'test-runtime',
+        async generate({ messages }) {
+            const lastSystemMessage = [...messages]
+                .reverse()
+                .find((message) => message.role === 'system');
+            const isAssessmentCall =
+                lastSystemMessage?.content.includes(
+                    'Return plain JSON only.'
+                ) === true;
+
+            return isAssessmentCall
+                ? {
+                      text: '{"decision":"finalize","reason":"done"}',
+                      model: 'gpt-5-mini',
+                      usage: {
+                          promptTokens: 8,
+                          completionTokens: 4,
+                          totalTokens: 12,
+                      },
+                      provenance: 'Inferred',
+                      citations: [],
+                  }
+                : {
+                      text: 'draft',
+                      model: 'gpt-5-mini',
+                      usage: {
+                          promptTokens: 10,
+                          completionTokens: 5,
+                          totalTokens: 15,
+                      },
+                      provenance: 'Inferred',
+                      citations: [],
+                  };
+        },
+    };
+
+    const result = await runBoundedReviewWorkflow({
+        generationRuntime,
+        generationRequest: {
+            model: 'gpt-5-mini',
+            messages: [{ role: 'user', content: 'Summarize weather' }],
+        },
+        messagesWithHints: [{ role: 'user', content: 'Summarize weather' }],
+        generationStartedAtMs: Date.now(),
+        workflowConfig: {
+            workflowName: 'message_with_review_loop',
+            maxIterations: 1,
+            maxDurationMs: 15000,
+        },
+        workflowPolicy: {
+            enablePlanning: false,
+            enableToolUse: true,
+            enableReplanning: false,
+            enableGeneration: true,
+            enableAssessment: true,
+            enableRevision: true,
+        },
+        captureUsage: (generationResult) => ({
+            model: generationResult.model,
+            promptTokens: generationResult.usage?.promptTokens ?? 0,
+            completionTokens: generationResult.usage?.completionTokens ?? 0,
+            totalTokens: generationResult.usage?.totalTokens ?? 0,
+            estimatedCost: {
+                inputCostUsd: 0,
+                outputCostUsd: 0,
+                totalCostUsd: 0,
+            },
+        }),
+    });
+
+    assert.equal(result.outcome, 'generated');
+    assert.equal(
+        result.workflowLineage.steps.some((step) => step.stepKind === 'tool'),
+        false
+    );
+});


### PR DESCRIPTION
## Summary
- Extracted clarification response assembly into `buildToolClarificationResponse` and removed inline construction from `chatOrchestrator`.
- Added shared `buildToolExecutionEvent` mapper for deterministic `ToolExecutionContext -> ToolExecutionEvent` construction and reused it in clarification responses.
- Added targeted parity coverage before workflow-owned tool-step migration:
  - weather success executes tool and still runs normal generation
  - weather failure preserves fail-open behavior with failed tool metadata
  - weather clarification short-circuits generation and records skipped generation metadata
  - workflow engine review path does not yet emit concrete `tool` steps
- Kept tool execution ownership in `chatOrchestrator` + `toolRegistry` (no move into `workflowEngine`).
- Renamed weather-specific continuation/failure helpers to explicit adapter-level names and fixed type/import issues:
  - `weatherClarificationContinuation.ts`
  - `weatherToolFailureResponse.ts`

## Architecture Notes
- Weather continuation/failure behavior is treated as adapter-level behavior.
- Continuation resolution re-enters the normal `toolIntent -> resolveToolSelection -> executeSelectedTool` path.
- Failure responses stay deterministic and non-speculative (no fabricated factual content).

## Testing
- `pnpm review`
- `pnpm lint`
- `pnpm --filter @footnote/backend build`
- `pnpm exec tsx --test packages/backend/test/toolExecutionParity.test.ts`
- `pnpm exec tsx --test --test-name-pattern "runChatMessages marks tool execution as executed when retrieval was used" packages/backend/test/chatService.test.ts`
- `pnpm exec tsx --test --test-name-pattern "weather adapter passes through needs_clarification result with status executed" packages/backend/test/toolRegistry.test.ts`
- `pnpm exec tsx --test --test-name-pattern "buildToolClarificationResponse formats numbered options and preserves execution contexts|buildToolExecutionEvent|runBoundedReviewWorkflow does not emit concrete tool steps in current engine-owned review path" packages/backend/test/toolClarificationResponse.test.ts packages/backend/test/toolExecutionEvents.test.ts packages/backend/test/workflowEngine.test.ts`
