### PR TITLE
Route fast mode through minimal workflow path

### DIFF
--- a/docs/architecture/context-integrations/weather-forecast.md
+++ b/docs/architecture/context-integrations/weather-forecast.md
@@ -47,11 +47,11 @@ Provider ownership:
 Weather context-step execution currently applies only to the
 `bounded-review` profile used by `balanced` and `grounded`.
 
-The `generate-only` profile used by `fast` bypasses the workflow engine, so it
-does not use the context-step path. Weather support there would need separate
-handling. That split is intentional: the fast path is direct single-pass
-generation without the workflow infrastructure that injects context before
-generation.
+The `generate-only` profile used by `fast` runs through the workflow engine
+with a minimal path (one generate step, no assess/revise), but it does not use
+the context-step path. Weather support in fast mode would need separate handling.
+The fast path uses the workflow infrastructure but with a stripped-down profile
+that does not include context injection before generation.
 
 ## Outcome Contract
 

--- a/docs/architecture/workflow.md
+++ b/docs/architecture/workflow.md
@@ -131,7 +131,9 @@ The current chat path looks like this:
 4. Planner runs once in `chatOrchestrator` before workflow execution and generation.
 5. Planner output goes through surface policy, capability policy, and tool
    policy.
-6. `chatService` runs either direct generation or the bounded review loop.
+6. `chatService` runs the workflow engine with the profile selected for the mode:
+    - `fast` uses the `generate-only` profile (one generate step, no assess/revise)
+    - `balanced` and `grounded` use the `bounded-review` profile (generate -> assess -> revise loop)
 7. Response metadata records mode, planner influence, workflow lineage, cost,
    and trace or provenance fields.
 

--- a/packages/backend/src/services/workflowProfileRegistry.ts
+++ b/packages/backend/src/services/workflowProfileRegistry.ts
@@ -165,7 +165,7 @@ const WORKFLOW_MODE_BEHAVIOR_MAP: Readonly<
         executionContractPresetId: 'fast-direct',
         workflowProfileClass: 'direct',
         workflowProfileId: 'generate-only',
-        workflowExecution: 'disabled',
+        workflowExecution: 'always',
         reviewPass: 'excluded',
         reviseStep: 'disallowed',
         evidencePosture: 'minimal',

--- a/packages/backend/test/chatService.test.ts
+++ b/packages/backend/test/chatService.test.ts
@@ -1305,7 +1305,7 @@ test('runChatMessages maps planner execution context into a workflow planner ste
     );
 });
 
