### PR TITLE
Move weather execution into workflow context steps

### DIFF
--- a/docs/architecture/context-integrations/weather-forecast.md
+++ b/docs/architecture/context-integrations/weather-forecast.md
@@ -34,13 +34,13 @@ Provider ownership:
 1. Planner emits a bounded tool intent for `weather_forecast`.
 2. Orchestrator resolves tool selection and executes the weather adapter.
 3. The weather tool returns one of three outcomes:
-   - `ok`
-   - `error`
-   - `needs_clarification`
+    - `ok`
+    - `error`
+    - `needs_clarification`
 4. Orchestrator either:
-   - injects normalized weather context and continues generation (`ok`)
-   - short-circuits to a clarification message (`needs_clarification`)
-   - records failure and continues safely where allowed (`error`)
+    - injects normalized weather context and continues generation (`ok`)
+    - short-circuits to a clarification message (`needs_clarification`)
+    - records failure and continues safely where allowed (`error`)
 
 ## Outcome Contract
 
@@ -77,11 +77,17 @@ Provider malformation is treated as `invalid_response`, not ambiguity.
 
 ## Provenance and Metadata
 
-Normalized tool payloads retain provider-facing provenance fields such as:
+Normalized tool payloads retain provider-facing provenance fields:
 
-- `provider`
-- `endpoint`
-- `requestedAt`
+- `provider` - provider identifier (e.g., 'open-meteo')
+- `endpoint` - exact API URL used; intended for trace/audit, not user-facing
+- `requestedAt` - ISO timestamp of API call
+- `resolvedFromEndpoint` - (optional) geocoding endpoint when location was resolved
+- `citationUrl` - human-readable provider source URL for user-facing citations
+- `citationLabel` - human-readable label for the citation source
+
+The `endpoint` field is useful for debugging and audit trails. The `citationUrl`
+and `citationLabel` fields are intended for user-facing attribution.
 
 Tool execution metadata is recorded through backend execution context and
 response metadata assembly.

--- a/docs/architecture/workflow.md
+++ b/docs/architecture/workflow.md
@@ -355,19 +355,22 @@ handling, `WorkflowRecord` output, and `StepRecord` output.
 The shared workflow vocabulary includes `plan`, `tool`, `generate`, `assess`,
 `revise`, and `finalize`.
 
-`plan` and `tool` are part of the vocabulary, but they are not the main
-current chat loop.
-
 Today:
 
 - planner timing still lives in `chatOrchestrator` before workflow execution
-- concrete tool execution still lives in `chatOrchestrator` and `toolRegistry`
-- workflow metadata can still include bridged planner lineage
+- weather_forecast execution timing moved to workflow context-step path
+- web_search unchanged (not migrated)
+- planner unchanged (not migrated)
+- workflow metadata can include bridged planner lineage
 
-Recent helpers like `buildToolClarificationResponse` and
-`buildToolExecutionEvent` are migration seams for future workflow-owned tool
-steps. They are not evidence that tool execution already moved into
-`workflowEngine`.
+The context-step path allows the workflow engine to execute tool work (like
+weather_forecast) before generation, inject context into the generation
+prompt, and handle clarification/failure scenarios while preserving fail-open
+semantics.
+
+The adapter `toolRegistryContextStepAdapter.ts` keeps the workflow engine
+provider-neutral while mapping tool-registry execution into the workflow
+context-step shape.
 
 ## Step records
 

--- a/docs/status/workflow-engine-rollout-status.md
+++ b/docs/status/workflow-engine-rollout-status.md
@@ -10,36 +10,67 @@ The main current architecture is in:
 
 If everything here lands, this status note can be removed.
 
+## Completed
+
+### weather_forecast context-step integration
+
+Status: `done`
+
+`weather_forecast` execution timing has been moved into the workflow
+context-step path. This is the first concrete context integration that uses
+the workflow-engine-owned context-step execution flow.
+
+The execution flow is now:
+
+1. `chatOrchestrator` builds context-step request and executor for weather
+2. `chatService` passes these to `runBoundedReviewWorkflow`
+3. `workflowEngine` executes the context step before generation
+4. Weather success injects context messages into generation prompt
+5. Weather clarification stops generation and returns clarification response
+6. Weather failure continues fail-open (no-fabrication guardrail preserved)
+
+Ownership summary:
+
+- planner selection: orchestrator-owned (pre-workflow)
+- weather execution timing: workflow context-step-owned
+- concrete provider logic (Open-Meteo): adapter-owned
+- web_search: unchanged (not migrated)
+- planner: unchanged (not migrated)
+
+The context-step adapter (`toolRegistryContextStepAdapter.ts`) keeps the
+workflow engine provider-neutral while preserving weather tool semantics.
+
+### Mode coverage
+
+The context-step weather execution path currently applies to:
+
+- `bounded-review` profile (balanced/grounded modes): Uses workflow engine with
+  context-step weather execution.
+
+The following modes/profiles do NOT use the context-step path:
+
+- `generate-only` profile (fast mode): Bypasses workflow engine entirely and
+  does not use the context-step path. Weather execution would need separate
+  handling if fast mode weather support is desired.
+
+This split is intentional for now: the fast/generate-only path is a direct
+single-pass generation without workflow orchestration, so it doesn't have the
+infrastructure to inject context before generation.
+
 ## Still Open
 
-### Tool step execution
+### Tool step expansion
 
 Status: `pending`
 
-The workflow engine already knows about `tool` as a step kind and already has
-limit support such as `maxToolCalls`.
-
-What is still missing is workflow-engine-owned tool-step execution in the main
-chat path.
-
-Today concrete `weather_forecast` execution still lives in
-`chatOrchestrator` and `toolRegistry`. The bounded workflow execution in the
-engine still runs concrete `generate`, `assess`, and `revise` steps.
-
-Recent prep work added migration seams such as:
-
-- `buildToolClarificationResponse` for clarification response assembly
-- `buildToolExecutionEvent` for standardized tool execution event mapping
-- parity tests that pin current orchestrator-owned weather behavior
-
-That prep improves migration safety, but it does not mean tool execution has
-moved into `workflowEngine`.
+Additional tool integrations beyond weather_forecast have not yet been moved
+into the workflow context-step path. The infrastructure is in place; each
+additional tool would follow the same pattern as weather.
 
 The remaining goal is:
 
-- execute tool work through real `tool` workflow steps
-- record each concrete call attempt in workflow lineage
-- define whether that execution is sequential, parallel, or both
+- extend context-step path to additional tools as needed
+- maintain fail-open semantics for each integration
 
 ### Planner as a first-class workflow step
 

--- a/packages/backend/src/services/chatOrchestrator.ts
+++ b/packages/backend/src/services/chatOrchestrator.ts
@@ -41,13 +41,10 @@ import { resolveWorkflowModeDecision } from './workflowProfileRegistry.js';
 import { buildSteerabilityControls } from './steerabilityControls.js';
 import type { WeatherForecastTool } from './openMeteoForecastTool.js';
 import { applySingleToolPolicy } from './tools/toolPolicy.js';
-import {
-    executeSelectedTool,
-    resolveToolSelection,
-} from './tools/toolRegistry.js';
+import { resolveToolSelection } from './tools/toolRegistry.js';
 import { buildToolClarificationResponse } from './tools/toolClarificationResponse.js';
-import { buildWeatherToolFailureResponse } from './tools/weatherToolFailureResponse.js';
 import { resolveWeatherClarificationContinuation } from './tools/weatherClarificationContinuation.js';
+import { createToolRegistryContextStepExecutor } from './contextIntegrations/toolRegistryContextStepAdapter.js';
 import { runtimeConfig } from '../config.js';
 import { logger } from '../utils/logger.js';
 import type { IncidentAlertRouter } from './incidentAlerts.js';