-test('runChatMessages executes fast workflow mode as direct generation without workflow lineage', async () => {
+test('runChatMessages executes fast workflow mode as minimal workflow with one generate step', async () => {
     let generationCalls = 0;
     let capturedWorkflow:
         | ResponseMetadataRuntimeContext['workflow']
@@ -1391,8 +1391,13 @@ test('runChatMessages executes fast workflow mode as direct generation without w
 
     assert.equal(response.message, 'generate-only response');
     assert.equal(generationCalls, 1);
-    assert.equal(capturedWorkflowRunConfig, undefined);
-    assert.equal(capturedWorkflow, undefined);
+    assert.ok(capturedWorkflowRunConfig !== undefined);
+    assert.equal(
+        capturedWorkflowRunConfig?.workflowName,
+        'message_generate_only'
+    );
+    assert.ok(capturedWorkflow !== undefined);
+    assert.equal(capturedWorkflow?.workflowName, 'message_generate_only');
 });
 
 test('runChatMessages handles surfaced no-generation reasons without runtime fallback generation', async () => {
@@ -1787,13 +1792,13 @@ test('runChatMessages keeps workflow execution policy gated by the execution con
 
 test('runChatMessages records workflow mode decision in metadata and applies fast behavior', async () => {
     let reviewWorkflowCalls = 0;
-    let directGenerationCalls = 0;
+    let workflowGenerationCalls = 0;
     const generationRuntime: GenerationRuntime = {
         kind: 'test-runtime',
         async generate() {
-            directGenerationCalls += 1;
+            workflowGenerationCalls += 1;
             return {
-                text: 'direct mode response',
+                text: 'workflow mode response',
                 model: 'gpt-5-mini',
                 usage: {
                     promptTokens: 10,
@@ -1819,9 +1824,36 @@ test('runChatMessages records workflow mode decision in metadata and applies fas
         },
         runReviewWorkflow: async () => {
             reviewWorkflowCalls += 1;
-            throw new Error(
-                'runReviewWorkflow should not execute in fast mode'
-            );
+            return {
+                outcome: 'generated',
+                generationResult: await generationRuntime.generate({
+                    messages: [],
+                    model: 'gpt-5-mini',
+                }),
+                workflowLineage: {
+                    workflowId: 'wf_fast',
+                    workflowName: 'message_generate_only',
+                    status: 'completed',
+                    terminationReason: 'goal_satisfied',
+                    stepCount: 1,
+                    maxSteps: 1,
+                    maxDurationMs: 15000,
+                    steps: [
+                        {
+                            stepId: 'step_1',
+                            attempt: 1,
+                            stepKind: 'generate',
+                            startedAt: new Date().toISOString(),
+                            finishedAt: new Date().toISOString(),
+                            durationMs: 10,
+                            outcome: {
+                                status: 'executed',
+                                summary: 'Generated response.',
+                            },
+                        },
+                    ],
+                },
+            } satisfies RunBoundedReviewWorkflowResult;
         },
     });
 
@@ -1830,14 +1862,14 @@ test('runChatMessages records workflow mode decision in metadata and applies fas
         conversationSnapshot: 'Summarize this.',
     });
 
-    assert.equal(response.message, 'direct mode response');
-    assert.equal(directGenerationCalls, 1);
-    assert.equal(reviewWorkflowCalls, 0);
+    assert.equal(response.message, 'workflow mode response');
+    assert.equal(workflowGenerationCalls, 1);
+    assert.equal(reviewWorkflowCalls, 1);
     assert.equal(response.metadata.workflowMode?.modeId, 'fast');
     assert.equal(response.metadata.workflowMode?.initial_mode, 'fast');
     assert.equal(
         response.metadata.workflowMode?.behavior.workflowExecution,
-        'disabled'
+        'always'
     );
     assert.equal(
         response.metadata.workflowMode?.behavior.evidencePosture,

--- a/packages/backend/test/workflowProfileRegistry.test.ts
+++ b/packages/backend/test/workflowProfileRegistry.test.ts
@@ -116,7 +116,7 @@ test('resolveWorkflowRuntimeConfig applies forceWorkflowExecution and review-loo
         maxDurationMs: 9000,
     });
     assert.equal(fastRuntimeConfig.profileId, 'generate-only');
-    assert.equal(fastRuntimeConfig.workflowExecutionEnabled, false);
+    assert.equal(fastRuntimeConfig.workflowExecutionEnabled, true);
     assert.equal(fastRuntimeConfig.workflowExecutionLimits.maxWorkflowSteps, 1);
     assert.equal(
         fastRuntimeConfig.workflowExecutionLimits.maxDeliberationCalls,


### PR DESCRIPTION
## Summary

- Routes fast mode through the workflow engine using the existing generate-only profile
- Fast mode now produces workflow lineage with a single generate step
- Removes the direct-generate bypass that existed for fast mode
- All modes (fast/balanced/grounded) now use the workflow engine consistently

## Changes

### Core Change
- workflowProfileRegistry.ts: Changed workflowExecution from disabled to always for fast mode

### Tests Updated
- workflowProfileRegistry.test.ts: Updated expectation for workflowExecutionEnabled to true
- chatService.test.ts: Updated 2 tests to expect workflow execution and lineage instead of direct generation

### Documentation Updated
- docs/architecture/workflow.md: Clarified runtime flow for all modes
- docs/architecture/context-integrations/weather-forecast.md: Updated to describe fast as minimal workflow path

## Behavior

| Aspect | Before | After |
|--------|--------|-------|
| Fast mode workflow execution | Disabled (bypassed) | Enabled (workflow engine) |
| Fast mode generation calls | 1 direct call | 1 call via workflow |
| Assess/revise | Not run | Not run (profile-based) |
| Workflow lineage | None | Single generate step |
| Planner execution | Before workflow | Unchanged |

## Validation

All tests pass:
- pnpm lint
- pnpm validate-footnote-tags (436 files)
- Backend build
- 45 related tests
- Docker build
- pnpm review (0 errors, 0 warnings)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified fast mode workflow behavior: now executes through minimal workflow infrastructure (generate-only path) without assessment and revision steps, rather than completely bypassing the workflow engine.
  * Updated workflow execution mode descriptions for balanced and grounded modes.
  * Noted that weather context injection in fast mode requires separate handling due to exclusion of context-step processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->