@@ -446,6 +443,30 @@ export const createChatOrchestrator = ({
         const toolRequestContext = toolSelection.toolRequest;
         toolExecutionContext =
             toolSelection.toolExecution ?? toolExecutionContext;
+        const weatherContextStepRequest =
+            toolRequestContext.toolName === 'weather_forecast' &&
+            toolRequestContext.requested
+                ? {
+                      integrationName: 'weather_forecast',
+                      requested: toolRequestContext.requested,
+                      eligible: toolRequestContext.eligible,
+                      ...(toolRequestContext.reasonCode !== undefined && {
+                          reasonCode: toolRequestContext.reasonCode,
+                      }),
+                      ...(toolIntent.input !== undefined && {
+                          input: toolIntent.input as Record<string, unknown>,
+                      }),
+                  }
+                : undefined;
+        const weatherContextStepExecutor =
+            weatherContextStepRequest !== undefined
+                ? createToolRegistryContextStepExecutor({
+                      weatherForecastTool,
+                      onWarn: (message, meta) => {
+                          chatOrchestratorLogger.warn(message, meta);
+                      },
+                  })
+                : undefined;
         const weatherRouting = {
             weatherLikeRequest: isWeatherLikeRequest(
                 normalizedRequest.latestUserInput
@@ -637,29 +658,14 @@ export const createChatOrchestrator = ({
         // Web keeps default prompt persona layers.
         const personaPrompt =
             backendOwnedProfileOverlay ?? promptLayers.personaPrompt;
-        const toolExecution = await executeSelectedTool({
-            toolSelection,
-            weatherForecastTool,
-            onWarn: (message, meta) => {
-                chatOrchestratorLogger.warn(message, meta);
-            },
-        });
-        const toolResultMessage = toolExecution.toolResultMessage;
-        toolExecutionContext =
-            toolExecution.toolExecutionContext ?? toolExecutionContext;
         const weatherExecutionAttempted =
             toolExecutionContext?.toolName === 'weather_forecast' &&
             (toolExecutionContext.status === 'executed' ||
                 toolExecutionContext.status === 'failed');
         const weatherOutcome =
-            toolExecutionContext?.toolName === 'weather_forecast'
-                ? toolExecutionContext.clarification
-                    ? 'needs_clarification'
-                    : toolExecutionContext.status === 'failed'
-                      ? 'failed'
-                      : toolExecutionContext.status === 'executed'
-                        ? 'ok'
-                        : 'not_executed'
+            toolRequestContext.toolName === 'weather_forecast' &&
+            toolRequestContext.requested
+                ? 'not_executed'
                 : 'not_selected';
         if (
             weatherRouting.weatherLikeRequest ||
@@ -755,147 +761,6 @@ export const createChatOrchestrator = ({
             });
         }
 
-        if (
-            toolExecutionContext?.toolName === 'weather_forecast' &&
-            toolExecutionContext.status === 'failed'
-        ) {
-            return buildWeatherToolFailureResponse({
-                toolContext: toolExecutionContext,
-                metadataContext: {
-                    modelVersion: selectedResponseProfile.providerModel,
-                    conversationSnapshot: JSON.stringify({
-                        request: normalizedRequest,
-                        planner: {
-                            action: executionPlan.action,
-                            modality: executionPlan.modality,
-                            profileId: executionPlan.profileId,
-                            safetyTier: executionPlan.safetyTier,
-                            generation: executionPlan.generation,
-                            toolIntent,
-                            toolRequest: toolRequestContext,
-                            ...(surfacePolicy && { surfacePolicy }),
-                        },
-                        executionContract: {
-                            policyId: resolvedExecutionContract.policyId,
-                            policyVersion:
-                                resolvedExecutionContract.policyVersion,
-                        },
-                        toolFailure: {
-                            toolName: toolExecutionContext.toolName,
-                            reasonCode: toolExecutionContext.reasonCode,
-                        },
-                    }),
-                    executionContext: {
-                        planner: {
-                            status: plannerExecution.status,
-                            reasonCode: plannerExecution.reasonCode,
-                            purpose: plannerExecution.purpose,
-                            contractType: plannerExecution.contractType,
-                            applyOutcome: plannerApplyOutcome,
-                            mattered: plannerMattered,
-                            matteredControlIds: plannerMatteredControlIds,
-                            profileId: plannerProfile.id,
-                            originalProfileId: plannerProfile.id,
-                            effectiveProfileId: plannerProfile.id,
-                            provider: plannerProfile.provider,
-                            model: plannerProfile.providerModel,
-                            durationMs: plannerExecution.durationMs,
-                        },
-                        evaluator: evaluatorExecutionContext,
-                        generation: {
-                            status: 'executed',
-                            profileId: selectedResponseProfile.id,
-                            originalProfileId: originalSelectedProfileId,
-                            effectiveProfileId: effectiveSelectedProfileId,
-                            provider: selectedResponseProfile.provider,
-                            model: selectedResponseProfile.providerModel,
-                        },
-                    },
-                },
-                latestUserInput: normalizedRequest.latestUserInput,
-                buildResponseMetadata,
-            });
-        }
-
-        if (
-            toolExecutionContext?.clarification &&
-            toolExecutionContext.status === 'executed'
-        ) {
-            chatOrchestratorLogger.info('chat.weather.routing', {
-                event: 'chat.weather.routing',
-                stage: 'clarification_short_circuit',
-                surface: normalizedRequest.surface,
-                ...weatherRouting,
-                weatherExecutionAttempted,
-                weatherOutcome: 'needs_clarification',
-                clarificationShortCircuitHit: true,
-            });
-            chatOrchestratorLogger.info(
-                'tool returned clarification, short-circuiting generation',
-                {
-                    toolName: toolExecutionContext.toolName,
-                    reasonCode: toolExecutionContext.clarification.reasonCode,
-                    optionCount:
-                        toolExecutionContext.clarification.options.length,
-                }
-            );
-            return buildToolClarificationResponse({
-                toolContext: toolExecutionContext,
-                metadataContext: {
-                    modelVersion: selectedResponseProfile.providerModel,
-                    conversationSnapshot: JSON.stringify({
-                        request: normalizedRequest,
-                        planner: {
-                            action: executionPlan.action,
-                            modality: executionPlan.modality,
-                            profileId: executionPlan.profileId,
-                            safetyTier: executionPlan.safetyTier,
-                            generation: executionPlan.generation,
-                            toolIntent,
-                            toolRequest: toolRequestContext,
-                            ...(surfacePolicy && { surfacePolicy }),
-                        },
-                        executionContract: {
-                            policyId: resolvedExecutionContract.policyId,
-                            policyVersion:
-                                resolvedExecutionContract.policyVersion,
-                        },
-                        clarification: {
-                            toolName: toolExecutionContext.toolName,
-                            reasonCode:
-                                toolExecutionContext.clarification.reasonCode,
-                        },
-                    }),
-                    executionContext: {
-                        planner: {
-                            status: plannerExecution.status,
-                            reasonCode: plannerExecution.reasonCode,
-                            purpose: plannerExecution.purpose,
-                            contractType: plannerExecution.contractType,
-                            applyOutcome: plannerApplyOutcome,
-                            mattered: plannerMattered,
-                            matteredControlIds: plannerMatteredControlIds,
-                            profileId: plannerProfile.id,
-                            originalProfileId: plannerProfile.id,
-                            effectiveProfileId: plannerProfile.id,
-                            provider: plannerProfile.provider,
-                            model: plannerProfile.providerModel,
-                            durationMs: plannerExecution.durationMs,
-                        },
-                        evaluator: evaluatorExecutionContext,
-                        generation: {
-                            status: 'executed',
-                            profileId: selectedResponseProfile.id,
-                            originalProfileId: originalSelectedProfileId,
-                            effectiveProfileId: effectiveSelectedProfileId,
-                            provider: selectedResponseProfile.provider,
-                            model: selectedResponseProfile.providerModel,
-                        },
-                    },
-                },
-                buildResponseMetadata,
-            });
-        }
         const clarificationShortCircuitHit = false;
         if (
             (weatherRouting.weatherLikeRequest ||
@@ -936,14 +801,6 @@ export const createChatOrchestrator = ({
                 content: personaPrompt,
             },
             ...normalizedConversation,
-            ...(toolResultMessage
-                ? [
-                      {
-                          role: 'system' as const,
-                          content: toolResultMessage,
-                      },
-                  ]
-                : []),
             {
                 role: 'system',
                 content: [
@@ -1004,6 +861,9 @@ export const createChatOrchestrator = ({
             generation: executionPlan.generation,
             workflowModeId: workflowModeResolution.modeDecision.modeId,
             toolRequest: toolRequestContext,
+            contextStepRequest: weatherContextStepRequest,
+            contextStepExecutor: weatherContextStepExecutor,
+            latestUserInput: normalizedRequest.latestUserInput,
             ExecutionContract: resolvedExecutionContract,
             ...(executionContractScopeTuple !== undefined && {
                 executionContractTrustGraphContext: {

--- a/packages/backend/src/services/chatPlanner.ts
+++ b/packages/backend/src/services/chatPlanner.ts
@@ -1025,8 +1025,9 @@ const normalizePlan = (
         contractAssessment: PlannerContractAssessment;
     }): PlannerNormalizationResult => {
         const rawToolIntentValue =
-            isPlannerCandidate(candidate) && candidate.toolIntent !== undefined
-                ? candidate.toolIntent
+            isPlannerCandidate(candidate) &&
+            candidate.generation?.toolIntent !== undefined
+                ? candidate.generation.toolIntent
                 : undefined;
         const rawToolIntentPresent = rawToolIntentValue !== undefined;
         const rawToolIntentName =

--- a/packages/backend/src/services/chatService.ts
+++ b/packages/backend/src/services/chatService.ts
@@ -72,6 +72,126 @@ import { buildWeatherToolFailureResponse } from './tools/weatherToolFailureRespo
 const SURFACED_NO_GENERATION_MESSAGE =
     'I could not generate a response for this request.';
 
+const buildContextStepShortCircuit = ({
+    workflowContextStepResult,
+    executionContext,
+    toolRequest,
+    model,
+    defaultModel,
+    conversationSnapshot,
+    latestUserInput,
+    buildResponseMetadata,
+}: {
+    workflowContextStepResult: ContextStepResult | undefined;
+    executionContext: ResponseMetadataRuntimeContext['executionContext'];
+    toolRequest: ToolInvocationRequest | undefined;
+    model: string | undefined;
+    defaultModel: string;
+    conversationSnapshot: string;
+    latestUserInput: string | undefined;
+    buildResponseMetadata: (
+        assistantMetadata: AssistantResponseMetadata,
+        runtimeContext: ResponseMetadataRuntimeContext
+    ) => ResponseMetadata;
+}):
+    | {
+          response: PostChatResponse | undefined;
+          telemetry: FinalToolExecutionTelemetry;
+      }
+    | undefined => {
+    if (workflowContextStepResult === undefined) {
+        return undefined;
+    }
+
+    const { executionContext: contextExecutionContext } =
+        workflowContextStepResult;
+
+    const buildGenerationMetadataContext = () => ({
+        modelVersion: model ?? defaultModel,
+        conversationSnapshot,
+        executionContext: {
+            ...executionContext,
+            generation: {
+                status: 'executed',
+                profileId:
+                    executionContext?.generation?.profileId ??
+                    'workflow_context_step',
+                ...(executionContext?.generation?.originalProfileId !==
+                    undefined && {
+                    originalProfileId:
+                        executionContext.generation.originalProfileId,
+                }),
+                ...(executionContext?.generation?.effectiveProfileId !==
+                    undefined && {
+                    effectiveProfileId:
+                        executionContext.generation.effectiveProfileId,
+                }),
+                provider: executionContext?.generation?.provider ?? 'internal',
+                model:
+                    executionContext?.generation?.model ??
+                    model ??
+                    defaultModel,
+            },
+        },
+    });
+
+    if (contextExecutionContext.clarification !== undefined) {
+        const clarificationResponse = buildToolClarificationResponse({
+            toolContext: contextExecutionContext,
+            metadataContext: buildGenerationMetadataContext(),
+            buildResponseMetadata,
+        });
+        return {
+            response: clarificationResponse,
+            telemetry: {
+                toolName: contextExecutionContext.toolName,
+                status: contextExecutionContext.status,
+                ...(contextExecutionContext.reasonCode !== undefined && {
+                    reasonCode: contextExecutionContext.reasonCode,
+                }),
+                ...(toolRequest !== undefined && {
+                    eligible: toolRequest.eligible,
+                }),
+                ...(toolRequest?.reasonCode !== undefined && {
+                    requestReasonCode: toolRequest.reasonCode,
+                }),
+            },
+        };
+    }
+
+    if (
+        contextExecutionContext.toolName === 'weather_forecast' &&
+        contextExecutionContext.status === 'failed'
+    ) {
+        const failureResponse = buildWeatherToolFailureResponse({
+            toolContext: contextExecutionContext,
+            metadataContext: {
+                ...buildGenerationMetadataContext(),
+                latestUserInput: latestUserInput ?? conversationSnapshot,
+            },
+            buildResponseMetadata,
+        });
+        return {
+            response: failureResponse,
+            telemetry: {
+                toolName: contextExecutionContext.toolName,
+                status: contextExecutionContext.status,
+                ...(contextExecutionContext.reasonCode !== undefined && {
+                    reasonCode: contextExecutionContext.reasonCode,
+                }),
+                ...(toolRequest !== undefined && {
+                    eligible: toolRequest.eligible,
+                }),
+                ...(toolRequest?.reasonCode !== undefined && {
+                    requestReasonCode: toolRequest.reasonCode,
+                }),
+            },
+        };
+    }
+
+    return undefined;
+};
+
 type ExecutionContractTrustGraphRuntimeOptions = {
     adapter?: TrustGraphEvidenceAdapter;
     budget: {
@@ -752,291 +872,44 @@ export const createChatService = ({
             });
             workflowContextStepResult = workflowResult.contextStepResult;
             switch (workflowResult.outcome) {
-                case 'generated':
+                case 'generated': {
                     generationResult = workflowResult.generationResult;
                     workflowLineage = workflowResult.workflowLineage;
-                    if (
-                        workflowContextStepResult?.executionContext
-                            ?.clarification !== undefined
-                    ) {
-                        const clarificationResponse =
-                            buildToolClarificationResponse({
-                                toolContext:
-                                    workflowContextStepResult.executionContext,
-                                metadataContext: {
-                                    modelVersion: model ?? defaultModel,
-                                    conversationSnapshot,
-                                    executionContext: {
-                                        ...executionContext,
-                                        generation: {
-                                            status: 'executed',
-                                            profileId:
-                                                executionContext?.generation
-                                                    ?.profileId ??
-                                                'workflow_context_step',
-                                            ...(executionContext?.generation
-                                                ?.originalProfileId !==
-                                                undefined && {
-                                                originalProfileId:
-                                                    executionContext.generation
-                                                        .originalProfileId,
-                                            }),
-                                            ...(executionContext?.generation
-                                                ?.effectiveProfileId !==
-                                                undefined && {
-                                                effectiveProfileId:
-                                                    executionContext.generation
-                                                        .effectiveProfileId,
-                                            }),
-                                            provider:
-                                                executionContext?.generation
-                                                    ?.provider ?? 'internal',
-                                            model:
-                                                executionContext?.generation
-                                                    ?.model ??
-                                                model ??
-                                                defaultModel,
-                                        },
-                                    },
-                                },
-                                buildResponseMetadata,
-                            });
+                    const generatedShortCircuit = buildContextStepShortCircuit({
+                        workflowContextStepResult,
+                        executionContext,
+                        toolRequest,
+                        model,
+                        defaultModel,
+                        conversationSnapshot,
+                        latestUserInput,
+                        buildResponseMetadata,
+                    });
+                    if (generatedShortCircuit !== undefined) {
                         return toShortCircuitMessageResult(
-                            clarificationResponse,
-                            {
-                                toolName:
-                                    workflowContextStepResult.executionContext
-                                        .toolName,
-                                status: workflowContextStepResult
-                                    .executionContext.status,
-                                ...(workflowContextStepResult.executionContext
-                                    .reasonCode !== undefined && {
-                                    reasonCode:
-                                        workflowContextStepResult
-                                            .executionContext.reasonCode,
-                                }),
-                                ...(toolRequest !== undefined && {
-                                    eligible: toolRequest.eligible,
-                                }),
-                                ...(toolRequest?.reasonCode !== undefined && {
-                                    requestReasonCode: toolRequest.reasonCode,
-                                }),
-                            }
+                            generatedShortCircuit.response,
+                            generatedShortCircuit.telemetry
                         );
-                    }
-                    if (
-                        workflowContextStepResult?.executionContext.toolName ===
-                            'weather_forecast' &&
-                        workflowContextStepResult.executionContext.status ===
-                            'failed'
-                    ) {
-                        const failureResponse = buildWeatherToolFailureResponse(
-                            {
-                                toolContext:
-                                    workflowContextStepResult.executionContext,
-                                metadataContext: {
-                                    modelVersion: model ?? defaultModel,
-                                    conversationSnapshot,
-                                    executionContext: {
-                                        ...executionContext,
-                                        generation: {
-                                            status: 'executed',
-                                            profileId:
-                                                executionContext?.generation
-                                                    ?.profileId ??
-                                                'workflow_context_step',
-                                            ...(executionContext?.generation
-                                                ?.originalProfileId !==
-                                                undefined && {
-                                                originalProfileId:
-                                                    executionContext.generation
-                                                        .originalProfileId,
-                                            }),
-                                            ...(executionContext?.generation
-                                                ?.effectiveProfileId !==
-                                                undefined && {
-                                                effectiveProfileId:
-                                                    executionContext.generation
-                                                        .effectiveProfileId,
-                                            }),
-                                            provider:
-                                                executionContext?.generation
-                                                    ?.provider ?? 'internal',
-                                            model:
-                                                executionContext?.generation
-                                                    ?.model ??
-                                                model ??
-                                                defaultModel,
-                                        },
-                                    },
-                                },
-                                latestUserInput:
-                                    latestUserInput ?? conversationSnapshot,
-                                buildResponseMetadata,
-                            }
-                        );
-                        return toShortCircuitMessageResult(failureResponse, {
-                            toolName:
-                                workflowContextStepResult.executionContext
-                                    .toolName,
-                            status: workflowContextStepResult.executionContext
-                                .status,
-                            ...(workflowContextStepResult.executionContext
-                                .reasonCode !== undefined && {
-                                reasonCode:
-                                    workflowContextStepResult.executionContext
-                                        .reasonCode,
-                            }),
-                            ...(toolRequest !== undefined && {
-                                eligible: toolRequest.eligible,
-                            }),
-                            ...(toolRequest?.reasonCode !== undefined && {
-                                requestReasonCode: toolRequest.reasonCode,
-                            }),
-                        });
                     }
                     break;
+                }
                 case 'no_generation': {
                     workflowLineage = workflowResult.workflowLineage;
-                    if (
-                        workflowContextStepResult?.executionContext
-                            ?.clarification !== undefined
-                    ) {
-                        const clarificationResponse =
-                            buildToolClarificationResponse({
-                                toolContext:
-                                    workflowContextStepResult.executionContext,
-                                metadataContext: {
-                                    modelVersion: model ?? defaultModel,
-                                    conversationSnapshot,
-                                    executionContext: {
-                                        ...executionContext,
-                                        generation: {
-                                            status: 'executed',
-                                            profileId:
-                                                executionContext?.generation
-                                                    ?.profileId ??
-                                                'workflow_context_step',
-                                            ...(executionContext?.generation
-                                                ?.originalProfileId !==
-                                                undefined && {
-                                                originalProfileId:
-                                                    executionContext.generation
-                                                        .originalProfileId,
-                                            }),
-                                            ...(executionContext?.generation
-                                                ?.effectiveProfileId !==
-                                                undefined && {
-                                                effectiveProfileId:
-                                                    executionContext.generation
-                                                        .effectiveProfileId,
-                                            }),
-                                            provider:
-                                                executionContext?.generation
-                                                    ?.provider ?? 'internal',
-                                            model:
-                                                executionContext?.generation
-                                                    ?.model ??
-                                                model ??
-                                                defaultModel,
-                                        },
-                                    },
-                                },
-                                buildResponseMetadata,
-                            });
+                    const noGenShortCircuit = buildContextStepShortCircuit({
+                        workflowContextStepResult,
+                        executionContext,
+                        toolRequest,
+                        model,
+                        defaultModel,
+                        conversationSnapshot,
+                        latestUserInput,
+                        buildResponseMetadata,
+                    });
+                    if (noGenShortCircuit !== undefined) {
                         return toShortCircuitMessageResult(
-                            clarificationResponse,
-                            {
-                                toolName:
-                                    workflowContextStepResult.executionContext
-                                        .toolName,
-                                status: workflowContextStepResult
-                                    .executionContext.status,
-                                ...(workflowContextStepResult.executionContext
-                                    .reasonCode !== undefined && {
-                                    reasonCode:
-                                        workflowContextStepResult
-                                            .executionContext.reasonCode,
-                                }),
-                                ...(toolRequest !== undefined && {
-                                    eligible: toolRequest.eligible,
-                                }),
-                                ...(toolRequest?.reasonCode !== undefined && {
-                                    requestReasonCode: toolRequest.reasonCode,
-                                }),
-                            }
+                            noGenShortCircuit.response,
+                            noGenShortCircuit.telemetry
                         );
-                    }
-                    if (
-                        workflowContextStepResult?.executionContext.toolName ===
-                            'weather_forecast' &&
-                        workflowContextStepResult.executionContext.status ===
-                            'failed'
-                    ) {
-                        const failureResponse = buildWeatherToolFailureResponse(
-                            {
-                                toolContext:
-                                    workflowContextStepResult.executionContext,
-                                metadataContext: {
-                                    modelVersion: model ?? defaultModel,
-                                    conversationSnapshot,
-                                    executionContext: {
-                                        ...executionContext,
-                                        generation: {
-                                            status: 'executed',
-                                            profileId:
-                                                executionContext?.generation
-                                                    ?.profileId ??
-                                                'workflow_context_step',
-                                            ...(executionContext?.generation
-                                                ?.originalProfileId !==
-                                                undefined && {
-                                                originalProfileId:
-                                                    executionContext.generation
-                                                        .originalProfileId,
-                                            }),
-                                            ...(executionContext?.generation
-                                                ?.effectiveProfileId !==
-                                                undefined && {
-                                                effectiveProfileId:
-                                                    executionContext.generation
-                                                        .effectiveProfileId,
-                                            }),
-                                            provider:
-                                                executionContext?.generation
-                                                    ?.provider ?? 'internal',
-                                            model:
-                                                executionContext?.generation
-                                                    ?.model ??
-                                                model ??
-                                                defaultModel,
-                                        },
-                                    },
-                                },
-                                latestUserInput:
-                                    latestUserInput ?? conversationSnapshot,
-                                buildResponseMetadata,
-                            }
-                        );
-                        return toShortCircuitMessageResult(failureResponse, {
-                            toolName:
-                                workflowContextStepResult.executionContext
-                                    .toolName,
-                            status: workflowContextStepResult.executionContext
-                                .status,
-                            ...(workflowContextStepResult.executionContext
-                                .reasonCode !== undefined && {
-                                reasonCode:
-                                    workflowContextStepResult.executionContext
-                                        .reasonCode,
-                            }),
-                            ...(toolRequest !== undefined && {
-                                eligible: toolRequest.eligible,
-                            }),
-                            ...(toolRequest?.reasonCode !== undefined && {
-                                requestReasonCode: toolRequest.reasonCode,
-                            }),
-                        });
                     }
                     const noGenerationResolution =
                         resolveNoGenerationHandlingFromTermination({

--- a/packages/backend/src/services/chatService.ts
+++ b/packages/backend/src/services/chatService.ts
@@ -135,10 +135,14 @@ const buildContextStepShortCircuit = ({
         },
     });
 
+    const generationMetadataContext = buildGenerationMetadataContext();
+
     if (contextExecutionContext.clarification !== undefined) {
         const clarificationResponse = buildToolClarificationResponse({
             toolContext: contextExecutionContext,
-            metadataContext: buildGenerationMetadataContext(),
+            metadataContext: generationMetadataContext as Parameters<
+                typeof buildToolClarificationResponse
+            >[0]['metadataContext'],
             buildResponseMetadata,
         });
         return {
@@ -165,10 +169,10 @@ const buildContextStepShortCircuit = ({
     ) {
         const failureResponse = buildWeatherToolFailureResponse({
             toolContext: contextExecutionContext,
-            metadataContext: {
-                ...buildGenerationMetadataContext(),
-                latestUserInput: latestUserInput ?? conversationSnapshot,
-            },
+            metadataContext: generationMetadataContext as Parameters<
+                typeof buildWeatherToolFailureResponse
+            >[0]['metadataContext'],
+            latestUserInput: latestUserInput ?? conversationSnapshot,
             buildResponseMetadata,
         });
         return {
@@ -885,7 +889,10 @@ export const createChatService = ({
                         latestUserInput,
                         buildResponseMetadata,
                     });
-                    if (generatedShortCircuit !== undefined) {
+                    if (
+                        generatedShortCircuit !== undefined &&
+                        generatedShortCircuit.response !== undefined
+                    ) {
                         return toShortCircuitMessageResult(
                             generatedShortCircuit.response,
                             generatedShortCircuit.telemetry
@@ -905,7 +912,10 @@ export const createChatService = ({
                         latestUserInput,
                         buildResponseMetadata,
                     });
-                    if (noGenShortCircuit !== undefined) {
+                    if (
+                        noGenShortCircuit !== undefined &&
+                        noGenShortCircuit.response !== undefined
+                    ) {
                         return toShortCircuitMessageResult(
                             noGenShortCircuit.response,
                             noGenShortCircuit.telemetry

--- a/packages/backend/src/services/chatService.ts
+++ b/packages/backend/src/services/chatService.ts
@@ -49,6 +49,9 @@ import {
 import {
     buildPlannerStepRecord,
     runBoundedReviewWorkflow,
+    type ContextStepExecutor,
+    type ContextStepRequest,
+    type ContextStepResult,
     type RunBoundedReviewWorkflowResult,
     type WorkflowPolicy,
 } from './workflowEngine.js';
@@ -63,6 +66,8 @@ import type {
 import type { ScopeValidationPolicy } from './executionContractTrustGraph/scopeValidator.js';
 import { logger } from '../utils/logger.js';
 import { runtimeConfig } from '../config.js';
+import { buildToolClarificationResponse } from './tools/toolClarificationResponse.js';
+import { buildWeatherToolFailureResponse } from './tools/weatherToolFailureResponse.js';
 
 const SURFACED_NO_GENERATION_MESSAGE =
     'I could not generate a response for this request.';
@@ -448,6 +453,9 @@ export type RunChatMessagesInput = {
     workflowModeId?: string;
     workflowModeEscalationRequest?: WorkflowModeEscalationRequest;
     toolRequest?: ToolInvocationRequest;
+    contextStepRequest?: ContextStepRequest;
+    contextStepExecutor?: ContextStepExecutor;
+    latestUserInput?: string;
     executionContractTrustGraphContext?: ExecutionContractTrustGraphContext;
     ExecutionContract?: ExecutionContract;
     steerabilityControls?: ResponseMetadata['steerabilityControls'];
@@ -571,6 +579,9 @@ export const createChatService = ({
         workflowModeId,
         workflowModeEscalationRequest,
         toolRequest,
+        contextStepRequest,
+        contextStepExecutor,
+        latestUserInput,
         executionContractTrustGraphContext,
         ExecutionContract,
         steerabilityControls,
@@ -580,6 +591,31 @@ export const createChatService = ({
         generationDurationMs: number;
         finalToolExecutionTelemetry?: FinalToolExecutionTelemetry;
     }> => {
+        const toShortCircuitMessageResult = (
+            response: PostChatResponse,
+            finalToolExecutionTelemetry: FinalToolExecutionTelemetry
+        ): {
+            message: string;
+            metadata: ResponseMetadata;
+            generationDurationMs: number;
+            finalToolExecutionTelemetry?: FinalToolExecutionTelemetry;
+        } => {
+            if (response.action !== 'message' || response.metadata === null) {
+                throw new Error(
+                    'Tool short-circuit response must be a message with metadata.'
+                );
+            }
+
+            return {
+                message: response.message,
+                metadata: response.metadata,
+                generationDurationMs: Math.max(
+                    0,
+                    Date.now() - generationStartedAt
+                ),
+                finalToolExecutionTelemetry,
+            };
+        };
         const generationStartedAt = Date.now();
         const normalizedGeneration = normalizeGenerationPlan(generation);
         // Repo-explainer mode appends one helper system hint so responses stay
@@ -641,6 +677,7 @@ export const createChatService = ({
 
         let generationResult: GenerationResult;
         let workflowLineage: WorkflowRecord | undefined;
+        let workflowContextStepResult: ContextStepResult | undefined;
         let fallbackAfterInternalNoGeneration = false;
         const plannerExecutionContext = executionContext?.planner;
         const plannerWorkflowStepRecord: StepRecord | undefined =
@@ -710,14 +747,297 @@ export const createChatService = ({
                 captureUsage: (result, requestedModel) =>
                     recordUsageForStep(result, requestedModel),
                 plannerStepRecord: plannerWorkflowStepRecord,
+                contextStepRequest,
+                contextStepExecutor,
             });
+            workflowContextStepResult = workflowResult.contextStepResult;
             switch (workflowResult.outcome) {
                 case 'generated':
                     generationResult = workflowResult.generationResult;
                     workflowLineage = workflowResult.workflowLineage;
+                    if (
+                        workflowContextStepResult?.executionContext
+                            ?.clarification !== undefined
+                    ) {
+                        const clarificationResponse =
+                            buildToolClarificationResponse({
+                                toolContext:
+                                    workflowContextStepResult.executionContext,
+                                metadataContext: {
+                                    modelVersion: model ?? defaultModel,
+                                    conversationSnapshot,
+                                    executionContext: {
+                                        ...executionContext,
+                                        generation: {
+                                            status: 'executed',
+                                            profileId:
+                                                executionContext?.generation
+                                                    ?.profileId ??
+                                                'workflow_context_step',
+                                            ...(executionContext?.generation
+                                                ?.originalProfileId !==
+                                                undefined && {
+                                                originalProfileId:
+                                                    executionContext.generation
+                                                        .originalProfileId,
+                                            }),
+                                            ...(executionContext?.generation
+                                                ?.effectiveProfileId !==
+                                                undefined && {
+                                                effectiveProfileId:
+                                                    executionContext.generation
+                                                        .effectiveProfileId,
+                                            }),
+                                            provider:
+                                                executionContext?.generation
+                                                    ?.provider ?? 'internal',
+                                            model:
+                                                executionContext?.generation
+                                                    ?.model ??
+                                                model ??
+                                                defaultModel,
+                                        },
+                                    },
+                                },
+                                buildResponseMetadata,
+                            });
+                        return toShortCircuitMessageResult(
+                            clarificationResponse,
+                            {
+                                toolName:
+                                    workflowContextStepResult.executionContext
+                                        .toolName,
+                                status: workflowContextStepResult
+                                    .executionContext.status,
+                                ...(workflowContextStepResult.executionContext
+                                    .reasonCode !== undefined && {
+                                    reasonCode:
+                                        workflowContextStepResult
+                                            .executionContext.reasonCode,
+                                }),
+                                ...(toolRequest !== undefined && {
+                                    eligible: toolRequest.eligible,
+                                }),
+                                ...(toolRequest?.reasonCode !== undefined && {
+                                    requestReasonCode: toolRequest.reasonCode,
+                                }),
+                            }
+                        );
+                    }
+                    if (
+                        workflowContextStepResult?.executionContext.toolName ===
+                            'weather_forecast' &&
+                        workflowContextStepResult.executionContext.status ===
+                            'failed'
+                    ) {
+                        const failureResponse = buildWeatherToolFailureResponse(
+                            {
+                                toolContext:
+                                    workflowContextStepResult.executionContext,
+                                metadataContext: {
+                                    modelVersion: model ?? defaultModel,
+                                    conversationSnapshot,
+                                    executionContext: {
+                                        ...executionContext,
+                                        generation: {
+                                            status: 'executed',
+                                            profileId:
+                                                executionContext?.generation
+                                                    ?.profileId ??
+                                                'workflow_context_step',
+                                            ...(executionContext?.generation
+                                                ?.originalProfileId !==
+                                                undefined && {
+                                                originalProfileId:
+                                                    executionContext.generation
+                                                        .originalProfileId,
+                                            }),
+                                            ...(executionContext?.generation
+                                                ?.effectiveProfileId !==
+                                                undefined && {
+                                                effectiveProfileId:
+                                                    executionContext.generation
+                                                        .effectiveProfileId,
+                                            }),
+                                            provider:
+                                                executionContext?.generation
+                                                    ?.provider ?? 'internal',
+                                            model:
+                                                executionContext?.generation
+                                                    ?.model ??
+                                                model ??
+                                                defaultModel,
+                                        },
+                                    },
+                                },
+                                latestUserInput:
+                                    latestUserInput ?? conversationSnapshot,
+                                buildResponseMetadata,
+                            }
+                        );
+                        return toShortCircuitMessageResult(failureResponse, {
+                            toolName:
+                                workflowContextStepResult.executionContext
+                                    .toolName,
+                            status: workflowContextStepResult.executionContext
+                                .status,
+                            ...(workflowContextStepResult.executionContext
+                                .reasonCode !== undefined && {
+                                reasonCode:
+                                    workflowContextStepResult.executionContext
+                                        .reasonCode,
+                            }),
+                            ...(toolRequest !== undefined && {
+                                eligible: toolRequest.eligible,
+                            }),
+                            ...(toolRequest?.reasonCode !== undefined && {
+                                requestReasonCode: toolRequest.reasonCode,
+                            }),
+                        });
+                    }
                     break;
                 case 'no_generation': {
                     workflowLineage = workflowResult.workflowLineage;
+                    if (
+                        workflowContextStepResult?.executionContext
+                            ?.clarification !== undefined
+                    ) {
+                        const clarificationResponse =
+                            buildToolClarificationResponse({
+                                toolContext:
+                                    workflowContextStepResult.executionContext,
+                                metadataContext: {
+                                    modelVersion: model ?? defaultModel,
+                                    conversationSnapshot,
+                                    executionContext: {
+                                        ...executionContext,
+                                        generation: {
+                                            status: 'executed',
+                                            profileId:
+                                                executionContext?.generation
+                                                    ?.profileId ??
+                                                'workflow_context_step',
+                                            ...(executionContext?.generation
+                                                ?.originalProfileId !==
+                                                undefined && {
+                                                originalProfileId:
+                                                    executionContext.generation
+                                                        .originalProfileId,
+                                            }),
+                                            ...(executionContext?.generation
+                                                ?.effectiveProfileId !==
+                                                undefined && {
+                                                effectiveProfileId:
+                                                    executionContext.generation
+                                                        .effectiveProfileId,
+                                            }),
+                                            provider:
+                                                executionContext?.generation
+                                                    ?.provider ?? 'internal',
+                                            model:
+                                                executionContext?.generation
+                                                    ?.model ??
+                                                model ??
+                                                defaultModel,
+                                        },
+                                    },
+                                },
+                                buildResponseMetadata,
+                            });
+                        return toShortCircuitMessageResult(
+                            clarificationResponse,
+                            {
+                                toolName:
+                                    workflowContextStepResult.executionContext
+                                        .toolName,
+                                status: workflowContextStepResult
+                                    .executionContext.status,
+                                ...(workflowContextStepResult.executionContext
+                                    .reasonCode !== undefined && {
+                                    reasonCode:
+                                        workflowContextStepResult
+                                            .executionContext.reasonCode,
+                                }),
+                                ...(toolRequest !== undefined && {
+                                    eligible: toolRequest.eligible,
+                                }),
+                                ...(toolRequest?.reasonCode !== undefined && {
+                                    requestReasonCode: toolRequest.reasonCode,
+                                }),
+                            }
+                        );
+                    }
+                    if (
+                        workflowContextStepResult?.executionContext.toolName ===
+                            'weather_forecast' &&
+                        workflowContextStepResult.executionContext.status ===
+                            'failed'
+                    ) {
+                        const failureResponse = buildWeatherToolFailureResponse(
+                            {
+                                toolContext:
+                                    workflowContextStepResult.executionContext,
+                                metadataContext: {
+                                    modelVersion: model ?? defaultModel,
+                                    conversationSnapshot,
+                                    executionContext: {
+                                        ...executionContext,
+                                        generation: {
+                                            status: 'executed',
+                                            profileId:
+                                                executionContext?.generation
+                                                    ?.profileId ??
+                                                'workflow_context_step',
+                                            ...(executionContext?.generation
+                                                ?.originalProfileId !==
+                                                undefined && {
+                                                originalProfileId:
+                                                    executionContext.generation
+                                                        .originalProfileId,
+                                            }),
+                                            ...(executionContext?.generation
+                                                ?.effectiveProfileId !==
+                                                undefined && {
+                                                effectiveProfileId:
+                                                    executionContext.generation
+                                                        .effectiveProfileId,
+                                            }),
+                                            provider:
+                                                executionContext?.generation
+                                                    ?.provider ?? 'internal',
+                                            model:
+                                                executionContext?.generation
+                                                    ?.model ??
+                                                model ??
+                                                defaultModel,
+                                        },
+                                    },
+                                },
+                                latestUserInput:
+                                    latestUserInput ?? conversationSnapshot,
+                                buildResponseMetadata,
+                            }
+                        );
+                        return toShortCircuitMessageResult(failureResponse, {
+                            toolName:
+                                workflowContextStepResult.executionContext
+                                    .toolName,
+                            status: workflowContextStepResult.executionContext
+                                .status,
+                            ...(workflowContextStepResult.executionContext
+                                .reasonCode !== undefined && {
+                                reasonCode:
+                                    workflowContextStepResult.executionContext
+                                        .reasonCode,
+                            }),
+                            ...(toolRequest !== undefined && {
+                                eligible: toolRequest.eligible,
+                            }),
+                            ...(toolRequest?.reasonCode !== undefined && {
+                                requestReasonCode: toolRequest.reasonCode,
+                            }),
+                        });
+                    }
                     const noGenerationResolution =
                         resolveNoGenerationHandlingFromTermination({
                             terminationReason:
@@ -918,7 +1238,9 @@ export const createChatService = ({
         // Any mode escalation lineage is resolved by workflowProfileRegistry.
         // Runtime metadata here only carries the resolved decision payload.
         const hasSearchIntent = normalizedGeneration?.search !== undefined;
-        const upstreamToolExecution = executionContext?.tool;
+        const upstreamToolExecution =
+            executionContext?.tool ??
+            workflowContextStepResult?.executionContext;
         const effectiveToolExecutionContext:
             | NonNullable<
                   ResponseMetadataRuntimeContext['executionContext']

--- a/packages/backend/src/services/contextIntegrations/toolRegistryContextStepAdapter.ts
+++ b/packages/backend/src/services/contextIntegrations/toolRegistryContextStepAdapter.ts
@@ -1,0 +1,94 @@
+/**
+ * @description: Adapts existing tool-registry execution into workflow-owned context-step executor shape.
+ * Keeps workflow engine provider-neutral while preserving current weather tool semantics.
+ * @footnote-scope: core
+ * @footnote-module: ToolRegistryContextStepAdapter
+ * @footnote-risk: medium - Mapping mistakes can misclassify tool outcomes or lose context payloads during workflow integration.
+ * @footnote-ethics: medium - Tool outcome normalization affects provenance clarity and fail-open trust signals.
+ */
+import type { ToolExecutionContext } from '@footnote/contracts/ethics-core';
+import type {
+    ContextStepExecutor,
+    ContextStepRequest,
+    ContextStepResult,
+} from '../workflowEngine.js';
+import type { WeatherForecastTool } from '../openMeteoForecastTool.js';
+import {
+    executeSelectedTool,
+    resolveToolSelection,
+} from '../tools/toolRegistry.js';
+
+const buildContextToolIntentInput = (
+    request: ContextStepRequest
+): Record<string, unknown> | undefined => {
+    if (request.input && typeof request.input === 'object') {
+        return request.input;
+    }
+
+    return undefined;
+};
+
+const buildFallbackToolExecutionContext = (
+    request: ContextStepRequest
+): ToolExecutionContext => ({
+    toolName: request.integrationName,
+    status: request.eligible ? 'failed' : 'skipped',
+    reasonCode:
+        request.reasonCode ??
+        (request.eligible ? 'unspecified_tool_outcome' : 'tool_unavailable'),
+});
+
+export const createToolRegistryContextStepExecutor = ({
+    weatherForecastTool,
+    onWarn,
+}: {
+    weatherForecastTool?: WeatherForecastTool;
+    onWarn?: (message: string, meta?: Record<string, unknown>) => void;
+}): ContextStepExecutor => {
+    const warn = onWarn ?? (() => undefined);
+
+    return async ({ request }): Promise<ContextStepResult> => {
+        const normalizedInput = buildContextToolIntentInput(request);
+        const toolSelection = resolveToolSelection({
+            generation: {
+                reasoningEffort: 'low',
+                verbosity: 'low',
+                toolIntent: {
+                    toolName: request.integrationName,
+                    requested: request.requested,
+                    ...(normalizedInput !== undefined && {
+                        input: normalizedInput,
+                    }),
+                },
+            },
+            weatherForecastTool,
+            ...(request.reasonCode !== undefined && {
+                inheritedToolExecution: {
+                    toolName: request.integrationName,
+                    status: request.eligible ? 'failed' : 'skipped',
+                    reasonCode: request.reasonCode,
+                } satisfies ToolExecutionContext,
+            }),
+        });
+
+        const execution = await executeSelectedTool({
+            toolSelection,
+            weatherForecastTool,
+            onWarn: warn,
+        });
+        const executionContext =
+            execution.toolExecutionContext ??
+            toolSelection.toolExecution ??
+            buildFallbackToolExecutionContext(request);
+
+        return {
+            executionContext,
+            ...(execution.toolResultMessage !== undefined && {
+                contextMessages: [execution.toolResultMessage],
+            }),
+            ...(executionContext.clarification !== undefined && {
+                clarification: executionContext.clarification,
+            }),
+        };
+    };
+};

--- a/packages/backend/src/services/openMeteoForecastTool.ts
+++ b/packages/backend/src/services/openMeteoForecastTool.ts
@@ -12,6 +12,8 @@ import type { ChatGenerationWeatherRequest } from './chatGenerationTypes.js';
 const OPEN_METEO_FORECAST_URL = 'https://api.open-meteo.com/v1/forecast';
 const OPEN_METEO_GEOCODING_URL =
     'https://geocoding-api.open-meteo.com/v1/search';
+const OPEN_METEO_DOCS_URL = 'https://open-meteo.com/en/docs';
+const OPEN_METEO_DOCS_LABEL = 'Open-Meteo Weather Forecast API';
 const DEFAULT_REQUEST_TIMEOUT_MS = 6_000;
 const DEFAULT_HORIZON_PERIODS = 5;
 const MIN_HORIZON_PERIODS = 1;
@@ -104,6 +106,8 @@ export type WeatherToolProvenance = {
     endpoint: string;
     requestedAt: string;
     resolvedFromEndpoint?: string;
+    citationUrl: string;
+    citationLabel: string;
 };
 
 export type WeatherForecastToolResult =
@@ -329,6 +333,8 @@ const buildErrorResult = ({
         endpoint,
         requestedAt,
         ...(resolvedFromEndpoint !== undefined && { resolvedFromEndpoint }),
+        citationUrl: OPEN_METEO_DOCS_URL,
+        citationLabel: OPEN_METEO_DOCS_LABEL,
     },
 });
 
@@ -427,6 +433,8 @@ const buildClarificationResult = ({
             endpoint,
             requestedAt,
             ...(resolvedFromEndpoint !== undefined && { resolvedFromEndpoint }),
+            citationUrl: OPEN_METEO_DOCS_URL,
+            citationLabel: OPEN_METEO_DOCS_LABEL,
         },
     };
 };
@@ -822,6 +830,8 @@ export const createOpenMeteoForecastTool = ({
                 ...(resolvedFromEndpoint !== undefined && {
                     resolvedFromEndpoint,
                 }),
+                citationUrl: OPEN_METEO_DOCS_URL,
+                citationLabel: OPEN_METEO_DOCS_LABEL,
             },
         };
     };

--- a/packages/backend/src/services/workflowEngine.ts
+++ b/packages/backend/src/services/workflowEngine.ts
@@ -974,8 +974,25 @@ export const runBoundedReviewWorkflow = async ({
                     workflowStatus = 'completed';
                     shouldStop = true;
                 }
-            } catch {
+            } catch (error) {
                 const contextStepFinishedAt = Date.now();
+                logger.error(
+                    'Context step execution failed; workflow continued fail-open without context.',
+                    {
+                        stepKind: 'tool',
+                        reasonCode: 'tool_execution_error',
+                        startedAtMs: contextStepStartedAt,
+                        finishedAtMs: contextStepFinishedAt,
+                        parentStepId: plannerRootStepId,
+                        attempt: 1,
+                        workflowName: workflowConfig.workflowName,
+                        workflowId,
+                        error:
+                            error instanceof Error
+                                ? error.message
+                                : String(error),
+                    }
+                );
                 captureStep({
                     stepKind: 'tool',
                     status: 'failed',

--- a/packages/backend/src/services/workflowEngine.ts
+++ b/packages/backend/src/services/workflowEngine.ts
@@ -10,6 +10,9 @@ import type { WorkflowTerminationReason } from '@footnote/contracts/ethics-core'
 import type {
     BoundedReviewAssessSignals,
     ExecutionStatus,
+    ToolClarification,
+    ToolExecutionContext,
+    ToolInvocationReasonCode,
     PlannerExecutionApplyOutcome,
     PlannerExecutionContractType,
     PlannerExecutionPurpose,
@@ -153,6 +156,8 @@ export type RunBoundedReviewWorkflowInput = {
         requestedModel: string | undefined
     ) => ReviewWorkflowUsageSummary;
     plannerStepRecord?: StepRecord;
+    contextStepRequest?: ContextStepRequest;
+    contextStepExecutor?: ContextStepExecutor;
 };
 
 export type RunBoundedReviewWorkflowResult =
@@ -160,11 +165,38 @@ export type RunBoundedReviewWorkflowResult =
           outcome: 'generated';
           generationResult: GenerationResult;
           workflowLineage: WorkflowRecord;
+          contextStepResult?: ContextStepResult;
       }
     | {
           outcome: 'no_generation';
           workflowLineage: WorkflowRecord;
+          contextStepResult?: ContextStepResult;
       };
+
+export type ContextStepRequest = {
+    integrationName: string;
+    requested: boolean;
+    eligible: boolean;
+    reasonCode?: ToolInvocationReasonCode;
+    input?: Record<string, unknown>;
+};
+
+export type ContextStepResult = {
+    executionContext: ToolExecutionContext;
+    contextMessages?: string[];
+    clarification?: ToolClarification;
+};
+
+export type ContextStepExecutorInput = {
+    request: ContextStepRequest;
+    workflowId: string;
+    workflowName: string;
+    attempt: number;
+};
+
+export type ContextStepExecutor = (
+    input: ContextStepExecutorInput
+) => Promise<ContextStepResult>;
 
 const LEGAL_TRANSITIONS: Record<
     WorkflowStepKind,
@@ -211,7 +243,11 @@ export const isTransitionAllowed = (
     }
 
     if (fromStepKind === null) {
-        return toStepKind === 'plan' || toStepKind === 'generate';
+        return (
+            toStepKind === 'plan' ||
+            toStepKind === 'tool' ||
+            toStepKind === 'generate'
+        );
     }
 
     if (fromStepKind === 'plan' && toStepKind === 'plan') {
@@ -623,6 +659,8 @@ export const runBoundedReviewWorkflow = async ({
     parseReviewDecision,
     captureUsage,
     plannerStepRecord,
+    contextStepRequest,
+    contextStepExecutor,
 }: RunBoundedReviewWorkflowInput): Promise<RunBoundedReviewWorkflowResult> => {
     // NOTE: Concrete tool execution is still orchestrator/registry-owned.
     // This engine path currently executes only bounded review generation steps.
@@ -672,6 +710,8 @@ export const runBoundedReviewWorkflow = async ({
     let latestReviewReason: string | undefined;
     let shouldStop = false;
     let exhaustedLimitKey: WorkflowLimitKey | undefined;
+    let executedContextStepResult: ContextStepResult | undefined;
+    let messagesWithContext = messagesWithHints;
     const effectiveReviewDecisionPrompt =
         reviewDecisionPrompt ?? profileStrategy.reviewDecisionPrompt;
     const effectiveRevisionPromptPrefix =
@@ -726,6 +766,7 @@ export const runBoundedReviewWorkflow = async ({
         stepKind: StepRecord['stepKind'];
         status: StepRecord['outcome']['status'];
         summary: string;
+        artifacts?: string[];
         startedAtMs: number;
         finishedAtMs: number;
         model?: string;
@@ -770,6 +811,9 @@ export const runBoundedReviewWorkflow = async ({
             outcome: {
                 status: input.status,
                 summary: input.summary,
+                ...(input.artifacts !== undefined && {
+                    artifacts: input.artifacts,
+                }),
                 ...(input.signals !== undefined && {
                     signals: input.signals,
                 }),
@@ -802,6 +846,158 @@ export const runBoundedReviewWorkflow = async ({
         return true;
     };
 
+    const injectContextMessagesIntoPrompt = (
+        baseMessages: RuntimeMessage[],
+        contextMessages: string[] | undefined
+    ): RuntimeMessage[] => {
+        if (!contextMessages || contextMessages.length === 0) {
+            return baseMessages;
+        }
+
+        const normalizedContextMessages = contextMessages
+            .map((message) => message.trim())
+            .filter((message) => message.length > 0)
+            .map(
+                (message): RuntimeMessage => ({
+                    role: 'system',
+                    content: message,
+                })
+            );
+        if (normalizedContextMessages.length === 0) {
+            return baseMessages;
+        }
+
+        const plannerMessageIndex = baseMessages.findIndex(
+            (message) =>
+                message.role === 'system' &&
+                message.content.includes('// BEGIN Planner Output')
+        );
+        if (plannerMessageIndex < 0) {
+            return [...baseMessages, ...normalizedContextMessages];
+        }
+
+        return [
+            ...baseMessages.slice(0, plannerMessageIndex),
+            ...normalizedContextMessages,
+            ...baseMessages.slice(plannerMessageIndex),
+        ];
+    };
+
+    if (
+        contextStepRequest?.requested === true &&
+        contextStepRequest.eligible &&
+        contextStepExecutor !== undefined
+    ) {
+        if (
+            !isTransitionAllowed(
+                workflowState.currentStepKind,
+                'tool',
+                workflowPolicy
+            )
+        ) {
+            terminationReason = 'transition_blocked_by_policy';
+            shouldStop = true;
+        } else if (!stopIfOverLimits('tool')) {
+            const contextStepStartedAt = Date.now();
+            try {
+                const contextStepResult = await contextStepExecutor({
+                    request: contextStepRequest,
+                    workflowId,
+                    workflowName: workflowConfig.workflowName,
+                    attempt: 1,
+                });
+                const contextStepFinishedAt = Date.now();
+                const normalizedExecutionContext: ToolExecutionContext = {
+                    ...contextStepResult.executionContext,
+                    toolName: contextStepResult.executionContext.toolName,
+                    ...(contextStepResult.executionContext.clarification ===
+                        undefined &&
+                        contextStepResult.clarification !== undefined && {
+                            clarification: contextStepResult.clarification,
+                        }),
+                };
+                executedContextStepResult = {
+                    executionContext: normalizedExecutionContext,
+                    ...(contextStepResult.contextMessages !== undefined && {
+                        contextMessages: contextStepResult.contextMessages,
+                    }),
+                    ...(normalizedExecutionContext.clarification !==
+                        undefined && {
+                        clarification: normalizedExecutionContext.clarification,
+                    }),
+                };
+                const status =
+                    normalizedExecutionContext.status === 'failed'
+                        ? 'failed'
+                        : 'executed';
+                captureStep({
+                    stepKind: 'tool',
+                    status,
+                    summary:
+                        status === 'failed'
+                            ? 'Context step failed; workflow continued fail-open without context.'
+                            : normalizedExecutionContext.clarification !==
+                                undefined
+                              ? 'Context step requires user clarification before generation.'
+                              : 'Context step executed and emitted bounded context messages.',
+                    ...(normalizedExecutionContext.reasonCode !== undefined && {
+                        reasonCode: normalizedExecutionContext.reasonCode,
+                    }),
+                    startedAtMs: contextStepStartedAt,
+                    finishedAtMs: contextStepFinishedAt,
+                    parentStepId: plannerRootStepId,
+                    attempt: 1,
+                    ...(contextStepResult.contextMessages !== undefined && {
+                        artifacts: contextStepResult.contextMessages,
+                    }),
+                    ...(normalizedExecutionContext.clarification !==
+                        undefined && {
+                        signals: {
+                            clarificationReasonCode:
+                                normalizedExecutionContext.clarification
+                                    .reasonCode,
+                            clarificationOptionCount:
+                                normalizedExecutionContext.clarification.options
+                                    .length,
+                        },
+                    }),
+                });
+                workflowState = applyStepExecutionToState(
+                    workflowState,
+                    'tool',
+                    0,
+                    1,
+                    0
+                );
+                if (normalizedExecutionContext.clarification !== undefined) {
+                    terminationReason = 'goal_satisfied';
+                    workflowStatus = 'completed';
+                    shouldStop = true;
+                }
+            } catch {
+                const contextStepFinishedAt = Date.now();
+                captureStep({
+                    stepKind: 'tool',
+                    status: 'failed',
+                    summary:
+                        'Context step execution failed; workflow continued fail-open without context.',
+                    reasonCode: 'tool_execution_error',
+                    startedAtMs: contextStepStartedAt,
+                    finishedAtMs: contextStepFinishedAt,
+                    parentStepId: plannerRootStepId,
+                    attempt: 1,
+                });
+                workflowState = applyStepExecutionToState(
+                    workflowState,
+                    'tool',
+                    0,
+                    1,
+                    0
+                );
+            }
+        }
+    }
+
     if (
         !isTransitionAllowed(
             workflowState.currentStepKind,
@@ -814,9 +1010,15 @@ export const runBoundedReviewWorkflow = async ({
     } else {
         if (!stopIfOverLimits('generate')) {
             const initialDraftStartedAt = generationStartedAtMs;
+            messagesWithContext = injectContextMessagesIntoPrompt(
+                messagesWithHints,
+                executedContextStepResult?.contextMessages
+            );
             try {
-                draftResult =
-                    await generationRuntime.generate(generationRequest);
+                draftResult = await generationRuntime.generate({
+                    ...generationRequest,
+                    messages: messagesWithContext,
+                });
                 const initialDraftFinishedAt = Date.now();
                 const initialDraftUsage = captureUsage(
                     draftResult,
@@ -913,7 +1115,7 @@ export const runBoundedReviewWorkflow = async ({
         try {
             const reviewResult = await generationRuntime.generate({
                 messages: [
-                    ...messagesWithHints,
+                    ...messagesWithContext,
                     {
                         role: 'assistant',
                         content: draftResult?.text ?? '',
@@ -1024,7 +1226,7 @@ export const runBoundedReviewWorkflow = async ({
                 const revisionResult = await generationRuntime.generate({
                     ...generationRequest,
                     messages: [
-                        ...messagesWithHints,
+                        ...messagesWithContext,
                         {
                             role: 'assistant',
                             content: draftResult?.text ?? '',
@@ -1141,6 +1343,9 @@ export const runBoundedReviewWorkflow = async ({
         return {
             outcome: 'no_generation',
             workflowLineage,
+            ...(executedContextStepResult !== undefined && {
+                contextStepResult: executedContextStepResult,
+            }),
         };
     }
 
@@ -1148,5 +1353,8 @@ export const runBoundedReviewWorkflow = async ({
         outcome: 'generated',
         generationResult: draftResult,
         workflowLineage,
+        ...(executedContextStepResult !== undefined && {
+            contextStepResult: executedContextStepResult,
+        }),
     };
 };

--- a/packages/backend/test/chatOrchestrator.test.ts
+++ b/packages/backend/test/chatOrchestrator.test.ts
@@ -1369,6 +1369,8 @@ test('orchestrator injects backend weather tool context and records executed too
                 provider: 'open-meteo',
                 endpoint: 'https://api.open-meteo.com/v1/forecast',
                 requestedAt: '2026-03-27T12:00:00.000Z',
+                citationUrl: 'https://open-meteo.com/en/docs',
+                citationLabel: 'Open-Meteo Weather Forecast API',
             },
         }),
     };
@@ -1506,6 +1508,8 @@ test('planner mixed weather and search requests apply single-tool weather priori
                 provider: 'open-meteo',
                 endpoint: 'https://api.open-meteo.com/v1/forecast',
                 requestedAt: '2026-03-27T12:00:00.000Z',
+                citationUrl: 'https://open-meteo.com/en/docs',
+                citationLabel: 'Open-Meteo Weather Forecast API',
             },
         }),
     };
@@ -2186,6 +2190,8 @@ test('orchestrator returns clarification when tool returns needs_clarification s
                 provider: 'open-meteo',
                 endpoint: 'https://geocoding-api.open-meteo.com/v1/search',
                 requestedAt: '2026-03-27T12:00:00.000Z',
+                citationUrl: 'https://open-meteo.com/en/docs',
+                citationLabel: 'Open-Meteo Weather Forecast API',
             },
         }),
     };
@@ -2319,6 +2325,8 @@ test('orchestrator continues normal weather path when tool returns status ok', a
                 provider: 'open-meteo',
                 endpoint: 'https://api.open-meteo.com/v1/forecast',
                 requestedAt: '2026-03-27T12:00:00.000Z',
+                citationUrl: 'https://open-meteo.com/en/docs',
+                citationLabel: 'Open-Meteo Weather Forecast API',
             },
         }),
     };

--- a/packages/backend/test/toolExecutionParity.test.ts
+++ b/packages/backend/test/toolExecutionParity.test.ts
@@ -43,6 +43,8 @@ test('weather success flows through workflow context-step: tool step recorded in
                 provider: 'open-meteo',
                 endpoint: 'mock',
                 requestedAt: '2026-01-01T00:00:00Z',
+                citationUrl: 'https://open-meteo.com/en/docs',
+                citationLabel: 'Open-Meteo Weather Forecast API',
             },
         }),
     };

--- a/packages/backend/test/toolExecutionParity.test.ts
+++ b/packages/backend/test/toolExecutionParity.test.ts
@@ -143,7 +143,7 @@ test('weather success flows through workflow context-step: tool step recorded in
         'Tool step should be executed'
     );
     assert.ok(
-        toolStep?.outcome.artifacts?.length ?? 0 > 0,
+        (toolStep?.outcome.artifacts?.length ?? 0) > 0,
         'Tool step should have context artifacts'
     );
 });

--- a/packages/backend/test/toolExecutionParity.test.ts
+++ b/packages/backend/test/toolExecutionParity.test.ts
@@ -1,5 +1,5 @@
 /**
- * @description: Pins current orchestrator-owned weather tool behavior before workflow tool-step migration.
+ * @description: Verifies weather tool behavior through the workflow context-step path.
  * @footnote-scope: test
  * @footnote-module: ToolExecutionParityTests
  * @footnote-risk: low - Focused parity checks with bounded test doubles.
@@ -9,34 +9,10 @@ import test from 'node:test';
 import assert from 'node:assert/strict';
 
 import type { GenerationRuntime } from '@footnote/agent-runtime';
-import type { PostChatRequest } from '@footnote/contracts/web';
-import { createMetadata } from './fixtures/responseMetadataFixture.js';
-import { runtimeConfig } from '../src/config.js';
-import { createChatOrchestrator } from '../src/services/chatOrchestrator.js';
-import {
-    buildResponseMetadata,
-    type ResponseMetadataRuntimeContext,
-} from '../src/services/openaiService.js';
 import type { WeatherForecastTool } from '../src/services/openMeteoForecastTool.js';
+import { runBoundedReviewWorkflow } from '../src/services/workflowEngine.js';
 
-const PLANNER_TOKEN_SENTINEL = 1200;
-
-const createChatRequest = (
-    overrides: Partial<PostChatRequest> = {}
-): PostChatRequest => ({
-    surface: 'discord',
-    trigger: { kind: 'direct' },
-    latestUserInput: 'What is the weather?',
-    conversation: [{ role: 'user', content: 'What is the weather?' }],
-    capabilities: {
-        canReact: true,
-        canGenerateImages: true,
-        canUseTts: true,
-    },
-    ...overrides,
-});
-
-const createGenerationRuntime = (
+const createTestRuntime = (
     implementation: (
         request: import('@footnote/agent-runtime').GenerationRequest
     ) => Promise<import('@footnote/agent-runtime').GenerationResult>
@@ -45,42 +21,7 @@ const createGenerationRuntime = (
     generate: implementation,
 });
 
-const buildWeatherToolIntentPlannerOutput = (input: {
-    location:
-        | { type: 'lat_lon'; latitude: number; longitude: number }
-        | { query: string };
-}): string =>
-    JSON.stringify({
-        action: 'message',
-        modality: 'text',
-        requestedCapabilityProfile: 'expressive-generation',
-        safetyTier: 'Low',
-        reasoning: 'Use weather tool for this forecast question.',
-        generation: {
-            reasoningEffort: 'low',
-            verbosity: 'low',
-            temperament: {
-                tightness: 4,
-                rationale: 3,
-                attribution: 4,
-                caution: 3,
-                extent: 4,
-            },
-            toolIntent: {
-                toolName: 'weather_forecast',
-                requested: true,
-                input: {
-                    location: input.location,
-                },
-            },
-        },
-    });
-
-test('weather success keeps tool status executed and still runs generation', async () => {
-    let generationCalled = false;
-    let capturedExecutionContext:
-        | ResponseMetadataRuntimeContext['executionContext']
-        | undefined;
+test('weather success flows through workflow context-step: tool step recorded in lineage', async () => {
     const weatherForecastTool: WeatherForecastTool = {
         fetchForecast: async () => ({
             toolName: 'weather_forecast',
@@ -106,109 +47,258 @@ test('weather success keeps tool status executed and still runs generation', asy
         }),
     };
 
-    const orchestrator = createChatOrchestrator({
-        generationRuntime: createGenerationRuntime(async (request) => {
-            if (request.maxOutputTokens === PLANNER_TOKEN_SENTINEL) {
-                return {
-                    text: buildWeatherToolIntentPlannerOutput({
-                        location: {
-                            type: 'lat_lon',
-                            latitude: 39.7684,
-                            longitude: -86.1581,
-                        },
-                    }),
-                    model: 'gpt-5-mini',
-                };
-            }
-            generationCalled = true;
-            return {
-                text: 'Generated weather reply',
-                model: request.model,
-                provenance: 'Inferred',
-                citations: [],
-            };
-        }),
-        storeTrace: async () => undefined,
-        buildResponseMetadata: (_assistantMetadata, runtimeContext) => {
-            capturedExecutionContext = runtimeContext.executionContext;
-            return createMetadata();
+    const generationRuntime = createTestRuntime(async () => ({
+        text: 'Weather forecast for Indianapolis: clear skies',
+        model: 'gpt-5-mini',
+        usage: {
+            promptTokens: 10,
+            completionTokens: 5,
+            totalTokens: 15,
         },
-        defaultModel: runtimeConfig.modelProfiles.defaultProfileId,
-        recordUsage: () => undefined,
-        weatherForecastTool,
+        provenance: 'Inferred',
+        citations: [],
+    }));
+
+    const result = await runBoundedReviewWorkflow({
+        generationRuntime,
+        generationRequest: {
+            model: 'gpt-5-mini',
+            messages: [{ role: 'user', content: 'What is the weather?' }],
+        },
+        messagesWithHints: [{ role: 'user', content: 'What is the weather?' }],
+        generationStartedAtMs: Date.now(),
+        workflowConfig: {
+            workflowName: 'message_with_review_loop',
+            maxIterations: 1,
+            maxDurationMs: 15000,
+        },
+        workflowPolicy: {
+            enablePlanning: false,
+            enableToolUse: true,
+            enableReplanning: false,
+            enableGeneration: true,
+            enableAssessment: true,
+            enableRevision: true,
+        },
+        contextStepRequest: {
+            integrationName: 'weather_forecast',
+            requested: true,
+            eligible: true,
+            input: {
+                location: {
+                    type: 'lat_lon',
+                    latitude: 39.7684,
+                    longitude: -86.1581,
+                },
+            },
+        },
+        contextStepExecutor: async ({ request }) => {
+            const execution = await weatherForecastTool.fetchForecast(
+                request.input as {
+                    location: {
+                        type: string;
+                        latitude: number;
+                        longitude: number;
+                    };
+                }
+            );
+            return {
+                executionContext: {
+                    toolName: 'weather_forecast',
+                    status: 'executed',
+                    durationMs: 10,
+                },
+                contextMessages: [
+                    `Weather in ${execution.location.name}: clear skies`,
+                ],
+            };
+        },
+        captureUsage: (generationResult) => ({
+            model: generationResult.model ?? 'gpt-5-mini',
+            promptTokens: generationResult.usage?.promptTokens ?? 0,
+            completionTokens: generationResult.usage?.completionTokens ?? 0,
+            totalTokens: generationResult.usage?.totalTokens ?? 0,
+            estimatedCost: {
+                inputCostUsd: 0,
+                outputCostUsd: 0,
+                totalCostUsd: 0,
+            },
+        }),
     });
 
-    const response = await orchestrator.runChat(createChatRequest());
-
-    assert.equal(response.action, 'message');
-    assert.equal(generationCalled, true);
-    assert.equal(capturedExecutionContext?.tool?.toolName, 'weather_forecast');
-    assert.equal(capturedExecutionContext?.tool?.status, 'executed');
+    assert.equal(
+        result.outcome,
+        'generated',
+        'Workflow should generate when context step succeeds'
+    );
+    const toolStep = result.workflowLineage.steps.find(
+        (step) => step.stepKind === 'tool'
+    );
+    assert.ok(toolStep, 'Workflow should have a tool step');
+    assert.equal(
+        toolStep?.outcome.status,
+        'executed',
+        'Tool step should be executed'
+    );
+    assert.ok(
+        toolStep?.outcome.artifacts?.length ?? 0 > 0,
+        'Tool step should have context artifacts'
+    );
 });
 
-test('weather failure preserves fail-open generation with failed tool status and reason code', async () => {
-    let capturedExecutionContext:
-        | ResponseMetadataRuntimeContext['executionContext']
-        | undefined;
+test('weather failure preserves fail-open: generation runs, tool step recorded as failed', async () => {
     const weatherForecastTool: WeatherForecastTool = {
         fetchForecast: async () => {
             throw new Error('weather upstream unavailable');
         },
     };
 
-    const orchestrator = createChatOrchestrator({
-        generationRuntime: createGenerationRuntime(async (request) => {
-            if (request.maxOutputTokens === PLANNER_TOKEN_SENTINEL) {
+    const generationRuntime = createTestRuntime(async () => ({
+        text: 'Fallback weather response',
+        model: 'gpt-5-mini',
+        usage: {
+            promptTokens: 10,
+            completionTokens: 5,
+            totalTokens: 15,
+        },
+        provenance: 'Inferred',
+        citations: [],
+    }));
+
+    const result = await runBoundedReviewWorkflow({
+        generationRuntime,
+        generationRequest: {
+            model: 'gpt-5-mini',
+            messages: [{ role: 'user', content: 'What is the weather?' }],
+        },
+        messagesWithHints: [{ role: 'user', content: 'What is the weather?' }],
+        generationStartedAtMs: Date.now(),
+        workflowConfig: {
+            workflowName: 'message_with_review_loop',
+            maxIterations: 1,
+            maxDurationMs: 15000,
+        },
+        workflowPolicy: {
+            enablePlanning: false,
+            enableToolUse: true,
+            enableReplanning: false,
+            enableGeneration: true,
+            enableAssessment: true,
+            enableRevision: true,
+        },
+        contextStepRequest: {
+            integrationName: 'weather_forecast',
+            requested: true,
+            eligible: true,
+            input: { location: 'Indianapolis' },
+        },
+        contextStepExecutor: async () => {
+            try {
+                await weatherForecastTool.fetchForecast({
+                    location: 'Indianapolis',
+                } as never);
                 return {
-                    text: buildWeatherToolIntentPlannerOutput({
-                        location: {
-                            type: 'lat_lon',
-                            latitude: 39.7684,
-                            longitude: -86.1581,
-                        },
-                    }),
-                    model: 'gpt-5-mini',
+                    executionContext: {
+                        toolName: 'weather_forecast',
+                        status: 'executed',
+                    },
+                };
+            } catch {
+                return {
+                    executionContext: {
+                        toolName: 'weather_forecast',
+                        status: 'failed',
+                        reasonCode: 'tool_execution_error',
+                    },
                 };
             }
-            return {
-                text: 'Fallback non-tool weather response',
-                model: request.model,
-                provenance: 'Inferred',
-                citations: [],
-            };
-        }),
-        storeTrace: async () => undefined,
-        buildResponseMetadata: (_assistantMetadata, runtimeContext) => {
-            capturedExecutionContext = runtimeContext.executionContext;
-            return createMetadata();
         },
-        defaultModel: runtimeConfig.modelProfiles.defaultProfileId,
-        recordUsage: () => undefined,
-        weatherForecastTool,
+        captureUsage: (generationResult) => ({
+            model: generationResult.model ?? 'gpt-5-mini',
+            promptTokens: generationResult.usage?.promptTokens ?? 0,
+            completionTokens: generationResult.usage?.completionTokens ?? 0,
+            totalTokens: generationResult.usage?.totalTokens ?? 0,
+            estimatedCost: {
+                inputCostUsd: 0,
+                outputCostUsd: 0,
+                totalCostUsd: 0,
+            },
+        }),
     });
 
-    const response = await orchestrator.runChat(createChatRequest());
-
-    assert.equal(response.action, 'message');
-    assert.equal(capturedExecutionContext?.tool?.toolName, 'weather_forecast');
-    assert.equal(capturedExecutionContext?.tool?.status, 'failed');
     assert.equal(
-        capturedExecutionContext?.tool?.reasonCode,
-        'tool_execution_error'
+        result.outcome,
+        'generated',
+        'Workflow should still generate on context step failure (fail-open)'
+    );
+    const toolStep = result.workflowLineage.steps.find(
+        (step) => step.stepKind === 'tool'
+    );
+    assert.ok(toolStep, 'Workflow should have a tool step');
+    assert.equal(
+        toolStep?.outcome.status,
+        'failed',
+        'Tool step should be marked as failed'
+    );
+    assert.equal(
+        toolStep?.reasonCode,
+        'tool_execution_error',
+        'Tool step should have error reason code'
     );
 });
 
-test('weather clarification short-circuits generation and records skipped generation metadata', async () => {
-    let generationCalled = false;
-    const weatherForecastTool: WeatherForecastTool = {
-        fetchForecast: async () => ({
-            toolName: 'weather_forecast',
-            status: 'needs_clarification',
-            request: {
-                location: {
-                    type: 'place_query',
-                    query: 'New York',
-                },
+test('weather clarification short-circuits: no generation, clarification response returned', async () => {
+    let generationCalls = 0;
+    const generationRuntime = createTestRuntime(async () => {
+        generationCalls += 1;
+        return {
+            text: 'should not be generated',
+            model: 'gpt-5-mini',
+            usage: {
+                promptTokens: 10,
+                completionTokens: 5,
+                totalTokens: 15,
+            },
+            provenance: 'Inferred',
+            citations: [],
+        };
+    });
+
+    const result = await runBoundedReviewWorkflow({
+        generationRuntime,
+        generationRequest: {
+            model: 'gpt-5-mini',
+            messages: [
+                { role: 'user', content: 'What is the weather in New York?' },
+            ],
+        },
+        messagesWithHints: [
+            { role: 'user', content: 'What is the weather in New York?' },
+        ],
+        generationStartedAtMs: Date.now(),
+        workflowConfig: {
+            workflowName: 'message_with_review_loop',
+            maxIterations: 0,
+            maxDurationMs: 15000,
+        },
+        workflowPolicy: {
+            enablePlanning: false,
+            enableToolUse: true,
+            enableReplanning: false,
+            enableGeneration: true,
+            enableAssessment: true,
+            enableRevision: true,
+        },
+        contextStepRequest: {
+            integrationName: 'weather_forecast',
+            requested: true,
+            eligible: true,
+            input: { location: 'New York' },
+        },
+        contextStepExecutor: async () => ({
+            executionContext: {
+                toolName: 'weather_forecast',
+                status: 'executed',
             },
             clarification: {
                 reasonCode: 'ambiguous_location',
@@ -218,56 +308,50 @@ test('weather clarification short-circuits generation and records skipped genera
                         id: 'nyc',
                         label: 'New York City, New York, United States',
                     },
+                    { id: 'albany', label: 'Albany, New York, United States' },
                 ],
             },
-            provenance: {
-                provider: 'open-meteo',
-                endpoint: 'mock',
-                requestedAt: '2026-01-01T00:00:00Z',
+        }),
+        captureUsage: (generationResult) => ({
+            model: generationResult.model ?? 'gpt-5-mini',
+            promptTokens: generationResult.usage?.promptTokens ?? 0,
+            completionTokens: generationResult.usage?.completionTokens ?? 0,
+            totalTokens: generationResult.usage?.totalTokens ?? 0,
+            estimatedCost: {
+                inputCostUsd: 0,
+                outputCostUsd: 0,
+                totalCostUsd: 0,
             },
         }),
-    };
-
-    const orchestrator = createChatOrchestrator({
-        generationRuntime: createGenerationRuntime(async (request) => {
-            if (request.maxOutputTokens === PLANNER_TOKEN_SENTINEL) {
-                return {
-                    text: buildWeatherToolIntentPlannerOutput({
-                        location: {
-                            query: 'New York',
-                        },
-                    }),
-                    model: 'gpt-5-mini',
-                };
-            }
-            generationCalled = true;
-            return {
-                text: 'should not be generated',
-                model: request.model,
-                provenance: 'Inferred',
-                citations: [],
-            };
-        }),
-        storeTrace: async () => undefined,
-        buildResponseMetadata,
-        defaultModel: runtimeConfig.modelProfiles.defaultProfileId,
-        recordUsage: () => undefined,
-        weatherForecastTool,
     });
 
-    const response = await orchestrator.runChat(createChatRequest());
-
-    assert.equal(response.action, 'message');
-    assert.equal(generationCalled, false);
-    assert.match(response.message, /Which New York did you mean\?/);
-    const toolEvent = response.metadata.execution?.find(
-        (event) => event.kind === 'tool'
+    assert.equal(
+        result.outcome,
+        'no_generation',
+        'Workflow should not generate when clarification is needed'
     );
-    assert.equal(toolEvent?.toolName, 'weather_forecast');
-    assert.equal(toolEvent?.status, 'executed');
-    assert.equal(toolEvent?.clarification?.reasonCode, 'ambiguous_location');
-    const generationEvent = response.metadata.execution?.find(
-        (event) => event.kind === 'generation'
+    assert.equal(
+        generationCalls,
+        0,
+        'Generation should not be called when clarification is needed'
     );
-    assert.equal(generationEvent?.status, 'skipped');
+    const toolStep = result.workflowLineage.steps.find(
+        (step) => step.stepKind === 'tool'
+    );
+    assert.ok(toolStep, 'Workflow should have a tool step');
+    assert.equal(
+        toolStep?.outcome.status,
+        'executed',
+        'Tool step should be executed'
+    );
+    assert.equal(
+        toolStep?.outcome.signals?.clarificationReasonCode,
+        'ambiguous_location',
+        'Tool step should have clarification reason'
+    );
+    assert.equal(
+        result.contextStepResult?.clarification?.reasonCode,
+        'ambiguous_location',
+        'Context result should have clarification'
+    );
 });

--- a/packages/backend/test/toolExecutionParity.test.ts
+++ b/packages/backend/test/toolExecutionParity.test.ts
@@ -96,7 +96,7 @@ test('weather success flows through workflow context-step: tool step recorded in
             const execution = await weatherForecastTool.fetchForecast(
                 request.input as {
                     location: {
-                        type: string;
+                        type: 'lat_lon';
                         latitude: number;
                         longitude: number;
                     };
@@ -109,7 +109,9 @@ test('weather success flows through workflow context-step: tool step recorded in
                     durationMs: 10,
                 },
                 contextMessages: [
-                    `Weather in ${execution.location.name}: clear skies`,
+                    execution.status === 'ok' && execution.location?.name
+                        ? `Weather in ${execution.location.name}: clear skies`
+                        : 'Weather context: clear skies',
                 ],
             };
         },

--- a/packages/backend/test/toolRegistry.test.ts
+++ b/packages/backend/test/toolRegistry.test.ts
@@ -212,6 +212,8 @@ test('weather adapter passes through needs_clarification result with status exec
                     provider: 'open-meteo',
                     endpoint: 'mock',
                     requestedAt: '2026-01-01T00:00:00Z',
+                    citationUrl: 'https://open-meteo.com/en/docs',
+                    citationLabel: 'Open-Meteo Weather Forecast API',
                 },
             }),
         },
@@ -236,7 +238,7 @@ test('weather adapter passes through needs_clarification result with status exec
                                   label: 'New York City, New York, United States',
                               },
                               {
-                                  id: 'nys',
+                                  id: 'ny_state',
                                   label: 'New York State, United States',
                               },
                           ],
@@ -245,6 +247,8 @@ test('weather adapter passes through needs_clarification result with status exec
                           provider: 'open-meteo',
                           endpoint: 'mock',
                           requestedAt: '2026-01-01T00:00:00Z',
+                          citationUrl: 'https://open-meteo.com/en/docs',
+                          citationLabel: 'Open-Meteo Weather Forecast API',
                       },
                   }),
               }

--- a/packages/backend/test/toolRegistryContextStepAdapter.test.ts
+++ b/packages/backend/test/toolRegistryContextStepAdapter.test.ts
@@ -36,6 +36,8 @@ test('context-step adapter maps weather success to executed context with tool re
                 provider: 'open-meteo',
                 endpoint: 'mock',
                 requestedAt: '2026-01-01T00:00:00Z',
+                citationUrl: 'https://open-meteo.com/en/docs',
+                citationLabel: 'Open-Meteo Weather Forecast API',
             },
         }),
     };
@@ -136,6 +138,8 @@ test('context-step adapter maps weather clarification to executed context with c
                 provider: 'open-meteo',
                 endpoint: 'mock',
                 requestedAt: '2026-01-01T00:00:00Z',
+                citationUrl: 'https://open-meteo.com/en/docs',
+                citationLabel: 'Open-Meteo Weather Forecast API',
             },
         }),
     };

--- a/packages/backend/test/toolRegistryContextStepAdapter.test.ts
+++ b/packages/backend/test/toolRegistryContextStepAdapter.test.ts
@@ -1,0 +1,171 @@
+/**
+ * @description: Verifies tool-registry context-step adapter mapping into workflow context-step executor results.
+ * Confirms weather success, failure, and clarification semantics are preserved.
+ * @footnote-scope: test
+ * @footnote-module: ToolRegistryContextStepAdapterTests
+ * @footnote-risk: medium - Missing coverage could hide mapping drift before workflow timing cutover.
+ * @footnote-ethics: medium - Context-step outcome fidelity is required for transparent fail-open and clarification behavior.
+ */
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import type { WeatherForecastTool } from '../src/services/openMeteoForecastTool.js';
+import { createToolRegistryContextStepExecutor } from '../src/services/contextIntegrations/toolRegistryContextStepAdapter.js';
+
+test('context-step adapter maps weather success to executed context with tool result message', async () => {
+    const weatherForecastTool: WeatherForecastTool = {
+        fetchForecast: async () => ({
+            toolName: 'weather_forecast',
+            status: 'ok',
+            request: {
+                location: {
+                    type: 'lat_lon',
+                    latitude: 39.7684,
+                    longitude: -86.1581,
+                },
+            },
+            location: {
+                name: 'Indianapolis, IN',
+            },
+            forecast: {
+                generatedAt: '2026-01-01T00:00:00Z',
+                updatedAt: '2026-01-01T00:00:00Z',
+                periods: [],
+            },
+            provenance: {
+                provider: 'open-meteo',
+                endpoint: 'mock',
+                requestedAt: '2026-01-01T00:00:00Z',
+            },
+        }),
+    };
+    const contextStepExecutor = createToolRegistryContextStepExecutor({
+        weatherForecastTool,
+    });
+
+    const result = await contextStepExecutor({
+        request: {
+            integrationName: 'weather_forecast',
+            requested: true,
+            eligible: true,
+            input: {
+                location: {
+                    type: 'lat_lon',
+                    latitude: 39.7684,
+                    longitude: -86.1581,
+                },
+            },
+        },
+        workflowId: 'wf_1',
+        workflowName: 'message_with_review_loop',
+        attempt: 1,
+    });
+
+    assert.equal(result.executionContext.toolName, 'weather_forecast');
+    assert.equal(result.executionContext.status, 'executed');
+    assert.equal(result.executionContext.reasonCode, undefined);
+    assert.equal(result.contextMessages?.length, 1);
+    assert.match(
+        result.contextMessages?.[0] ?? '',
+        /BEGIN Backend Tool Result/
+    );
+});
+
+test('context-step adapter preserves weather fail-open failure reason codes', async () => {
+    const weatherForecastTool: WeatherForecastTool = {
+        fetchForecast: async () => {
+            throw new Error('weather upstream unavailable');
+        },
+    };
+    const warnings: Array<{ message: string; meta?: Record<string, unknown> }> =
+        [];
+    const contextStepExecutor = createToolRegistryContextStepExecutor({
+        weatherForecastTool,
+        onWarn: (message, meta) => {
+            warnings.push({ message, meta });
+        },
+    });
+
+    const result = await contextStepExecutor({
+        request: {
+            integrationName: 'weather_forecast',
+            requested: true,
+            eligible: true,
+            input: {
+                location: {
+                    type: 'lat_lon',
+                    latitude: 39.7684,
+                    longitude: -86.1581,
+                },
+            },
+        },
+        workflowId: 'wf_2',
+        workflowName: 'message_with_review_loop',
+        attempt: 1,
+    });
+
+    assert.equal(result.executionContext.toolName, 'weather_forecast');
+    assert.equal(result.executionContext.status, 'failed');
+    assert.equal(result.executionContext.reasonCode, 'tool_execution_error');
+    assert.equal(result.contextMessages, undefined);
+    assert.equal(warnings.length, 1);
+});
+
+test('context-step adapter maps weather clarification to executed context with clarification payload', async () => {
+    const weatherForecastTool: WeatherForecastTool = {
+        fetchForecast: async () => ({
+            toolName: 'weather_forecast',
+            status: 'needs_clarification',
+            request: {
+                location: {
+                    type: 'place_query',
+                    query: 'Springfield',
+                },
+            },
+            clarification: {
+                reasonCode: 'ambiguous_location',
+                question: 'Which Springfield did you mean?',
+                options: [
+                    {
+                        id: 'springfield_il',
+                        label: 'Springfield, Illinois',
+                    },
+                ],
+            },
+            provenance: {
+                provider: 'open-meteo',
+                endpoint: 'mock',
+                requestedAt: '2026-01-01T00:00:00Z',
+            },
+        }),
+    };
+    const contextStepExecutor = createToolRegistryContextStepExecutor({
+        weatherForecastTool,
+    });
+
+    const result = await contextStepExecutor({
+        request: {
+            integrationName: 'weather_forecast',
+            requested: true,
+            eligible: true,
+            input: {
+                location: {
+                    type: 'place_query',
+                    query: 'Springfield',
+                },
+            },
+        },
+        workflowId: 'wf_3',
+        workflowName: 'message_with_review_loop',
+        attempt: 1,
+    });
+
+    assert.equal(result.executionContext.toolName, 'weather_forecast');
+    assert.equal(result.executionContext.status, 'executed');
+    assert.equal(
+        result.executionContext.clarification?.reasonCode,
+        'ambiguous_location'
+    );
+    assert.equal(result.clarification?.reasonCode, 'ambiguous_location');
+    assert.equal(result.contextMessages?.length, 1);
+});

--- a/packages/backend/test/workflowEngine.test.ts
+++ b/packages/backend/test/workflowEngine.test.ts
@@ -47,6 +47,7 @@ const createLimits = (): ExecutionLimits => ({
 
 test('isTransitionAllowed permits only plan/generate from initial state', () => {
     assert.equal(isTransitionAllowed(null, 'plan', permissivePolicy), true);
+    assert.equal(isTransitionAllowed(null, 'tool', permissivePolicy), true);
     assert.equal(isTransitionAllowed(null, 'generate', permissivePolicy), true);
     assert.equal(isTransitionAllowed(null, 'assess', permissivePolicy), false);
 });
@@ -1127,5 +1128,247 @@ test('runBoundedReviewWorkflow does not emit concrete tool steps in current engi
     assert.equal(
         result.workflowLineage.steps.some((step) => step.stepKind === 'tool'),
         false
+    );
+});
+
+test('runBoundedReviewWorkflow executes injected context step and records context artifacts before generation', async () => {
+    const generationRuntime: GenerationRuntime = {
+        kind: 'test-runtime',
+        async generate() {
+            return {
+                text: 'draft',
+                model: 'gpt-5-mini',
+                usage: {
+                    promptTokens: 10,
+                    completionTokens: 5,
+                    totalTokens: 15,
+                },
+                provenance: 'Inferred',
+                citations: [],
+            };
+        },
+    };
+
+    const result = await runBoundedReviewWorkflow({
+        generationRuntime,
+        generationRequest: {
+            model: 'gpt-5-mini',
+            messages: [{ role: 'user', content: 'Need weather summary' }],
+        },
+        messagesWithHints: [
+            { role: 'user', content: 'Need weather summary' },
+            { role: 'system', content: 'hint' },
+        ],
+        generationStartedAtMs: Date.now(),
+        workflowConfig: {
+            workflowName: 'message_with_review_loop',
+            maxIterations: 1,
+            maxDurationMs: 15000,
+        },
+        workflowPolicy: {
+            enablePlanning: false,
+            enableToolUse: true,
+            enableReplanning: false,
+            enableGeneration: true,
+            enableAssessment: true,
+            enableRevision: true,
+        },
+        contextStepRequest: {
+            integrationName: 'weather_forecast',
+            requested: true,
+            eligible: true,
+            input: { location: 'Indianapolis' },
+        },
+        contextStepExecutor: async () => ({
+            executionContext: {
+                toolName: 'weather_forecast',
+                status: 'executed',
+                durationMs: 4,
+            },
+            contextMessages: ['weather_context: clear skies'],
+        }),
+        captureUsage: (generationResult) => ({
+            model: generationResult.model ?? 'gpt-5-mini',
+            promptTokens: generationResult.usage?.promptTokens ?? 0,
+            completionTokens: generationResult.usage?.completionTokens ?? 0,
+            totalTokens: generationResult.usage?.totalTokens ?? 0,
+            estimatedCost: {
+                inputCostUsd: 0,
+                outputCostUsd: 0,
+                totalCostUsd: 0,
+            },
+        }),
+    });
+
+    assert.equal(result.outcome, 'generated');
+    const toolStep = result.workflowLineage.steps.find(
+        (step) => step.stepKind === 'tool'
+    );
+    assert.ok(toolStep);
+    assert.equal(toolStep.outcome.status, 'executed');
+    assert.deepEqual(toolStep.outcome.artifacts, [
+        'weather_context: clear skies',
+    ]);
+});
+
+test('runBoundedReviewWorkflow records failed injected context step with reason and continues fail-open', async () => {
+    const generationRuntime: GenerationRuntime = {
+        kind: 'test-runtime',
+        async generate() {
+            return {
+                text: 'draft',
+                model: 'gpt-5-mini',
+                usage: {
+                    promptTokens: 10,
+                    completionTokens: 5,
+                    totalTokens: 15,
+                },
+                provenance: 'Inferred',
+                citations: [],
+            };
+        },
+    };
+
+    const result = await runBoundedReviewWorkflow({
+        generationRuntime,
+        generationRequest: {
+            model: 'gpt-5-mini',
+            messages: [{ role: 'user', content: 'Need weather summary' }],
+        },
+        messagesWithHints: [{ role: 'user', content: 'Need weather summary' }],
+        generationStartedAtMs: Date.now(),
+        workflowConfig: {
+            workflowName: 'message_with_review_loop',
+            maxIterations: 1,
+            maxDurationMs: 15000,
+        },
+        workflowPolicy: {
+            enablePlanning: false,
+            enableToolUse: true,
+            enableReplanning: false,
+            enableGeneration: true,
+            enableAssessment: true,
+            enableRevision: true,
+        },
+        contextStepRequest: {
+            integrationName: 'weather_forecast',
+            requested: true,
+            eligible: true,
+            input: { location: 'Indianapolis' },
+        },
+        contextStepExecutor: async () => ({
+            executionContext: {
+                toolName: 'weather_forecast',
+                status: 'failed',
+                reasonCode: 'tool_timeout',
+                durationMs: 10,
+            },
+        }),
+        captureUsage: (generationResult) => ({
+            model: generationResult.model ?? 'gpt-5-mini',
+            promptTokens: generationResult.usage?.promptTokens ?? 0,
+            completionTokens: generationResult.usage?.completionTokens ?? 0,
+            totalTokens: generationResult.usage?.totalTokens ?? 0,
+            estimatedCost: {
+                inputCostUsd: 0,
+                outputCostUsd: 0,
+                totalCostUsd: 0,
+            },
+        }),
+    });
+
+    assert.equal(result.outcome, 'generated');
+    const toolStep = result.workflowLineage.steps.find(
+        (step) => step.stepKind === 'tool'
+    );
+    assert.ok(toolStep);
+    assert.equal(toolStep.outcome.status, 'failed');
+    assert.equal(toolStep.reasonCode, 'tool_timeout');
+});
+
+test('runBoundedReviewWorkflow stops before generation when injected context step requires clarification', async () => {
+    let generationCalls = 0;
+    const generationRuntime: GenerationRuntime = {
+        kind: 'test-runtime',
+        async generate() {
+            generationCalls += 1;
+            return {
+                text: 'draft',
+                model: 'gpt-5-mini',
+                usage: {
+                    promptTokens: 10,
+                    completionTokens: 5,
+                    totalTokens: 15,
+                },
+                provenance: 'Inferred',
+                citations: [],
+            };
+        },
+    };
+
+    const result = await runBoundedReviewWorkflow({
+        generationRuntime,
+        generationRequest: {
+            model: 'gpt-5-mini',
+            messages: [{ role: 'user', content: 'Need weather summary' }],
+        },
+        messagesWithHints: [{ role: 'user', content: 'Need weather summary' }],
+        generationStartedAtMs: Date.now(),
+        workflowConfig: {
+            workflowName: 'message_with_review_loop',
+            maxIterations: 0,
+            maxDurationMs: 15000,
+        },
+        workflowPolicy: {
+            enablePlanning: false,
+            enableToolUse: true,
+            enableReplanning: false,
+            enableGeneration: true,
+            enableAssessment: true,
+            enableRevision: true,
+        },
+        contextStepRequest: {
+            integrationName: 'weather_forecast',
+            requested: true,
+            eligible: true,
+            input: { location: 'Springfield' },
+        },
+        contextStepExecutor: async () => ({
+            executionContext: {
+                toolName: 'weather_forecast',
+                status: 'executed',
+            },
+            clarification: {
+                reasonCode: 'ambiguous_location',
+                question: 'Which Springfield did you mean?',
+                options: [
+                    { id: '1', label: 'Springfield, Illinois' },
+                    { id: '2', label: 'Springfield, Missouri' },
+                ],
+            },
+        }),
+        captureUsage: () => ({
+            model: 'gpt-5-mini',
+            promptTokens: 0,
+            completionTokens: 0,
+            totalTokens: 0,
+            estimatedCost: {
+                inputCostUsd: 0,
+                outputCostUsd: 0,
+                totalCostUsd: 0,
+            },
+        }),
+    });
+
+    assert.equal(result.outcome, 'no_generation');
+    assert.equal(generationCalls, 0);
+    const toolStep = result.workflowLineage.steps.find(
+        (step) => step.stepKind === 'tool'
+    );
+    assert.ok(toolStep);
+    assert.equal(toolStep.outcome.status, 'executed');
+    assert.equal(
+        toolStep.outcome.signals?.clarificationReasonCode,
+        'ambiguous_location'
     );
 });


### PR DESCRIPTION
## Summary
- Threaded weather execution through a workflow-owned context-step seam instead of running it directly in orchestration
- Added a provider-neutral context-step adapter around the existing weather/tool registry path
- Kept planner timing, web search, and workflow engine provider-neutral while preserving clarification, failure, and provenance behavior
- Updated workflow docs and rollout status to reflect the new cutover

## Testing
- Added and updated unit tests for workflow context-step execution, adapter mapping, and weather parity
- Verified weather success, failure, clarification, and no-double-execution behavior through backend tests
- Lint and formatting passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Updated architecture and rollout documentation reflecting workflow engine enhancements.

* **Refactor**
  * Reorganized weather forecast tool execution within the workflow system for improved error handling and clarification request management.
  * Enhanced workflow engine to better manage context-based tool interactions with improved fail-safe behavior.

* **Tests**
  * Added and updated tests to validate tool execution parity and context-step adapter functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->