### PR TITLE
feat(workflow): add planner workflow groundwork seams

### DIFF
--- a/.devin/wiki.json
+++ b/.devin/wiki.json
@@ -110,7 +110,9 @@
                 "packages/api-client/src",
                 "packages/contracts/src",
                 "docs/api/openapi.yaml",
-                "docs/architecture/prompt-resolution.md"
+                "docs/architecture/prompt-resolution.md",
+                "docs/architecture/workflow.md",
+                "docs/architecture/context-integrations/README.md"
             ],
             "page_notes": [
                 {
@@ -123,6 +125,14 @@
                 },
                 {
                     "content": "Include prompt resolution order in the architecture page: start with shared prompts, apply optional `PROMPT_CONFIG_PATH` overrides, then choose one active persona from `BOT_PROFILE_*` settings.",
+                    "author": "Maintainer"
+                },
+                {
+                    "content": "Workflow is the current execution skeleton for chat modes. See the Workflow page for mode/profile details.",
+                    "author": "Maintainer"
+                },
+                {
+                    "content": "Context integrations bring external context (like weather) into workflows without giving integrations policy authority. See the Context Integrations page.",
                     "author": "Maintainer"
                 }
             ]
@@ -143,6 +153,10 @@
                 },
                 {
                     "content": "Include provenance, evidence/freshness scores, risk tier, tradeoff count, citations, chain hash, stale-after behavior, trace retrieval, and trace display.",
+                    "author": "Maintainer"
+                },
+                {
+                    "content": "Also define: workflow mode (fast/balanced/grounded), workflow profile (generate-only/bounded-review), context step (injected pre-generation context), planner result applier (policy-application seam), terminal_action (planner early exit: ignore/react/image).",
                     "author": "Maintainer"
                 }
             ]
@@ -215,6 +229,79 @@
             ]
         },
         {
+            "title": "Workflow",
+            "purpose": "Document workflow modes, profiles, engine behavior, and where planner and context steps fit into the execution path.",
+            "parent": "Foundations",
+            "entrypoints": [
+                "docs/architecture/workflow.md",
+                "docs/status/workflow-engine-rollout-status.md",
+                "packages/backend/src/services/workflowEngine.ts",
+                "packages/backend/src/services/workflowProfileRegistry.ts",
+                "packages/backend/src/services/workflowProfileContract.ts",
+                "packages/backend/test/workflowEngine.test.ts",
+                "packages/backend/test/workflowProfileRegistry.test.ts"
+            ],
+            "page_notes": [
+                {
+                    "content": "Workflow is the step pattern Footnote uses to answer a request. Keep the page flow-first, showing one request moving through the workflow.",
+                    "author": "Maintainer"
+                },
+                {
+                    "content": "fast mode uses generate-only profile (single-pass generation). balanced and grounded modes use bounded-review profile (generate -> assess -> revise).",
+                    "author": "Maintainer"
+                },
+                {
+                    "content": "workflowEngine owns step timing and lineage, not provider policy. The engine decides step legality, enforces limits, and records termination reasons.",
+                    "author": "Maintainer"
+                },
+                {
+                    "content": "Planner still runs before workflow execution in current implementation. Planner output goes through policy application (PlannerResultApplier) before reaching generation.",
+                    "author": "Maintainer"
+                },
+                {
+                    "content": "weather_forecast is the first concrete context-step integration, executing before the generate step in bounded-review workflows.",
+                    "author": "Maintainer"
+                }
+            ]
+        },
+        {
+            "title": "Context Integrations",
+            "purpose": "Document how Footnote brings external context into workflows without giving integrations policy authority.",
+            "parent": "Foundations",
+            "entrypoints": [
+                "docs/architecture/context-integrations/README.md",
+                "docs/architecture/context-integrations/weather-forecast.md",
+                "docs/proposals/web-search-context-integration.md",
+                "packages/backend/src/services/contextIntegrations/toolRegistryContextStepAdapter.ts",
+                "packages/backend/src/services/openMeteoForecastTool.ts",
+                "packages/backend/src/services/tools/weatherForecastToolAdapter.ts",
+                "packages/backend/test/toolRegistryContextStepAdapter.test.ts",
+                "packages/backend/test/openMeteoForecastTool.test.ts"
+            ],
+            "page_notes": [
+                {
+                    "content": "Context integrations add evidence and context without owning execution policy. The backend decides routing, limits, and final response behavior.",
+                    "author": "Maintainer"
+                },
+                {
+                    "content": "weather_forecast is implemented as a workflow context-step integration. It executes before the generate step and can inject context into the generation prompt.",
+                    "author": "Maintainer"
+                },
+                {
+                    "content": "web_search is proposal/future work, not implemented as context-step execution yet. See the proposal for intended provider-neutral direction.",
+                    "author": "Maintainer"
+                },
+                {
+                    "content": "TrustGraph uses a separate evidence-ingestion seam, not the workflow context-step path. See context-integrations/trustgraph.md.",
+                    "author": "Maintainer"
+                },
+                {
+                    "content": "Search discovery is distinct from source reading. Discovery provides candidate sources; reading and citing sources is a later, stronger step.",
+                    "author": "Maintainer"
+                }
+            ]
+        },
+        {
             "title": "Packages",
             "purpose": "Group the major code areas by package so contributors can quickly find where features live and which surfaces they affect.",
             "entrypoints": [
@@ -277,6 +364,10 @@
                 {
                     "content": "Call out forward direction: this package is not limited to chat. It is the execution substrate for multiple backend-owned task types as provider capability expands.",
                     "author": "Maintainer"
+                },
+                {
+                    "content": "Model-native search is distinct from explicit context integrations like weather_forecast. Runtime search behavior is not equivalent to provider-neutral search integrations.",
+                    "author": "Maintainer"
                 }
             ]
         },
@@ -336,7 +427,14 @@
             "entrypoints": [
                 "packages/backend/src",
                 "server.js",
-                "docs/api/openapi.yaml"
+                "docs/api/openapi.yaml",
+                "packages/backend/src/handlers/webhook.ts",
+                "packages/backend/src/handlers/blog.ts",
+                "packages/backend/src/storage/blogStore.ts",
+                "packages/backend/src/storage/incidents/sqliteIncidentStore.ts",
+                "packages/backend/src/utils/pseudonymization.ts",
+                "packages/backend/test/incidentStore.test.ts",
+                "packages/backend/test/pseudonymization.test.ts"
             ],
             "page_notes": [
                 {
@@ -345,6 +443,10 @@
                 },
                 {
                     "content": "Describe runtime composition as a backend responsibility. The backend builds and selects the generation runtime, but it still owns the public chat contract and all user-facing provenance semantics.",
+                    "author": "Maintainer"
+                },
+                {
+                    "content": "Webhook and blog ingestion are backend support flows. Incident storage and pseudonymization are also backend support areas. See the handlers and storage modules for these features.",
                     "author": "Maintainer"
                 }
             ]
@@ -358,6 +460,14 @@
                 "packages/backend/src/services/chatOrchestrator.ts",
                 "packages/backend/src/services/chatService.ts",
                 "packages/backend/src/services/chatPlanner.ts",
+                "packages/backend/src/services/workflowEngine.ts",
+                "packages/backend/src/services/workflowProfileRegistry.ts",
+                "packages/backend/src/services/workflowProfileContract.ts",
+                "packages/backend/src/services/chatOrchestrator/plannerResultApplier.ts",
+                "packages/backend/src/services/chatService/postPlanAssembly.ts",
+                "packages/backend/src/services/chatService/plannerActionOutcome.ts",
+                "packages/backend/src/services/plannerWorkflowSeams.ts",
+                "packages/backend/src/services/contextIntegrations/toolRegistryContextStepAdapter.ts",
                 "packages/agent-runtime/src",
                 "packages/backend/src/services/responseMetadataHeuristics.ts",
                 "packages/contracts/src/web/types.ts",
@@ -374,6 +484,18 @@
                 },
                 {
                     "content": "Update this page for the runtime seam: planner decisions stay in backend, generation runs through `@footnote/agent-runtime`, and VoltAgent handles chat text generation.",
+                    "author": "Maintainer"
+                },
+                {
+                    "content": "Chat requests now route through workflowEngine. fast uses generate-only profile; balanced and grounded use bounded-review profile.",
+                    "author": "Maintainer"
+                },
+                {
+                    "content": "Planner timing is still pre-workflow in current implementation. Planner output remains advisory and goes through policy application before execution.",
+                    "author": "Maintainer"
+                },
+                {
+                    "content": "weather_forecast uses the workflow context-step path to inject context before generation in bounded-review modes.",
                     "author": "Maintainer"
                 }
             ]
@@ -426,45 +548,8 @@
                 }
             ]
         },
-        {
-            "title": "Webhook & Blog Ingestion",
-            "purpose": "Document backend webhook ingestion and blog serving, including GitHub signature validation, storage behavior, and web consumption paths.",
-            "parent": "Backend",
-            "entrypoints": [
-                "packages/backend/src/handlers/webhook.ts",
-                "packages/backend/src/handlers/blog.ts",
-                "packages/backend/src/storage/blogStore.ts",
-                "packages/web/src/utils/blog.ts",
-                "docs/api/openapi.yaml"
-            ],
-            "page_notes": [
-                {
-                    "content": "Keep this page operational. Show trusted input, persisted fields, and how malformed webhook payloads are handled safely.",
-                    "author": "Maintainer"
-                },
-                {
-                    "content": "Link to web blog pages so readers can follow the end-to-end ingestion-to-render flow.",
-                    "author": "Maintainer"
-                }
-            ]
-        },
-        {
-            "title": "Incidents",
-            "purpose": "Explain how incident records, audit events, and pseudonymized identifiers are stored and tested in the backend.",
-            "parent": "Backend",
-            "entrypoints": [
-                "packages/backend/src/storage/incidents/sqliteIncidentStore.ts",
-                "packages/backend/src/utils/pseudonymization.ts",
-                "packages/backend/test/incidentStore.test.ts",
-                "packages/backend/test/pseudonymization.test.ts"
-            ],
-            "page_notes": [
-                {
-                    "content": "Be clear about why Discord-facing identifiers are pseudonymized, where raw IDs must not appear, and how tests enforce those expectations.",
-                    "author": "Maintainer"
-                }
-            ]
-        },
+        
+        
         {
             "title": "Config",
             "purpose": "Document backend configuration loading, environment bootstrap, public config exposure, and failure behavior when config is incomplete.",
@@ -608,11 +693,21 @@
             "entrypoints": [
                 "packages/web/src",
                 "packages/web/src/App.tsx",
-                "packages/web/src/utils/api.ts"
+                "packages/web/src/utils/api.ts",
+                "packages/web/src/pages/BlogListPage.tsx",
+                "packages/web/src/pages/BlogPostPage.tsx",
+                "packages/web/src/components/BlogPostCard.tsx",
+                "packages/web/src/components/BlogProvenance.tsx",
+                "packages/web/src/utils/blog.ts",
+                "packages/web/src/pages/EmbedPage.tsx"
             ],
             "page_notes": [
                 {
                     "content": "Keep this page user-facing. Describe what users can do in the web app before diving into individual pages and components.",
+                    "author": "Maintainer"
+                },
+                {
+                    "content": "Blog and Embed are secondary web surfaces. Blog covers list pages, post rendering, provenance display, and fetch utilities. Embed covers iframe sizing and external integrations.",
                     "author": "Maintainer"
                 }
             ]
@@ -649,39 +744,7 @@
                 }
             ]
         },
-        {
-            "title": "Blog",
-            "purpose": "Document the web blog experience, including list pages, post rendering, provenance display, and supporting fetch utilities.",
-            "parent": "Web",
-            "entrypoints": [
-                "packages/web/src/pages/BlogListPage.tsx",
-                "packages/web/src/pages/BlogPostPage.tsx",
-                "packages/web/src/components/BlogPostCard.tsx",
-                "packages/web/src/components/BlogProvenance.tsx",
-                "packages/web/src/utils/blog.ts"
-            ],
-            "page_notes": [
-                {
-                    "content": "Keep this page lightweight. The blog is a secondary surface, so explain it clearly without letting it overshadow chat, traces, and provenance.",
-                    "author": "Maintainer"
-                }
-            ]
-        },
-        {
-            "title": "Embed",
-            "purpose": "Document the embeddable web surface and how iframe sizing, hosting expectations, and external integrations work.",
-            "parent": "Web",
-            "entrypoints": [
-                "packages/web/src/pages/EmbedPage.tsx",
-                "packages/web/src/utils/api.ts"
-            ],
-            "page_notes": [
-                {
-                    "content": "Explain the user-facing embed experience, then describe the messaging and sizing behavior that make it work across host pages.",
-                    "author": "Maintainer"
-                }
-            ]
-        },
+        
         {
             "title": "OpenAPI",
             "purpose": "Document how the authoritative OpenAPI spec connects to code, runtime schemas, and validation tooling across the repository.",

--- a/docs/architecture/workflow.md
+++ b/docs/architecture/workflow.md
@@ -314,7 +314,8 @@ The policy defines capability toggles such as `enablePlanning`,
 and `enableRevision`.
 
 The default limits define hard caps such as `maxWorkflowSteps`, `maxToolCalls`,
-`maxDeliberationCalls`, `maxTokensTotal`, and `maxDurationMs`.
+`maxPlanCycles`, `maxReviewCycles`, `maxDeliberationCalls` (compatibility
+field), `maxTokensTotal`, and `maxDurationMs`.
 
 Optional profile extensions can support review and revision behavior, but they
 cannot override required no-generation classification, disposition, or
@@ -355,12 +356,12 @@ The shared workflow vocabulary includes `plan`, `tool`, `generate`, `assess`,
 
 ### Current ownership
 
-| Component                        | Owner   | Notes                                                                                               |
-| -------------------------------- | ------- | --------------------------------------------------------------------------------------------------- |
-| `workflowEngine`                 | Core    | Owns bounded-review steps (`generate`, `assess`, `revise`) and injected context-step execution      |
-| `chatOrchestrator`               | Core    | Owns planner execution (pre-workflow), mode/profile/contract resolution, tool intent construction   |
-| `chatService`                    | Core    | Invokes workflowEngine, handles context-step short-circuit responses (clarification, failure)       |
-| `toolRegistryContextStepAdapter` | Adapter | Keeps workflowEngine provider-neutral while mapping tool-registry execution into context-step shape |
+| Component                        | Owner   | Notes                                                                                                               |
+| -------------------------------- | ------- | ------------------------------------------------------------------------------------------------------------------- |
+| `workflowEngine`                 | Core    | Owns bounded-review steps (`generate`, `assess`, `revise`) and injected context-step execution                      |
+| `chatOrchestrator`               | Core    | Owns deterministic bootstrap (mode/profile/contract), planner policy application seam, and tool intent construction |
+| `chatService`                    | Core    | Invokes workflowEngine, handles context-step short-circuit responses (clarification, failure)                       |
+| `toolRegistryContextStepAdapter` | Adapter | Keeps workflowEngine provider-neutral while mapping tool-registry execution into context-step shape                 |
 
 ### Context-step executor pattern
 
@@ -389,6 +390,11 @@ The adapter `toolRegistryContextStepAdapter.ts` implements this pattern for
 Planner runs before workflow execution in `chatOrchestrator`. Planner
 output goes through surface policy, capability policy, and tool policy before
 reaching the chat service.
+
+Groundwork now includes an injected planner policy-application seam
+(`PlannerResultApplier`) that keeps planner output advisory while preserving
+backend policy authority. Planner timing is still pre-workflow in current
+runtime behavior.
 
 Planner lineage can appear in workflow metadata as a `plan` step when that
 metadata exists for the run. That is a lineage bridge, not a change in planner
@@ -425,7 +431,8 @@ Workflow limits are backend-enforced stops, not model suggestions.
 `WorkflowPolicy` defines legal transitions and capability toggles.
 
 `ExecutionLimits` defines hard caps: `maxWorkflowSteps`, `maxToolCalls`,
-`maxDeliberationCalls`, `maxTokensTotal`, and `maxDurationMs`.
+`maxPlanCycles`, `maxReviewCycles`, `maxDeliberationCalls` (compatibility),
+`maxTokensTotal`, and `maxDurationMs`.
 
 Model output can recommend transitions only where policy allows.
 

--- a/docs/architecture/workflow.md
+++ b/docs/architecture/workflow.md
@@ -396,6 +396,10 @@ Groundwork now includes an injected planner policy-application seam
 backend policy authority. Planner timing is still pre-workflow in current
 runtime behavior.
 
+Post-plan planner payload/message assembly now runs through a bounded
+`chatService` seam (`assemblePostPlanGenerationInput`) so message construction
+is no longer embedded directly in orchestration branches.
+
 Planner lineage can appear in workflow metadata as a `plan` step when that
 metadata exists for the run. That is a lineage bridge, not a change in planner
 authority. Planner timing and execution are still not workflow-engine-owned.

--- a/docs/status/workflow-engine-rollout-status.md
+++ b/docs/status/workflow-engine-rollout-status.md
@@ -4,23 +4,35 @@ This file tracks the remaining rollout work. The canonical architecture is in
 [docs/architecture/workflow.md](../architecture/workflow.md) and
 [docs/architecture/context-integrations/README.md](../architecture/context-integrations/README.md).
 
+## Completed Groundwork
+
+- **Planning/review budgets**: Completed. Workflow limits now separate planning
+  cycles from review cycles through `maxPlanCycles` and `maxReviewCycles`.
+  `maxDeliberationCalls` remains as a compatibility field.
+
+- **Planner policy application seam**: Completed. `PlannerResultApplier`
+  centralizes post-planner policy application such as surface coercion,
+  generation override merge, single-tool policy, profile resolution, and
+  context-step request derivation.
+
+- **Planner timing**: Still pending. Planner still runs before workflow
+  execution in `chatOrchestrator`. The next blocker is moving post-plan message
+  assembly into `chatService`, so workflow-owned planner timing can be
+  introduced without moving policy logic into `workflowEngine`.
+
 ## Pending Work
 
-- **Planning and review budgets**: Split the old broad deliberation budget into
-  separate planning and review limits, such as `maxPlanCycles` and
-  `maxReviewCycles`. Planning and review have different jobs, costs, and
-  failure modes, so they should not share one vague budget.
+- **Planner timing cutover**: Move planner invocation into workflow-owned timing
+  through an injected planner executor after post-plan message assembly is moved
+  into `chatService`.
 
-- **Planner step ownership**: Planner still runs before workflow execution in
-  `chatOrchestrator`. The desired shape is a hybrid workflow step: workflow
-  owns planner timing through an injected planner executor, while mode,
-  Execution Contract, profile, and policy layers remain authoritative. Planner
-  output stays advisory.
+- **Post-plan message assembly**: Move generation message/payload assembly to a
+  bounded `chatService` seam that can consume `PlannerResultApplier` output.
 
 - **Planner lineage cleanup**: Planner lineage currently bridges into workflow
-  metadata after planner execution. Before moving planner timing, consolidate
-  planner step recording so there is one canonical path and no duplicate plan
-  events.
+metadata after planner execution. Before moving planner timing, consolidate
+planner step recording so there is one canonical path and no duplicate plan
+events.
 
 - **Tool/context-step expansion**: Only `weather_forecast` uses the workflow
   context-step path. The infrastructure exists for additional tools, but none
@@ -30,11 +42,6 @@ This file tracks the remaining rollout work. The canonical architecture is in
   current search/runtime path. The proposal in
   [docs/proposals/web-search-context-integration.md](../proposals/web-search-context-integration.md)
   describes the intended provider-neutral direction.
-
-- **maxIterations=0 semantics**: When `maxIterations=0`, the workflow completes
-  after initial generation with `terminationReason: 'goal_satisfied'`. This is
-  single-pass generation without a review loop. Documentation follow-up is
-  optional.
 
 ## Related Docs
 

--- a/docs/status/workflow-engine-rollout-status.md
+++ b/docs/status/workflow-engine-rollout-status.md
@@ -16,23 +16,26 @@ This file tracks the remaining rollout work. The canonical architecture is in
   context-step request derivation.
 
 - **Planner timing**: Still pending. Planner still runs before workflow
-  execution in `chatOrchestrator`. The next blocker is moving post-plan message
-  assembly into `chatService`, so workflow-owned planner timing can be
-  introduced without moving policy logic into `workflowEngine`.
+  execution in `chatOrchestrator`.
+
+- **Post-plan message assembly seam**: Completed. Planner-applied
+  message/payload assembly now runs through a bounded `chatService` seam so the
+  planner payload and generation snapshot assembly are no longer embedded in
+  the orchestration branch.
 
 ## Pending Work
 
 - **Planner timing cutover**: Move planner invocation into workflow-owned timing
-  through an injected planner executor after post-plan message assembly is moved
-  into `chatService`.
-
-- **Post-plan message assembly**: Move generation message/payload assembly to a
-  bounded `chatService` seam that can consume `PlannerResultApplier` output.
+  through an injected planner executor.
+  Remaining blocker: non-message planner actions (`react`, `ignore`, `image`)
+  and early orchestration exits are still handled before workflow execution, so
+  timing cutover needs a bounded workflow/transport seam for those outcomes
+  without moving policy logic into `workflowEngine`.
 
 - **Planner lineage cleanup**: Planner lineage currently bridges into workflow
-metadata after planner execution. Before moving planner timing, consolidate
-planner step recording so there is one canonical path and no duplicate plan
-events.
+  metadata after planner execution. Before moving planner timing, consolidate
+  planner step recording so there is one canonical path and no duplicate plan
+  events.
 
 - **Tool/context-step expansion**: Only `weather_forecast` uses the workflow
   context-step path. The infrastructure exists for additional tools, but none

--- a/packages/backend/src/services/chatOrchestrator.ts
+++ b/packages/backend/src/services/chatOrchestrator.ts
@@ -55,7 +55,10 @@ import {
 } from './chatOrchestrator/evaluatorCoordination.js';
 import { type PlannerPayloadChatPlan } from './chatOrchestrator/plannerPayload.js';
 import { assemblePostPlanGenerationInput } from './chatService/postPlanAssembly.js';
-import { resolvePlannerActionOutcome } from './chatService/plannerActionOutcome.js';
+import {
+    resolvePlannerActionOutcome,
+    plannerTerminalActionToResponse,
+} from './chatService/plannerActionOutcome.js';
 import {
     buildControlObservabilityEnvelope,
     emitControlObservabilityEnvelope,
@@ -720,6 +723,22 @@ export const createChatOrchestrator = ({
                 : executionPlan.safetyTier;
         const executionContractScopeTuple =
             buildExecutionContractScopeTuple(normalizedRequest);
+
+        if (plannerActionOutcome.kind === 'terminal_action') {
+            if (plannerActionOutcome.fallbackReason !== undefined) {
+                fallbackReasons.push(plannerActionOutcome.fallbackReason);
+            }
+            if (plannerActionOutcome.warningMessage !== undefined) {
+                chatOrchestratorLogger.warn(
+                    plannerActionOutcome.warningMessage
+                );
+            }
+            const terminalResponse = plannerTerminalActionToResponse(
+                plannerActionOutcome.terminalAction
+            );
+            return terminalResponse;
+        }
+
         const postPlanAssembly = assemblePostPlanGenerationInput({
             systemPrompt: promptLayers.systemPrompt,
             personaPrompt,
@@ -801,16 +820,6 @@ export const createChatOrchestrator = ({
             },
             steerabilityControls,
         });
-        if (plannerActionOutcome.kind === 'terminal_action') {
-            if (plannerActionOutcome.fallbackReason !== undefined) {
-                fallbackReasons.push(plannerActionOutcome.fallbackReason);
-            }
-            if (plannerActionOutcome.warningMessage !== undefined) {
-                chatOrchestratorLogger.warn(
-                    plannerActionOutcome.warningMessage
-                );
-            }
-        }
         if (response.kind === 'terminal_action') {
             const terminalResponse =
                 response.response ??

--- a/packages/backend/src/services/chatOrchestrator.ts
+++ b/packages/backend/src/services/chatOrchestrator.ts
@@ -53,9 +53,9 @@ import {
     runDeterministicEvaluator,
     type EvaluatorExecutionContext,
 } from './chatOrchestrator/evaluatorCoordination.js';
-import { resolveNonMessagePlannerAction } from './chatOrchestrator/actionResolution.js';
 import { type PlannerPayloadChatPlan } from './chatOrchestrator/plannerPayload.js';
 import { assemblePostPlanGenerationInput } from './chatService/postPlanAssembly.js';
+import { resolvePlannerActionOutcome } from './chatService/plannerActionOutcome.js';
 import {
     buildControlObservabilityEnvelope,
     emitControlObservabilityEnvelope,
@@ -556,27 +556,32 @@ export const createChatOrchestrator = ({
             }),
         };
 
-        const nonMessageResponse = resolveNonMessagePlannerAction(
-            {
-                executionPlan,
-                normalizedRequest,
-                fallbackRollupSelectionSource,
-            },
-            {
-                fallbackReasons,
-                emitFallbackRollup,
-                notifyBreakerEvent,
-                warn: (message, meta) => {
-                    chatOrchestratorLogger.warn(message, meta);
-                },
+        const plannerActionOutcome = resolvePlannerActionOutcome({
+            executionPlan,
+            normalizedRequest,
+        });
+        if (plannerActionOutcome.kind === 'terminal_action') {
+            if (plannerActionOutcome.fallbackReason !== undefined) {
+                fallbackReasons.push(plannerActionOutcome.fallbackReason);
             }
-        );
-        if (nonMessageResponse) {
-            emitControlObservability({
-                responseAction: nonMessageResponse.action,
+            if (plannerActionOutcome.warningMessage !== undefined) {
+                chatOrchestratorLogger.warn(
+                    plannerActionOutcome.warningMessage
+                );
+            }
+            notifyBreakerEvent({
+                responseId: null,
+                responseAction:
+                    plannerActionOutcome.terminalAction.responseAction,
                 responseModality: executionPlan.modality,
             });
-            return nonMessageResponse;
+            emitFallbackRollup(fallbackRollupSelectionSource);
+            emitControlObservability({
+                responseAction:
+                    plannerActionOutcome.terminalAction.responseAction,
+                responseModality: executionPlan.modality,
+            });
+            return plannerActionOutcome.terminalAction.response;
         }
         const promptLayers = renderConversationPromptLayers(
             normalizedRequest.surface === 'discord'

--- a/packages/backend/src/services/chatOrchestrator.ts
+++ b/packages/backend/src/services/chatOrchestrator.ts
@@ -560,29 +560,6 @@ export const createChatOrchestrator = ({
             executionPlan,
             normalizedRequest,
         });
-        if (plannerActionOutcome.kind === 'terminal_action') {
-            if (plannerActionOutcome.fallbackReason !== undefined) {
-                fallbackReasons.push(plannerActionOutcome.fallbackReason);
-            }
-            if (plannerActionOutcome.warningMessage !== undefined) {
-                chatOrchestratorLogger.warn(
-                    plannerActionOutcome.warningMessage
-                );
-            }
-            notifyBreakerEvent({
-                responseId: null,
-                responseAction:
-                    plannerActionOutcome.terminalAction.responseAction,
-                responseModality: executionPlan.modality,
-            });
-            emitFallbackRollup(fallbackRollupSelectionSource);
-            emitControlObservability({
-                responseAction:
-                    plannerActionOutcome.terminalAction.responseAction,
-                responseModality: executionPlan.modality,
-            });
-            return plannerActionOutcome.terminalAction.response;
-        }
         const promptLayers = renderConversationPromptLayers(
             normalizedRequest.surface === 'discord'
                 ? 'discord-chat'
@@ -762,7 +739,7 @@ export const createChatOrchestrator = ({
         // By the time we call ChatService, planner output and request overrides
         // have already been folded into one concrete profile and generation
         // plan.
-        const response = await chatService.runChatMessages({
+        const response = await chatService.runChatMessagesWithOutcome({
             messages: postPlanAssembly.conversationMessages,
             conversationSnapshot: postPlanAssembly.conversationSnapshot,
             orchestrationStartedAtMs: orchestrationStartedAt,
@@ -774,6 +751,7 @@ export const createChatOrchestrator = ({
             generation: executionPlan.generation,
             workflowModeId: workflowModeResolution.modeDecision.modeId,
             toolRequest: toolRequestContext,
+            plannerActionOutcome,
             contextStepRequest: weatherContextStepRequest,
             contextStepExecutor: weatherContextStepExecutor,
             latestUserInput: normalizedRequest.latestUserInput,
@@ -823,6 +801,54 @@ export const createChatOrchestrator = ({
             },
             steerabilityControls,
         });
+        if (plannerActionOutcome.kind === 'terminal_action') {
+            if (plannerActionOutcome.fallbackReason !== undefined) {
+                fallbackReasons.push(plannerActionOutcome.fallbackReason);
+            }
+            if (plannerActionOutcome.warningMessage !== undefined) {
+                chatOrchestratorLogger.warn(
+                    plannerActionOutcome.warningMessage
+                );
+            }
+        }
+        if (response.kind === 'terminal_action') {
+            const terminalResponse =
+                response.response ??
+                ({
+                    action: 'ignore',
+                    metadata: null,
+                } as const);
+            emitFallbackRollup(fallbackRollupSelectionSource);
+            notifyBreakerEvent({
+                responseId: null,
+                responseAction: terminalResponse.action,
+                responseModality: executionPlan.modality,
+            });
+            emitControlObservability({
+                responseAction: terminalResponse.action,
+                responseModality: executionPlan.modality,
+            });
+            return terminalResponse;
+        }
+        if (response.metadata === undefined || response.message === undefined) {
+            chatOrchestratorLogger.warn(
+                'ChatService returned message outcome without message metadata; failing open to ignore.'
+            );
+            emitFallbackRollup(fallbackRollupSelectionSource);
+            notifyBreakerEvent({
+                responseId: null,
+                responseAction: 'ignore',
+                responseModality: executionPlan.modality,
+            });
+            emitControlObservability({
+                responseAction: 'ignore',
+                responseModality: executionPlan.modality,
+            });
+            return {
+                action: 'ignore',
+                metadata: null,
+            };
+        }
         // ChatService computes totalDurationMs before metadata assembly and
         // queued trace writes. Avoid mutating metadata here to keep trace
         // persistence race-free.

--- a/packages/backend/src/services/chatOrchestrator.ts
+++ b/packages/backend/src/services/chatOrchestrator.ts
@@ -22,13 +22,11 @@ import {
     type ChatPlannerInvocationContext,
 } from './chatPlanner.js';
 import { createOpenAiChatPlannerStructuredExecutor } from './chatPlannerStructuredOpenAi.js';
-import type { ChatGenerationPlan } from './chatGenerationTypes.js';
 import {
     resolveActiveProfileOverlayPrompt,
     resolveBotProfileDisplayName,
     resolveChatPersonaProfile,
 } from './chatProfileOverlay.js';
-import { coercePlanForSurface } from './chatSurfacePolicy.js';
 import { createModelProfileResolver } from './modelProfileResolver.js';
 import { listCapabilityProfileOptionsForStep } from './modelCapabilityPolicy.js';
 import {
@@ -40,11 +38,10 @@ import { resolveExecutionContract } from './executionContractResolver.js';
 import { resolveWorkflowModeDecision } from './workflowProfileRegistry.js';
 import { buildSteerabilityControls } from './steerabilityControls.js';
 import type { WeatherForecastTool } from './openMeteoForecastTool.js';
-import { applySingleToolPolicy } from './tools/toolPolicy.js';
-import { resolveToolSelection } from './tools/toolRegistry.js';
 import { buildToolClarificationResponse } from './tools/toolClarificationResponse.js';
 import { resolveWeatherClarificationContinuation } from './tools/weatherClarificationContinuation.js';
 import { createToolRegistryContextStepExecutor } from './contextIntegrations/toolRegistryContextStepAdapter.js';
+import { createPlannerResultApplier } from './chatOrchestrator/plannerResultApplier.js';
 import { runtimeConfig } from '../config.js';
 import { logger } from '../utils/logger.js';
 import type { IncidentAlertRouter } from './incidentAlerts.js';
@@ -57,7 +54,6 @@ import {
     runDeterministicEvaluator,
     type EvaluatorExecutionContext,
 } from './chatOrchestrator/evaluatorCoordination.js';
-import { resolveExecutionProfile } from './chatOrchestrator/profileResolution.js';
 import { resolveNonMessagePlannerAction } from './chatOrchestrator/actionResolution.js';
 import {
     buildPlannerPayload,
@@ -333,67 +329,12 @@ export const createChatOrchestrator = ({
                 });
             }
         };
-        const { plan, surfacePolicy } = coercePlanForSurface(
-            normalizedRequest,
-            planned.plan,
-            chatOrchestratorLogger
-        );
-        // Profile selection precedence:
-        // - `/chat` style submit requests may explicitly override via
-        //   request.profileId.
-        // - Non-submit requests defer to planner-selected capability profile.
-        // - Startup default profile remains final fail-open fallback.
-        // Fallback ownership:
-        // - workflow profile fallback: workflowProfileRegistry
-        // - model selector/default fallback: modelProfileResolver
-        // - planner output fallback: chatPlanner
-        // Keep each fallback policy in its owner; do not duplicate here.
-        // Runtime resolution stays authoritative and fail-open:
-        // unknown/disabled selections never hard-fail the request.
-        // Request-level generation overrides are advisory knobs from callers
-        // like `/chat` that want quick side-by-side runs without changing
-        // planner prompt semantics.
-        const requestGeneration = normalizedRequest.generation;
-        let generationForExecution: ChatGenerationPlan = {
-            ...plan.generation,
-            ...(requestGeneration?.reasoningEffort
-                ? { reasoningEffort: requestGeneration.reasoningEffort }
-                : {}),
-            ...(requestGeneration?.verbosity
-                ? { verbosity: requestGeneration.verbosity }
-                : {}),
-        };
-        if (clarificationContinuation.kind === 'resolved') {
-            generationForExecution = {
-                ...generationForExecution,
-                toolIntent: {
-                    toolName: 'weather_forecast',
-                    requested: true,
-                    input: clarificationContinuation.selectedOption.input,
-                },
-            };
-        }
-        const toolPolicyDecision = applySingleToolPolicy(
-            generationForExecution
-        );
-        generationForExecution = toolPolicyDecision.generation;
-        if (toolPolicyDecision.logEvent) {
-            chatOrchestratorLogger.warn(
-                'planner requested both weather and search; applying single-tool policy with weather priority',
-                {
-                    ...toolPolicyDecision.logEvent,
-                    surface: normalizedRequest.surface,
-                }
-            );
-        }
         // Contract-governed routing boundary:
         // 1) resolve initial high-level workflow mode (fixed for this run in v1)
         // 2) derive Execution Contract preset from mode
         // 3) execute orchestration within that contract
         const workflowModeResolution = resolveWorkflowModeDecision({
             modeId: runtimeConfig.chatWorkflow.modeId,
-            executionContractResponseMode:
-                generationForExecution.responseIntentHint?.responseMode,
         });
         // Pick the run mode first, then derive the contract from it. That keeps
         // later branches from inventing their own policy rules.
@@ -406,58 +347,57 @@ export const createChatOrchestrator = ({
                 workflowModeResolution.modeDecision.behavior
                     .executionContractPresetId,
         }).policyContract;
-        const profileResolution = resolveExecutionProfile(
-            {
-                normalizedRequest,
-                plan,
-                enabledProfiles,
-                searchCapableProfiles,
-                enabledProfilesById,
-                defaultResponseProfile,
-                generationForExecution,
-                resolvedExecutionPolicy: resolvedExecutionContract,
-            },
-            chatOrchestratorLogger
-        );
-        generationForExecution = profileResolution.generationForExecution;
-        fallbackReasons.push(...profileResolution.fallbackReasons);
-        const selectedResponseProfile =
-            profileResolution.selectedResponseProfile;
-        const fallbackRollupSelectionSource =
-            profileResolution.fallbackRollupSelectionSource;
-        const originalSelectedProfileId =
-            profileResolution.originalSelectedProfileId;
-        const effectiveSelectedProfileId =
-            profileResolution.effectiveSelectedProfileId;
-        const rerouteApplied = profileResolution.rerouteApplied;
-        const webSearchToolRequestContextOverride =
-            profileResolution.webSearchToolRequestContextOverride;
-        let toolExecutionContext = profileResolution.toolExecutionContext;
-        const toolSelection = resolveToolSelection({
-            generation: generationForExecution,
+        const plannerResultApplier = createPlannerResultApplier({
+            enabledProfiles,
+            searchCapableProfiles,
+            enabledProfilesById,
+            defaultResponseProfile,
             weatherForecastTool,
-            webSearchToolRequestOverride: webSearchToolRequestContextOverride,
-            inheritedToolExecution: toolExecutionContext,
+            logger: chatOrchestratorLogger,
         });
-        const toolIntent = toolSelection.toolIntent;
-        const toolRequestContext = toolSelection.toolRequest;
-        toolExecutionContext =
-            toolSelection.toolExecution ?? toolExecutionContext;
-        const weatherContextStepRequest =
-            toolRequestContext.toolName === 'weather_forecast' &&
-            toolRequestContext.requested
-                ? {
-                      integrationName: 'weather_forecast',
-                      requested: toolRequestContext.requested,
-                      eligible: toolRequestContext.eligible,
-                      ...(toolRequestContext.reasonCode !== undefined && {
-                          reasonCode: toolRequestContext.reasonCode,
-                      }),
-                      ...(toolIntent.input !== undefined && {
-                          input: toolIntent.input as Record<string, unknown>,
-                      }),
-                  }
-                : undefined;
+        const plannerApplication = plannerResultApplier({
+            normalizedRequest,
+            plannerStepResult: {
+                plan: planned.plan,
+                execution: planned.execution,
+                ingestion: {
+                    outputApplyOutcome:
+                        planned.execution.status === 'executed'
+                            ? 'accepted'
+                            : 'rejected',
+                    fallbackTier:
+                        planned.execution.status === 'executed'
+                            ? 'none'
+                            : 'safe_default_plan',
+                    correctionCodes: [],
+                    outOfContractFields: [],
+                    authorityFieldAttempts: [],
+                },
+                diagnostics: planned.diagnostics,
+            },
+            clarificationContinuation,
+            resolvedExecutionPolicy: resolvedExecutionContract,
+        });
+        fallbackReasons.push(
+            ...(plannerApplication.fallbackReasons as PlannerFallbackReason[])
+        );
+        const plan = plannerApplication.plan;
+        const surfacePolicy = plannerApplication.surfacePolicy;
+        const generationForExecution =
+            plannerApplication.generationForExecution;
+        const selectedResponseProfile =
+            plannerApplication.selectedResponseProfile;
+        const fallbackRollupSelectionSource =
+            plannerApplication.fallbackRollupSelectionSource as PlannerSelectionSource;
+        const originalSelectedProfileId =
+            plannerApplication.originalSelectedProfileId;
+        const effectiveSelectedProfileId =
+            plannerApplication.effectiveSelectedProfileId;
+        const rerouteApplied = plannerApplication.rerouteApplied;
+        const toolRequestContext = plannerApplication.toolRequestContext;
+        const toolIntent = generationForExecution.toolIntent;
+        const toolExecutionContext = plannerApplication.toolExecutionContext;
+        const weatherContextStepRequest = plannerApplication.contextStepRequest;
         const weatherContextStepExecutor =
             weatherContextStepRequest !== undefined
                 ? createToolRegistryContextStepExecutor({
@@ -484,12 +424,11 @@ export const createChatOrchestrator = ({
             plannerRequestedWeather:
                 plannerDiagnostics.normalizedToolIntentName ===
                 'weather_forecast',
-            toolSelectionRequested: toolSelection.toolRequest.requested,
-            toolSelectionEligible: toolSelection.toolRequest.eligible,
-            toolSelectionToolName: toolSelection.toolRequest.toolName,
-            toolSelectionReasonCode: toolSelection.toolRequest.reasonCode,
-            selectedWeather:
-                toolSelection.toolRequest.toolName === 'weather_forecast',
+            toolSelectionRequested: toolRequestContext.requested,
+            toolSelectionEligible: toolRequestContext.eligible,
+            toolSelectionToolName: toolRequestContext.toolName,
+            toolSelectionReasonCode: toolRequestContext.reasonCode,
+            selectedWeather: toolRequestContext.toolName === 'weather_forecast',
         };
         if (
             weatherRouting.weatherLikeRequest ||
@@ -555,7 +494,8 @@ export const createChatOrchestrator = ({
                 : surfacePolicy !== undefined ||
                     providerPreferencePolicyAdjusted ||
                     rerouteApplied ||
-                    toolPolicyDecision.logEvent !== undefined
+                    plannerApplication.plannerApplyOutcome ===
+                        'adjusted_by_policy'
                   ? 'adjusted_by_policy'
                   : 'applied';
         const emitControlObservability = (input: {
@@ -613,8 +553,10 @@ export const createChatOrchestrator = ({
             ...plan,
             generation: generationForExecution,
             profileId: selectedResponseProfile.id,
-            selectedCapabilityProfile:
-                profileResolution.selectedCapabilityProfile,
+            ...(plannerApplication.selectedCapabilityProfile !== undefined && {
+                selectedCapabilityProfile:
+                    plannerApplication.selectedCapabilityProfile,
+            }),
         };
 
         const nonMessageResponse = resolveNonMessagePlannerAction(
@@ -954,8 +896,8 @@ export const createChatOrchestrator = ({
             effectiveProfileId: effectiveSelectedProfileId,
             requestedCapabilityProfile: plan.requestedCapabilityProfile,
             selectedCapabilityProfile:
-                profileResolution.selectedCapabilityProfile,
-            capabilityReasonCode: profileResolution.capabilityReasonCode,
+                plannerApplication.selectedCapabilityProfile,
+            capabilityReasonCode: plannerApplication.capabilityReasonCode,
             searchRequested: generationForExecution.search !== undefined,
             toolName: response.finalToolExecutionTelemetry?.toolName,
             toolStatus: response.finalToolExecutionTelemetry?.status,

--- a/packages/backend/src/services/chatOrchestrator.ts
+++ b/packages/backend/src/services/chatOrchestrator.ts
@@ -8,7 +8,6 @@
 import type {
     PostChatRequest,
     PostChatResponse,
-    ChatConversationMessage,
 } from '@footnote/contracts/web';
 import type { SafetyTier } from '@footnote/contracts/ethics-core';
 import { renderConversationPromptLayers } from './prompts/conversationPromptLayers.js';
@@ -55,10 +54,8 @@ import {
     type EvaluatorExecutionContext,
 } from './chatOrchestrator/evaluatorCoordination.js';
 import { resolveNonMessagePlannerAction } from './chatOrchestrator/actionResolution.js';
-import {
-    buildPlannerPayload,
-    type PlannerPayloadChatPlan,
-} from './chatOrchestrator/plannerPayload.js';
+import { type PlannerPayloadChatPlan } from './chatOrchestrator/plannerPayload.js';
+import { assemblePostPlanGenerationInput } from './chatService/postPlanAssembly.js';
 import {
     buildControlObservabilityEnvelope,
     emitControlObservabilityEnvelope,
@@ -728,36 +725,6 @@ export const createChatOrchestrator = ({
             generation: executionPlan.generation,
         };
 
-        // Planner output is injected as a final system message so generation
-        // follows one bounded payload selected by backend policy.
-        // This payload is execution input only, never policy authority.
-        const conversationMessages: Array<
-            Pick<ChatConversationMessage, 'role' | 'content'>
-        > = [
-            {
-                role: 'system',
-                content: promptLayers.systemPrompt,
-            },
-            {
-                role: 'system',
-                content: personaPrompt,
-            },
-            ...normalizedConversation,
-            {
-                role: 'system',
-                content: [
-                    '// ==========',
-                    '// BEGIN Planner Output',
-                    '// This bounded planner output was selected by backend policy for this response.',
-                    '// It is execution input for this run, not execution-contract authority.',
-                    '// ==========',
-                    buildPlannerPayload(executionPlanForPrompt, surfacePolicy),
-                    '// ==========',
-                    '// END Planner Output',
-                    '// ==========',
-                ].join('\n'),
-            },
-        ];
         const safetyTierRank: Record<SafetyTier, number> = {
             Low: 1,
             Medium: 2,
@@ -771,29 +738,28 @@ export const createChatOrchestrator = ({
                 : executionPlan.safetyTier;
         const executionContractScopeTuple =
             buildExecutionContractScopeTuple(normalizedRequest);
+        const postPlanAssembly = assemblePostPlanGenerationInput({
+            systemPrompt: promptLayers.systemPrompt,
+            personaPrompt,
+            normalizedConversation,
+            executionPlanForPrompt,
+            surfacePolicy,
+            normalizedRequest,
+            orchestrationSafetyTier,
+            toolIntent,
+            toolRequestContext,
+            executionContract: {
+                policyId: resolvedExecutionContract.policyId,
+                policyVersion: resolvedExecutionContract.policyVersion,
+            },
+        });
 
         // By the time we call ChatService, planner output and request overrides
         // have already been folded into one concrete profile and generation
         // plan.
         const response = await chatService.runChatMessages({
-            messages: conversationMessages,
-            conversationSnapshot: JSON.stringify({
-                request: normalizedRequest,
-                planner: {
-                    action: executionPlan.action,
-                    modality: executionPlan.modality,
-                    profileId: executionPlan.profileId,
-                    safetyTier: orchestrationSafetyTier,
-                    generation: executionPlan.generation,
-                    toolIntent,
-                    toolRequest: toolRequestContext,
-                    ...(surfacePolicy && { surfacePolicy }),
-                },
-                executionContract: {
-                    policyId: resolvedExecutionContract.policyId,
-                    policyVersion: resolvedExecutionContract.policyVersion,
-                },
-            }),
+            messages: postPlanAssembly.conversationMessages,
+            conversationSnapshot: postPlanAssembly.conversationSnapshot,
             orchestrationStartedAtMs: orchestrationStartedAt,
             plannerTemperament: executionPlan.generation.temperament,
             safetyTier: orchestrationSafetyTier,

--- a/packages/backend/src/services/chatOrchestrator/plannerResultApplier.ts
+++ b/packages/backend/src/services/chatOrchestrator/plannerResultApplier.ts
@@ -1,0 +1,201 @@
+/**
+ * @description: Applies planner output under backend policy and prepares
+ * downstream workflow inputs without granting planner authority.
+ * @footnote-scope: core
+ * @footnote-module: ChatOrchestratorPlannerResultApplier
+ * @footnote-risk: high - Incorrect policy application can route execution to wrong profiles/tools.
+ * @footnote-ethics: high - This seam preserves planner-advisory behavior and backend policy authority.
+ */
+import type { ModelProfile } from '@footnote/contracts';
+import type { PostChatRequest } from '@footnote/contracts/web';
+import type { ChatPlan } from '../chatPlanner.js';
+import type { ChatGenerationPlan } from '../chatGenerationTypes.js';
+import { coercePlanForSurface } from '../chatSurfacePolicy.js';
+import { applySingleToolPolicy } from '../tools/toolPolicy.js';
+import { resolveToolSelection } from '../tools/toolRegistry.js';
+import type { WeatherForecastTool } from '../openMeteoForecastTool.js';
+import { resolveExecutionProfile } from './profileResolution.js';
+import type {
+    PlannerApplicationInput,
+    PlannerApplicationResult,
+} from '../plannerWorkflowSeams.js';
+
+type PlannerSelectionSource = 'default' | 'planner' | 'request_override';
+
+export type CreatePlannerResultApplierInput = {
+    enabledProfiles: ModelProfile[];
+    searchCapableProfiles: ModelProfile[];
+    enabledProfilesById: Map<string, ModelProfile>;
+    defaultResponseProfile: ModelProfile;
+    weatherForecastTool?: WeatherForecastTool;
+    logger: {
+        debug: (message: string, meta?: Record<string, unknown>) => void;
+        warn: (message: string, meta?: Record<string, unknown>) => void;
+    };
+};
+
+export type PlannerResultApplierBootstrap = {
+    normalizedRequest: PostChatRequest;
+    clarificationContinuation:
+        | {
+              kind: 'resolved';
+              selectedOption: { input: Record<string, unknown> };
+          }
+        | { kind: 'none' | 'unresolved' };
+    resolvedExecutionPolicy: Parameters<
+        typeof resolveExecutionProfile
+    >[0]['resolvedExecutionPolicy'];
+};
+
+export const createPlannerResultApplier = (
+    input: CreatePlannerResultApplierInput
+): ((
+    plannerInput: PlannerApplicationInput & PlannerResultApplierBootstrap
+) => PlannerApplicationResult) => {
+    return (plannerInput) => {
+        const plannerPlan = plannerInput.plannerStepResult.plan;
+        const fallbackReasons: string[] = [];
+        if (plannerInput.plannerStepResult.execution.status === 'failed') {
+            const plannerFailureReason =
+                plannerInput.plannerStepResult.execution.reasonCode ===
+                'planner_invalid_output'
+                    ? 'planner_execution_failed_planner_invalid_output'
+                    : plannerInput.plannerStepResult.execution.reasonCode ===
+                        'planner_runtime_error'
+                      ? 'planner_execution_failed_planner_runtime_error'
+                      : 'planner_execution_failed_unknown';
+            fallbackReasons.push(plannerFailureReason);
+        }
+        const { plan, surfacePolicy } = coercePlanForSurface(
+            plannerInput.normalizedRequest,
+            plannerPlan,
+            input.logger
+        );
+        const requestGeneration = plannerInput.normalizedRequest.generation;
+        let generationForExecution: ChatGenerationPlan = {
+            ...plan.generation,
+            ...(requestGeneration?.reasoningEffort
+                ? { reasoningEffort: requestGeneration.reasoningEffort }
+                : {}),
+            ...(requestGeneration?.verbosity
+                ? { verbosity: requestGeneration.verbosity }
+                : {}),
+        };
+        if (plannerInput.clarificationContinuation.kind === 'resolved') {
+            generationForExecution = {
+                ...generationForExecution,
+                toolIntent: {
+                    toolName: 'weather_forecast',
+                    requested: true,
+                    input: plannerInput.clarificationContinuation.selectedOption
+                        .input,
+                },
+            };
+        }
+        const toolPolicyDecision = applySingleToolPolicy(
+            generationForExecution
+        );
+        generationForExecution = toolPolicyDecision.generation;
+        if (toolPolicyDecision.logEvent) {
+            input.logger.warn(
+                'planner requested both weather and search; applying single-tool policy with weather priority',
+                {
+                    ...toolPolicyDecision.logEvent,
+                    surface: plannerInput.normalizedRequest.surface,
+                }
+            );
+        }
+        const profileResolution = resolveExecutionProfile(
+            {
+                normalizedRequest: plannerInput.normalizedRequest,
+                plan,
+                enabledProfiles: input.enabledProfiles,
+                searchCapableProfiles: input.searchCapableProfiles,
+                enabledProfilesById: input.enabledProfilesById,
+                defaultResponseProfile: input.defaultResponseProfile,
+                generationForExecution,
+                resolvedExecutionPolicy: plannerInput.resolvedExecutionPolicy,
+            },
+            input.logger
+        );
+        generationForExecution = profileResolution.generationForExecution;
+        fallbackReasons.push(...profileResolution.fallbackReasons);
+        const selectedResponseProfile =
+            profileResolution.selectedResponseProfile;
+        const toolSelection = resolveToolSelection({
+            generation: generationForExecution,
+            weatherForecastTool: input.weatherForecastTool,
+            webSearchToolRequestOverride:
+                profileResolution.webSearchToolRequestContextOverride,
+            inheritedToolExecution: profileResolution.toolExecutionContext,
+        });
+
+        const contextStepRequest =
+            toolSelection.toolRequest.toolName === 'weather_forecast' &&
+            toolSelection.toolRequest.requested
+                ? {
+                      integrationName: 'weather_forecast',
+                      requested: toolSelection.toolRequest.requested,
+                      eligible: toolSelection.toolRequest.eligible,
+                      ...(toolSelection.toolRequest.reasonCode !==
+                          undefined && {
+                          reasonCode: toolSelection.toolRequest.reasonCode,
+                      }),
+                      ...(toolSelection.toolIntent.input !== undefined && {
+                          input: toolSelection.toolIntent.input as Record<
+                              string,
+                              unknown
+                          >,
+                      }),
+                  }
+                : undefined;
+        const plannerApplyOutcome =
+            plannerInput.plannerStepResult.execution.status !== 'executed'
+                ? 'not_applied'
+                : fallbackReasons.length > 0
+                  ? 'adjusted_by_policy'
+                  : 'applied';
+        const plannerMattered = plannerApplyOutcome !== 'not_applied';
+        const plannerMatteredControlIds =
+            plannerApplyOutcome === 'adjusted_by_policy'
+                ? ['provider_preference']
+                : [];
+
+        return {
+            plan: {
+                ...plan,
+                generation: generationForExecution,
+                profileId: selectedResponseProfile.id,
+                provider: selectedResponseProfile.provider,
+                capabilities: selectedResponseProfile.capabilities,
+            } as ChatPlan,
+            ...(surfacePolicy !== undefined && { surfacePolicy }),
+            generationForExecution,
+            selectedResponseProfile,
+            originalSelectedProfileId:
+                profileResolution.originalSelectedProfileId,
+            effectiveSelectedProfileId:
+                profileResolution.effectiveSelectedProfileId,
+            rerouteApplied: profileResolution.rerouteApplied,
+            ...(profileResolution.selectedCapabilityProfile !== undefined && {
+                selectedCapabilityProfile:
+                    profileResolution.selectedCapabilityProfile,
+            }),
+            ...(profileResolution.capabilityReasonCode !== undefined && {
+                capabilityReasonCode: profileResolution.capabilityReasonCode,
+            }),
+            toolRequestContext: toolSelection.toolRequest,
+            toolExecutionContext: toolSelection.toolExecution,
+            contextStepRequest,
+            plannerApplyOutcome,
+            plannerMattered,
+            plannerMatteredControlIds,
+            fallbackReasons,
+            fallbackRollupSelectionSource:
+                profileResolution.fallbackRollupSelectionSource as PlannerSelectionSource,
+        };
+    };
+};
+
+export type PlannerResultApplierBootstrapContext =
+    PlannerResultApplierBootstrap;

--- a/packages/backend/src/services/chatService.ts
+++ b/packages/backend/src/services/chatService.ts
@@ -55,6 +55,10 @@ import {
     type RunBoundedReviewWorkflowResult,
     type WorkflowPolicy,
 } from './workflowEngine.js';
+import type {
+    PlannerStepExecutor,
+    PlannerStepRequest,
+} from './plannerWorkflowSeams.js';
 import { runEvidenceIngestion } from './executionContractTrustGraph/trustGraphEvidenceIngestion.js';
 import type {
     ScopeTuple,
@@ -377,74 +381,6 @@ const OWNERSHIP_DENIAL_PREFIXES: readonly string[] = [
     'insufficient_data:',
 ];
 
-const hasPlannerWorkflowStep = (workflow: WorkflowRecord): boolean =>
-    workflow.steps.some((step) => step.stepKind === 'plan');
-
-const attachPlannerWorkflowLineage = (input: {
-    workflowLineage: WorkflowRecord;
-    executionContext: ResponseMetadataRuntimeContext['executionContext'];
-    generationStartedAtMs: number;
-}): WorkflowRecord => {
-    const plannerExecution = input.executionContext?.planner;
-    if (plannerExecution === undefined) {
-        return input.workflowLineage;
-    }
-
-    if (hasPlannerWorkflowStep(input.workflowLineage)) {
-        return input.workflowLineage;
-    }
-
-    const existingStepIds = new Set(
-        input.workflowLineage.steps.map((step) => step.stepId)
-    );
-    let plannerStepId = 'step_plan_1';
-    let plannerStepIndex = 1;
-    while (existingStepIds.has(plannerStepId)) {
-        plannerStepIndex += 1;
-        plannerStepId = `step_plan_${plannerStepIndex}`;
-    }
-
-    const plannerStep = buildPlannerStepRecord({
-        stepId: plannerStepId,
-        attempt: 1,
-        finishedAtMs: input.generationStartedAtMs,
-        summary: {
-            status: plannerExecution.status,
-            reasonCode: plannerExecution.reasonCode,
-            purpose: plannerExecution.purpose,
-            contractType: plannerExecution.contractType,
-            applyOutcome: plannerExecution.applyOutcome,
-            durationMs: plannerExecution.durationMs,
-            profileId: plannerExecution.profileId,
-            originalProfileId: plannerExecution.originalProfileId,
-            effectiveProfileId: plannerExecution.effectiveProfileId,
-            provider: plannerExecution.provider,
-            model: plannerExecution.model,
-            mattered: plannerExecution.mattered,
-            matteredControlIds: plannerExecution.matteredControlIds,
-        },
-    });
-
-    return {
-        ...input.workflowLineage,
-        stepCount: input.workflowLineage.steps.length + 1,
-        maxSteps: input.workflowLineage.maxSteps + 1,
-        ...(input.workflowLineage.effectiveLimits !== undefined && {
-            effectiveLimits: input.workflowLineage.effectiveLimits.map(
-                (limit) =>
-                    limit.key === 'maxWorkflowSteps' &&
-                    typeof limit.value === 'number'
-                        ? {
-                              ...limit,
-                              value: limit.value + 1,
-                          }
-                        : limit
-            ),
-        }),
-        steps: [plannerStep, ...input.workflowLineage.steps],
-    };
-};
-
 const extractOwnershipDenialReason = (
     details: string | undefined
 ):
@@ -579,6 +515,8 @@ export type RunChatMessagesInput = {
     toolRequest?: ToolInvocationRequest;
     contextStepRequest?: ContextStepRequest;
     contextStepExecutor?: ContextStepExecutor;
+    plannerStepRequest?: PlannerStepRequest;
+    plannerStepExecutor?: PlannerStepExecutor;
     latestUserInput?: string;
     executionContractTrustGraphContext?: ExecutionContractTrustGraphContext;
     ExecutionContract?: ExecutionContract;
@@ -705,6 +643,8 @@ export const createChatService = ({
         toolRequest,
         contextStepRequest,
         contextStepExecutor,
+        plannerStepRequest,
+        plannerStepExecutor,
         latestUserInput,
         executionContractTrustGraphContext,
         ExecutionContract,
@@ -853,9 +793,11 @@ export const createChatService = ({
                     maxIterations: Math.max(
                         0,
                         Math.min(
-                            Math.ceil(
-                                workflowExecutionLimits.maxDeliberationCalls / 2
-                            ),
+                            workflowExecutionLimits.maxReviewCycles ??
+                                Math.ceil(
+                                    workflowExecutionLimits.maxDeliberationCalls /
+                                        2
+                                ),
                             Math.ceil(
                                 Math.max(
                                     0,
@@ -871,6 +813,8 @@ export const createChatService = ({
                 captureUsage: (result, requestedModel) =>
                     recordUsageForStep(result, requestedModel),
                 plannerStepRecord: plannerWorkflowStepRecord,
+                plannerStepRequest,
+                plannerStepExecutor,
                 contextStepRequest,
                 contextStepExecutor,
             });
@@ -1210,14 +1154,7 @@ export const createChatService = ({
                     durationMs: generationDurationMs,
                 } satisfies GenerationExecutionContext)
               : undefined;
-        const normalizedWorkflowLineage =
-            workflowLineage !== undefined
-                ? attachPlannerWorkflowLineage({
-                      workflowLineage,
-                      executionContext,
-                      generationStartedAtMs: generationStartedAt,
-                  })
-                : undefined;
+        const normalizedWorkflowLineage = workflowLineage;
 
         const runtimeContext: ResponseMetadataRuntimeContext = {
             modelVersion: usageModel,

--- a/packages/backend/src/services/chatService.ts
+++ b/packages/backend/src/services/chatService.ts
@@ -55,6 +55,10 @@ import {
     type RunBoundedReviewWorkflowResult,
     type WorkflowPolicy,
 } from './workflowEngine.js';
+import {
+    plannerTerminalActionToResponse,
+    type PlannerActionOutcome,
+} from './chatService/plannerActionOutcome.js';
 import type {
     PlannerStepExecutor,
     PlannerStepRequest,
@@ -517,6 +521,7 @@ export type RunChatMessagesInput = {
     contextStepExecutor?: ContextStepExecutor;
     plannerStepRequest?: PlannerStepRequest;
     plannerStepExecutor?: PlannerStepExecutor;
+    plannerActionOutcome?: PlannerActionOutcome;
     latestUserInput?: string;
     executionContractTrustGraphContext?: ExecutionContractTrustGraphContext;
     ExecutionContract?: ExecutionContract;
@@ -529,6 +534,27 @@ export type FinalToolExecutionTelemetry = {
     reasonCode?: ToolExecutionContext['reasonCode'];
     eligible?: boolean;
     requestReasonCode?: ToolInvocationRequest['reasonCode'];
+};
+
+export type RunChatMessagesResult =
+    | {
+          kind: 'message';
+          message: string;
+          metadata: ResponseMetadata;
+          generationDurationMs: number;
+          finalToolExecutionTelemetry?: FinalToolExecutionTelemetry;
+      }
+    | {
+          kind: 'terminal_action';
+          response: Exclude<PostChatResponse, { action: 'message' }>;
+          generationDurationMs: number;
+      };
+
+type RunChatMessagesLegacyResult = {
+    message: string;
+    metadata: ResponseMetadata;
+    generationDurationMs: number;
+    finalToolExecutionTelemetry?: FinalToolExecutionTelemetry;
 };
 
 /**
@@ -627,7 +653,7 @@ export const createChatService = ({
         };
     };
 
-    const runChatMessages = async ({
+    const runChatMessagesWithOutcome = async ({
         messages,
         conversationSnapshot,
         orchestrationStartedAtMs,
@@ -645,25 +671,16 @@ export const createChatService = ({
         contextStepExecutor,
         plannerStepRequest,
         plannerStepExecutor,
+        plannerActionOutcome: _plannerActionOutcome,
         latestUserInput,
         executionContractTrustGraphContext,
         ExecutionContract,
         steerabilityControls,
-    }: RunChatMessagesInput): Promise<{
-        message: string;
-        metadata: ResponseMetadata;
-        generationDurationMs: number;
-        finalToolExecutionTelemetry?: FinalToolExecutionTelemetry;
-    }> => {
+    }: RunChatMessagesInput): Promise<RunChatMessagesResult> => {
         const toShortCircuitMessageResult = (
             response: PostChatResponse,
             finalToolExecutionTelemetry: FinalToolExecutionTelemetry
-        ): {
-            message: string;
-            metadata: ResponseMetadata;
-            generationDurationMs: number;
-            finalToolExecutionTelemetry?: FinalToolExecutionTelemetry;
-        } => {
+        ): RunChatMessagesResult => {
             if (response.action !== 'message' || response.metadata === null) {
                 throw new Error(
                     'Tool short-circuit response must be a message with metadata.'
@@ -671,6 +688,7 @@ export const createChatService = ({
             }
 
             return {
+                kind: 'message',
                 message: response.message,
                 metadata: response.metadata,
                 generationDurationMs: Math.max(
@@ -843,6 +861,18 @@ export const createChatService = ({
                         );
                     }
                     break;
+                }
+                case 'terminal_action': {
+                    return {
+                        kind: 'terminal_action',
+                        response: plannerTerminalActionToResponse(
+                            workflowResult.terminalAction
+                        ),
+                        generationDurationMs: Math.max(
+                            0,
+                            Date.now() - generationStartedAt
+                        ),
+                    };
                 }
                 case 'no_generation': {
                     workflowLineage = workflowResult.workflowLineage;
@@ -1249,11 +1279,36 @@ export const createChatService = ({
         });
 
         return {
+            kind: 'message',
             message: generationResult.text,
             metadata: metadataWithTrustGraph,
             generationDurationMs,
             ...(finalToolExecutionTelemetry !== undefined && {
                 finalToolExecutionTelemetry,
+            }),
+        };
+    };
+
+    const runChatMessages = async (
+        input: RunChatMessagesInput
+    ): Promise<RunChatMessagesLegacyResult> => {
+        const result = await runChatMessagesWithOutcome(input);
+        if (
+            result.kind !== 'message' ||
+            result.message === undefined ||
+            result.metadata === undefined
+        ) {
+            throw new Error(
+                'runChatMessages received terminal action outcome; use runChatMessagesWithOutcome for action-aware orchestration.'
+            );
+        }
+
+        return {
+            message: result.message,
+            metadata: result.metadata,
+            generationDurationMs: result.generationDurationMs,
+            ...(result.finalToolExecutionTelemetry !== undefined && {
+                finalToolExecutionTelemetry: result.finalToolExecutionTelemetry,
             }),
         };
     };
@@ -1277,10 +1332,20 @@ export const createChatService = ({
             },
             { role: 'user', content: question.trim() },
         ];
-        const response = await runChatMessages({
+        const response = await runChatMessagesWithOutcome({
             messages,
             conversationSnapshot: question.trim(),
         });
+
+        if (response.kind !== 'message') {
+            if (response.response === undefined) {
+                return {
+                    action: 'ignore',
+                    metadata: null,
+                };
+            }
+            return response.response;
+        }
 
         return {
             action: 'message',
@@ -1293,5 +1358,6 @@ export const createChatService = ({
     return {
         runChat,
         runChatMessages,
+        runChatMessagesWithOutcome,
     };
 };

--- a/packages/backend/src/services/chatService/plannerActionOutcome.ts
+++ b/packages/backend/src/services/chatService/plannerActionOutcome.ts
@@ -1,0 +1,110 @@
+/**
+ * @description: Classifies policy-applied planner actions into either a
+ * terminal transport response or message-continuation workflow execution.
+ * @footnote-scope: core
+ * @footnote-module: ChatServicePlannerActionOutcome
+ * @footnote-risk: medium - Incorrect classification can skip generation or return wrong action types.
+ * @footnote-ethics: medium - Action routing affects user-visible behavior and trust.
+ */
+import type {
+    PostChatRequest,
+    PostChatResponse,
+} from '@footnote/contracts/web';
+import type { ChatPlan } from '../chatPlanner.js';
+import type { PlannerFallbackReason } from '../plannerFallbackTelemetryRollup.js';
+
+type PlannerTerminalAction =
+    | {
+          responseAction: 'ignore';
+          response: PostChatResponse;
+      }
+    | {
+          responseAction: 'react';
+          response: PostChatResponse;
+      }
+    | {
+          responseAction: 'image';
+          response: PostChatResponse;
+      };
+
+export type PlannerActionOutcome =
+    | {
+          kind: 'continue_message';
+      }
+    | {
+          kind: 'terminal_action';
+          terminalAction: PlannerTerminalAction;
+          fallbackReason?: PlannerFallbackReason;
+          warningMessage?: string;
+      };
+
+export const resolvePlannerActionOutcome = (input: {
+    executionPlan: ChatPlan;
+    normalizedRequest: PostChatRequest;
+}): PlannerActionOutcome => {
+    if (input.executionPlan.action === 'ignore') {
+        return {
+            kind: 'terminal_action',
+            terminalAction: {
+                responseAction: 'ignore',
+                response: {
+                    action: 'ignore',
+                    metadata: null,
+                },
+            },
+        };
+    }
+
+    if (input.executionPlan.action === 'react') {
+        return {
+            kind: 'terminal_action',
+            terminalAction: {
+                responseAction: 'react',
+                response: {
+                    action: 'react',
+                    reaction: input.executionPlan.reaction ?? '👍',
+                    metadata: null,
+                },
+            },
+        };
+    }
+
+    if (
+        input.executionPlan.action === 'image' &&
+        input.executionPlan.imageRequest !== undefined
+    ) {
+        return {
+            kind: 'terminal_action',
+            terminalAction: {
+                responseAction: 'image',
+                response: {
+                    action: 'image',
+                    imageRequest: input.executionPlan.imageRequest,
+                    metadata: null,
+                },
+            },
+        };
+    }
+
+    if (
+        input.executionPlan.action === 'image' &&
+        input.executionPlan.imageRequest === undefined
+    ) {
+        return {
+            kind: 'terminal_action',
+            terminalAction: {
+                responseAction: 'ignore',
+                response: {
+                    action: 'ignore',
+                    metadata: null,
+                },
+            },
+            fallbackReason: 'image_action_missing_image_request',
+            warningMessage: `Chat planner returned image without imageRequest; falling back to ignore. surface=${input.normalizedRequest.surface} trigger=${input.normalizedRequest.trigger.kind} latestUserInputLength=${input.normalizedRequest.latestUserInput.length}`,
+        };
+    }
+
+    return {
+        kind: 'continue_message',
+    };
+};

--- a/packages/backend/src/services/chatService/plannerActionOutcome.ts
+++ b/packages/backend/src/services/chatService/plannerActionOutcome.ts
@@ -12,20 +12,7 @@ import type {
 } from '@footnote/contracts/web';
 import type { ChatPlan } from '../chatPlanner.js';
 import type { PlannerFallbackReason } from '../plannerFallbackTelemetryRollup.js';
-
-type PlannerTerminalAction =
-    | {
-          responseAction: 'ignore';
-          response: PostChatResponse;
-      }
-    | {
-          responseAction: 'react';
-          response: PostChatResponse;
-      }
-    | {
-          responseAction: 'image';
-          response: PostChatResponse;
-      };
+import type { PlannerTerminalAction } from '../plannerWorkflowSeams.js';
 
 export type PlannerActionOutcome =
     | {
@@ -47,10 +34,6 @@ export const resolvePlannerActionOutcome = (input: {
             kind: 'terminal_action',
             terminalAction: {
                 responseAction: 'ignore',
-                response: {
-                    action: 'ignore',
-                    metadata: null,
-                },
             },
         };
     }
@@ -60,11 +43,7 @@ export const resolvePlannerActionOutcome = (input: {
             kind: 'terminal_action',
             terminalAction: {
                 responseAction: 'react',
-                response: {
-                    action: 'react',
-                    reaction: input.executionPlan.reaction ?? '👍',
-                    metadata: null,
-                },
+                reaction: input.executionPlan.reaction ?? '👍',
             },
         };
     }
@@ -77,11 +56,7 @@ export const resolvePlannerActionOutcome = (input: {
             kind: 'terminal_action',
             terminalAction: {
                 responseAction: 'image',
-                response: {
-                    action: 'image',
-                    imageRequest: input.executionPlan.imageRequest,
-                    metadata: null,
-                },
+                imageRequest: input.executionPlan.imageRequest,
             },
         };
     }
@@ -94,10 +69,6 @@ export const resolvePlannerActionOutcome = (input: {
             kind: 'terminal_action',
             terminalAction: {
                 responseAction: 'ignore',
-                response: {
-                    action: 'ignore',
-                    metadata: null,
-                },
             },
             fallbackReason: 'image_action_missing_image_request',
             warningMessage: `Chat planner returned image without imageRequest; falling back to ignore. surface=${input.normalizedRequest.surface} trigger=${input.normalizedRequest.trigger.kind} latestUserInputLength=${input.normalizedRequest.latestUserInput.length}`,
@@ -106,5 +77,29 @@ export const resolvePlannerActionOutcome = (input: {
 
     return {
         kind: 'continue_message',
+    };
+};
+
+export const plannerTerminalActionToResponse = (
+    terminalAction: PlannerTerminalAction
+): Exclude<PostChatResponse, { action: 'message' }> => {
+    if (terminalAction.responseAction === 'ignore') {
+        return {
+            action: 'ignore',
+            metadata: null,
+        };
+    }
+    if (terminalAction.responseAction === 'react') {
+        return {
+            action: 'react',
+            reaction: terminalAction.reaction,
+            metadata: null,
+        };
+    }
+
+    return {
+        action: 'image',
+        imageRequest: terminalAction.imageRequest,
+        metadata: null,
     };
 };

--- a/packages/backend/src/services/chatService/postPlanAssembly.ts
+++ b/packages/backend/src/services/chatService/postPlanAssembly.ts
@@ -1,0 +1,102 @@
+/**
+ * @description: Assembles post-plan generation messages and conversation
+ * snapshot payloads from policy-applied planner output.
+ * @footnote-scope: core
+ * @footnote-module: ChatServicePostPlanAssembly
+ * @footnote-risk: medium - Incorrect assembly can desync planner payload context from generation.
+ * @footnote-ethics: high - Stable assembly preserves auditable boundaries between planner advice and policy authority.
+ */
+import type {
+    ChatConversationMessage,
+    PostChatRequest,
+} from '@footnote/contracts/web';
+import type {
+    SafetyTier,
+    ToolInvocationRequest,
+} from '@footnote/contracts/ethics-core';
+import type { PlannerPayloadChatPlan } from '../chatOrchestrator/plannerPayload.js';
+import { buildPlannerPayload } from '../chatOrchestrator/plannerPayload.js';
+import type { ChatGenerationToolIntent } from '../chatGenerationTypes.js';
+
+export type PostPlanAssemblyInput = {
+    systemPrompt: string;
+    personaPrompt: string;
+    normalizedConversation: Array<
+        Pick<ChatConversationMessage, 'role' | 'content'>
+    >;
+    executionPlanForPrompt: PlannerPayloadChatPlan;
+    surfacePolicy?: { coercedFrom: 'message' | 'react' | 'ignore' | 'image' };
+    normalizedRequest: PostChatRequest;
+    orchestrationSafetyTier: SafetyTier;
+    toolIntent?: ChatGenerationToolIntent;
+    toolRequestContext: ToolInvocationRequest;
+    executionContract: {
+        policyId: string;
+        policyVersion: string;
+    };
+};
+
+export type PostPlanAssemblyResult = {
+    conversationMessages: Array<
+        Pick<ChatConversationMessage, 'role' | 'content'>
+    >;
+    conversationSnapshot: string;
+};
+
+export const assemblePostPlanGenerationInput = (
+    input: PostPlanAssemblyInput
+): PostPlanAssemblyResult => {
+    const conversationMessages: Array<
+        Pick<ChatConversationMessage, 'role' | 'content'>
+    > = [
+        {
+            role: 'system',
+            content: input.systemPrompt,
+        },
+        {
+            role: 'system',
+            content: input.personaPrompt,
+        },
+        ...input.normalizedConversation,
+        {
+            role: 'system',
+            content: [
+                '// ==========',
+                '// BEGIN Planner Output',
+                '// This bounded planner output was selected by backend policy for this response.',
+                '// It is execution input for this run, not execution-contract authority.',
+                '// ==========',
+                buildPlannerPayload(
+                    input.executionPlanForPrompt,
+                    input.surfacePolicy
+                ),
+                '// ==========',
+                '// END Planner Output',
+                '// ==========',
+            ].join('\n'),
+        },
+    ];
+
+    const conversationSnapshot = JSON.stringify({
+        request: input.normalizedRequest,
+        planner: {
+            action: input.executionPlanForPrompt.action,
+            modality: input.executionPlanForPrompt.modality,
+            profileId: input.executionPlanForPrompt.profileId,
+            safetyTier: input.orchestrationSafetyTier,
+            generation: input.executionPlanForPrompt.generation,
+            toolIntent: input.toolIntent,
+            toolRequest: input.toolRequestContext,
+            ...(input.surfacePolicy && { surfacePolicy: input.surfacePolicy }),
+        },
+        executionContract: {
+            policyId: input.executionContract.policyId,
+            policyVersion: input.executionContract.policyVersion,
+        },
+    });
+
+    return {
+        conversationMessages,
+        conversationSnapshot,
+    };
+};

--- a/packages/backend/src/services/plannerWorkflowSeams.ts
+++ b/packages/backend/src/services/plannerWorkflowSeams.ts
@@ -16,7 +16,14 @@ import type {
     ToolInvocationRequest,
 } from '@footnote/contracts/ethics-core';
 import type { ModelProfile } from '@footnote/contracts';
-import type { PostChatRequest } from '@footnote/contracts/web';
+import type {
+    ChatImageRequest,
+    PostChatRequest,
+} from '@footnote/contracts/web';
+import type {
+    GenerationRequest,
+    RuntimeMessage,
+} from '@footnote/agent-runtime';
 import type {
     ChatPlan,
     ChatPlannerCapabilityProfileOption,
@@ -60,6 +67,19 @@ export type PlannerStepExecutor = (
     input: PlannerStepRequest
 ) => Promise<PlannerStepResult>;
 
+export type PlannerTerminalAction =
+    | {
+          responseAction: 'ignore';
+      }
+    | {
+          responseAction: 'react';
+          reaction: string;
+      }
+    | {
+          responseAction: 'image';
+          imageRequest: ChatImageRequest;
+      };
+
 export type PlannerApplicationInput = {
     normalizedRequest: PostChatRequest;
     plannerStepResult: PlannerStepResult;
@@ -88,3 +108,24 @@ export type PlannerApplicationResult = {
 export type PlannerResultApplier = (
     input: PlannerApplicationInput
 ) => PlannerApplicationResult;
+
+export type PostPlannerWorkflowAdapterInput = {
+    plannerStepResult: PlannerStepResult;
+    workflowId: string;
+    workflowName: string;
+    attempt: number;
+    baseMessagesWithHints: RuntimeMessage[];
+    baseGenerationRequest: GenerationRequest;
+};
+
+export type PostPlannerWorkflowAdapterResult = {
+    terminalAction?: PlannerTerminalAction;
+    messagesWithHints: RuntimeMessage[];
+    generationRequest: GenerationRequest;
+    contextStepRequest?: ContextStepRequest;
+    plannerApplication?: PlannerApplicationResult;
+};
+
+export type PostPlannerWorkflowAdapter = (
+    input: PostPlannerWorkflowAdapterInput
+) => PostPlannerWorkflowAdapterResult;

--- a/packages/backend/src/services/plannerWorkflowSeams.ts
+++ b/packages/backend/src/services/plannerWorkflowSeams.ts
@@ -35,6 +35,7 @@ import type { ChatSurfacePolicyCoercion } from './chatSurfacePolicy.js';
 import type { CapabilityProfileId } from './modelCapabilityPolicy.js';
 import type { ContextStepRequest } from './workflowEngine.js';
 
+/** Input to planner executor. Produced by workflow engine; caller provides request and context. */
 export type PlannerStepRequest = {
     workflowId: string;
     workflowName: string;
@@ -44,6 +45,7 @@ export type PlannerStepRequest = {
     capabilityProfiles: ChatPlannerCapabilityProfileOption[];
 };
 
+/** Output from planner executor; fail-open on optional fields, execution.status is authoritative. */
 export type PlannerStepResult = {
     plan: ChatPlan;
     execution: {
@@ -67,6 +69,7 @@ export type PlannerStepExecutor = (
     input: PlannerStepRequest
 ) => Promise<PlannerStepResult>;
 
+/** Terminal transport actions from planner; intent-only, policy must render. */
 export type PlannerTerminalAction =
     | {
           responseAction: 'ignore';
@@ -80,11 +83,13 @@ export type PlannerTerminalAction =
           imageRequest: ChatImageRequest;
       };
 
+/** Input to policy-owned planner result applier. Produced by orchestrator with request. */
 export type PlannerApplicationInput = {
     normalizedRequest: PostChatRequest;
     plannerStepResult: PlannerStepResult;
 };
 
+/** Output from policy-owned result applier; plannerMattered indicates advisory influence. */
 export type PlannerApplicationResult = {
     plan: ChatPlan;
     surfacePolicy?: ChatSurfacePolicyCoercion;

--- a/packages/backend/src/services/plannerWorkflowSeams.ts
+++ b/packages/backend/src/services/plannerWorkflowSeams.ts
@@ -1,0 +1,90 @@
+/**
+ * @description: Defines planner workflow seam contracts used to keep workflow
+ * timing ownership separate from planner execution and policy application.
+ * @footnote-scope: interface
+ * @footnote-module: PlannerWorkflowSeams
+ * @footnote-risk: medium - Contract drift can desync planner-step handoff across runtime layers.
+ * @footnote-ethics: high - Clear seam ownership preserves planner-advisory boundaries and policy authority.
+ */
+import type {
+    ExecutionReasonCode,
+    ExecutionStatus,
+    PlannerExecutionApplyOutcome,
+    PlannerExecutionContractType,
+    PlannerExecutionPurpose,
+    ToolExecutionContext,
+    ToolInvocationRequest,
+} from '@footnote/contracts/ethics-core';
+import type { ModelProfile } from '@footnote/contracts';
+import type { PostChatRequest } from '@footnote/contracts/web';
+import type {
+    ChatPlan,
+    ChatPlannerCapabilityProfileOption,
+    PlannerToolIntentDiagnostics,
+} from './chatPlanner.js';
+import type { ChatPlannerInvocationContext } from './chatPlannerInvocation.js';
+import type { ChatGenerationPlan } from './chatGenerationTypes.js';
+import type { ChatSurfacePolicyCoercion } from './chatSurfacePolicy.js';
+import type { CapabilityProfileId } from './modelCapabilityPolicy.js';
+import type { ContextStepRequest } from './workflowEngine.js';
+
+export type PlannerStepRequest = {
+    workflowId: string;
+    workflowName: string;
+    attempt: number;
+    request: PostChatRequest;
+    invocationContext: ChatPlannerInvocationContext;
+    capabilityProfiles: ChatPlannerCapabilityProfileOption[];
+};
+
+export type PlannerStepResult = {
+    plan: ChatPlan;
+    execution: {
+        status: ExecutionStatus;
+        reasonCode?: ExecutionReasonCode;
+        purpose: PlannerExecutionPurpose;
+        contractType: PlannerExecutionContractType;
+        durationMs: number;
+    };
+    ingestion: {
+        outputApplyOutcome: 'accepted' | 'partially_applied' | 'rejected';
+        fallbackTier: 'none' | 'field_corrections' | 'safe_default_plan';
+        correctionCodes: string[];
+        outOfContractFields: string[];
+        authorityFieldAttempts: string[];
+    };
+    diagnostics: PlannerToolIntentDiagnostics;
+};
+
+export type PlannerStepExecutor = (
+    input: PlannerStepRequest
+) => Promise<PlannerStepResult>;
+
+export type PlannerApplicationInput = {
+    normalizedRequest: PostChatRequest;
+    plannerStepResult: PlannerStepResult;
+};
+
+export type PlannerApplicationResult = {
+    plan: ChatPlan;
+    surfacePolicy?: ChatSurfacePolicyCoercion;
+    generationForExecution: ChatGenerationPlan;
+    selectedResponseProfile: ModelProfile;
+    originalSelectedProfileId: string;
+    effectiveSelectedProfileId: string;
+    rerouteApplied: boolean;
+    selectedCapabilityProfile?: CapabilityProfileId;
+    capabilityReasonCode?: string;
+    toolRequestContext: ToolInvocationRequest;
+    toolExecutionContext?: ToolExecutionContext;
+    contextStepRequest?: ContextStepRequest;
+    plannerApplyOutcome: PlannerExecutionApplyOutcome;
+    plannerMattered: boolean;
+    plannerMatteredControlIds: string[];
+    fallbackReasons: string[];
+    fallbackRollupSelectionSource: 'default' | 'planner' | 'request_override';
+};
+
+export type PlannerResultApplier = (
+    input: PlannerApplicationInput
+) => PlannerApplicationResult;

--- a/packages/backend/src/services/workflowEngine.ts
+++ b/packages/backend/src/services/workflowEngine.ts
@@ -815,11 +815,15 @@ export const runBoundedReviewWorkflow = async ({
             normalizedMaxDurationMs
         ),
     };
-    executionLimits.maxDeliberationCalls = Math.max(
-        executionLimits.maxDeliberationCalls,
-        (executionLimits.maxPlanCycles ?? 0) +
-            (executionLimits.maxReviewCycles ?? 0)
-    );
+    const hasExplicitMaxDeliberationCalls =
+        workflowConfig.executionLimits?.maxDeliberationCalls !== undefined;
+    if (!hasExplicitMaxDeliberationCalls) {
+        executionLimits.maxDeliberationCalls = Math.max(
+            executionLimits.maxDeliberationCalls,
+            (executionLimits.maxPlanCycles ?? 0) +
+                (executionLimits.maxReviewCycles ?? 0)
+        );
+    }
     const effectiveMaxIterations =
         workflowConfig.executionLimits !== undefined
             ? Math.max(
@@ -837,6 +841,14 @@ export const runBoundedReviewWorkflow = async ({
         workflowName: workflowConfig.workflowName,
         startedAtMs: workflowStartedAt,
     });
+
+    if (plannerStepRecord?.stepKind === 'plan') {
+        workflowState = {
+            ...workflowState,
+            stepCount: workflowState.stepCount + 1,
+            planCallCount: workflowState.planCallCount + 1,
+        };
+    }
 
     const captureStep = (input: {
         stepKind: StepRecord['stepKind'];

--- a/packages/backend/src/services/workflowEngine.ts
+++ b/packages/backend/src/services/workflowEngine.ts
@@ -35,8 +35,9 @@ import type {
 } from '@footnote/agent-runtime';
 import { logger } from '../utils/logger.js';
 import type {
-    PlannerApplicationInput,
-    PlannerResultApplier,
+    PostPlannerWorkflowAdapter,
+    PostPlannerWorkflowAdapterResult,
+    PlannerTerminalAction,
     PlannerStepExecutor,
     PlannerStepRequest,
     PlannerStepResult,
@@ -167,11 +168,7 @@ export type RunBoundedReviewWorkflowInput = {
     plannerStepRecord?: StepRecord;
     plannerStepRequest?: PlannerStepRequest;
     plannerStepExecutor?: PlannerStepExecutor;
-    plannerResultApplier?: PlannerResultApplier;
-    plannerApplicationInput?: Omit<
-        PlannerApplicationInput,
-        'plannerStepResult'
-    >;
+    postPlannerWorkflowAdapter?: PostPlannerWorkflowAdapter;
     contextStepRequest?: ContextStepRequest;
     contextStepExecutor?: ContextStepExecutor;
 };
@@ -182,12 +179,22 @@ export type RunBoundedReviewWorkflowResult =
           generationResult: GenerationResult;
           workflowLineage: WorkflowRecord;
           plannerStepResult?: PlannerStepResult;
+          postPlannerWorkflowAdapterResult?: PostPlannerWorkflowAdapterResult;
+          contextStepResult?: ContextStepResult;
+      }
+    | {
+          outcome: 'terminal_action';
+          terminalAction: PlannerTerminalAction;
+          workflowLineage: WorkflowRecord;
+          plannerStepResult?: PlannerStepResult;
+          postPlannerWorkflowAdapterResult?: PostPlannerWorkflowAdapterResult;
           contextStepResult?: ContextStepResult;
       }
     | {
           outcome: 'no_generation';
           workflowLineage: WorkflowRecord;
           plannerStepResult?: PlannerStepResult;
+          postPlannerWorkflowAdapterResult?: PostPlannerWorkflowAdapterResult;
           contextStepResult?: ContextStepResult;
       };
 
@@ -705,6 +712,7 @@ export const runBoundedReviewWorkflow = async ({
     plannerStepRecord,
     plannerStepRequest,
     plannerStepExecutor,
+    postPlannerWorkflowAdapter,
     contextStepRequest,
     contextStepExecutor,
 }: RunBoundedReviewWorkflowInput): Promise<RunBoundedReviewWorkflowResult> => {
@@ -759,6 +767,13 @@ export const runBoundedReviewWorkflow = async ({
     let exhaustedLimitKey: WorkflowLimitKey | undefined;
     let executedContextStepResult: ContextStepResult | undefined;
     let messagesWithContext = messagesWithHints;
+    let effectiveGenerationRequest = generationRequest;
+    let effectiveMessagesWithHints = messagesWithHints;
+    let effectiveContextStepRequest = contextStepRequest;
+    let workflowTerminalAction: PlannerTerminalAction | undefined;
+    let postPlannerWorkflowAdapterResult:
+        | PostPlannerWorkflowAdapterResult
+        | undefined;
     const effectiveReviewDecisionPrompt =
         reviewDecisionPrompt ?? profileStrategy.reviewDecisionPrompt;
     const effectiveRevisionPromptPrefix =
@@ -967,6 +982,61 @@ export const runBoundedReviewWorkflow = async ({
         }
     }
 
+    if (
+        plannerExecutionResult !== undefined &&
+        postPlannerWorkflowAdapter !== undefined
+    ) {
+        postPlannerWorkflowAdapterResult = postPlannerWorkflowAdapter({
+            plannerStepResult: plannerExecutionResult,
+            workflowId,
+            workflowName: workflowConfig.workflowName,
+            attempt: 1,
+            baseMessagesWithHints: messagesWithHints,
+            baseGenerationRequest: generationRequest,
+        });
+        effectiveGenerationRequest =
+            postPlannerWorkflowAdapterResult.generationRequest;
+        effectiveMessagesWithHints =
+            postPlannerWorkflowAdapterResult.messagesWithHints;
+        effectiveContextStepRequest =
+            postPlannerWorkflowAdapterResult.contextStepRequest ??
+            effectiveContextStepRequest;
+        workflowTerminalAction =
+            postPlannerWorkflowAdapterResult.terminalAction;
+    }
+
+    if (workflowTerminalAction !== undefined) {
+        const terminalStartedAt = Date.now();
+        const terminalFinishedAt = Date.now();
+        captureStep({
+            stepKind: 'finalize',
+            status: 'executed',
+            summary:
+                workflowTerminalAction.responseAction === 'image'
+                    ? 'Workflow completed with planner terminal image action.'
+                    : workflowTerminalAction.responseAction === 'react'
+                      ? 'Workflow completed with planner terminal reaction action.'
+                      : 'Workflow completed with planner terminal ignore action.',
+            startedAtMs: terminalStartedAt,
+            finishedAtMs: terminalFinishedAt,
+            parentStepId: plannerRootStepId,
+            attempt: 1,
+            signals: {
+                terminalAction: workflowTerminalAction.responseAction,
+            },
+        });
+        workflowState = applyStepExecutionToState(
+            workflowState,
+            'finalize',
+            0,
+            0,
+            0
+        );
+        terminationReason = 'goal_satisfied';
+        workflowStatus = 'completed';
+        shouldStop = true;
+    }
+
     const injectContextMessagesIntoPrompt = (
         baseMessages: RuntimeMessage[],
         contextMessages: string[] | undefined
@@ -1005,8 +1075,8 @@ export const runBoundedReviewWorkflow = async ({
     };
 
     if (
-        contextStepRequest?.requested === true &&
-        contextStepRequest.eligible &&
+        effectiveContextStepRequest?.requested === true &&
+        effectiveContextStepRequest.eligible &&
         contextStepExecutor !== undefined
     ) {
         if (
@@ -1022,7 +1092,7 @@ export const runBoundedReviewWorkflow = async ({
             const contextStepStartedAt = Date.now();
             try {
                 const contextStepResult = await contextStepExecutor({
-                    request: contextStepRequest,
+                    request: effectiveContextStepRequest,
                     workflowId,
                     workflowName: workflowConfig.workflowName,
                     attempt: 1,
@@ -1149,18 +1219,18 @@ export const runBoundedReviewWorkflow = async ({
         if (!stopIfOverLimits('generate')) {
             const initialDraftStartedAt = generationStartedAtMs;
             messagesWithContext = injectContextMessagesIntoPrompt(
-                messagesWithHints,
+                effectiveMessagesWithHints,
                 executedContextStepResult?.contextMessages
             );
             try {
                 draftResult = await generationRuntime.generate({
-                    ...generationRequest,
+                    ...effectiveGenerationRequest,
                     messages: messagesWithContext,
                 });
                 const initialDraftFinishedAt = Date.now();
                 const initialDraftUsage = captureUsage(
                     draftResult,
-                    generationRequest.model
+                    effectiveGenerationRequest.model
                 );
                 const initialDraftStepId = captureStep({
                     stepKind: 'generate',
@@ -1263,12 +1333,12 @@ export const runBoundedReviewWorkflow = async ({
                         content: effectiveReviewDecisionPrompt,
                     },
                 ],
-                model: generationRequest.model,
-                ...(generationRequest.provider !== undefined && {
-                    provider: generationRequest.provider,
+                model: effectiveGenerationRequest.model,
+                ...(effectiveGenerationRequest.provider !== undefined && {
+                    provider: effectiveGenerationRequest.provider,
                 }),
-                ...(generationRequest.capabilities !== undefined && {
-                    capabilities: generationRequest.capabilities,
+                ...(effectiveGenerationRequest.capabilities !== undefined && {
+                    capabilities: effectiveGenerationRequest.capabilities,
                 }),
                 maxOutputTokens: 200,
                 reasoningEffort: 'low',
@@ -1277,7 +1347,7 @@ export const runBoundedReviewWorkflow = async ({
             const reviewFinishedAt = Date.now();
             const reviewUsage = captureUsage(
                 reviewResult,
-                generationRequest.model
+                effectiveGenerationRequest.model
             );
             workflowState = applyStepExecutionToState(
                 workflowState,
@@ -1362,7 +1432,7 @@ export const runBoundedReviewWorkflow = async ({
             const revisionStartedAt = Date.now();
             try {
                 const revisionResult = await generationRuntime.generate({
-                    ...generationRequest,
+                    ...effectiveGenerationRequest,
                     messages: [
                         ...messagesWithContext,
                         {
@@ -1378,7 +1448,7 @@ export const runBoundedReviewWorkflow = async ({
                 const revisionFinishedAt = Date.now();
                 const revisionUsage = captureUsage(
                     revisionResult,
-                    generationRequest.model
+                    effectiveGenerationRequest.model
                 );
                 const revisionStepId = captureStep({
                     stepKind: 'revise',
@@ -1477,10 +1547,33 @@ export const runBoundedReviewWorkflow = async ({
         steps: workflowSteps,
     };
 
+    if (workflowTerminalAction !== undefined) {
+        return {
+            outcome: 'terminal_action',
+            terminalAction: workflowTerminalAction,
+            workflowLineage,
+            ...(plannerExecutionResult !== undefined && {
+                plannerStepResult: plannerExecutionResult,
+            }),
+            ...(postPlannerWorkflowAdapterResult !== undefined && {
+                postPlannerWorkflowAdapterResult,
+            }),
+            ...(executedContextStepResult !== undefined && {
+                contextStepResult: executedContextStepResult,
+            }),
+        };
+    }
+
     if (draftResult === null) {
         return {
             outcome: 'no_generation',
             workflowLineage,
+            ...(plannerExecutionResult !== undefined && {
+                plannerStepResult: plannerExecutionResult,
+            }),
+            ...(postPlannerWorkflowAdapterResult !== undefined && {
+                postPlannerWorkflowAdapterResult,
+            }),
             ...(executedContextStepResult !== undefined && {
                 contextStepResult: executedContextStepResult,
             }),
@@ -1491,6 +1584,12 @@ export const runBoundedReviewWorkflow = async ({
         outcome: 'generated',
         generationResult: draftResult,
         workflowLineage,
+        ...(plannerExecutionResult !== undefined && {
+            plannerStepResult: plannerExecutionResult,
+        }),
+        ...(postPlannerWorkflowAdapterResult !== undefined && {
+            postPlannerWorkflowAdapterResult,
+        }),
         ...(executedContextStepResult !== undefined && {
             contextStepResult: executedContextStepResult,
         }),

--- a/packages/backend/src/services/workflowEngine.ts
+++ b/packages/backend/src/services/workflowEngine.ts
@@ -34,6 +34,13 @@ import type {
     RuntimeMessage,
 } from '@footnote/agent-runtime';
 import { logger } from '../utils/logger.js';
+import type {
+    PlannerApplicationInput,
+    PlannerResultApplier,
+    PlannerStepExecutor,
+    PlannerStepRequest,
+    PlannerStepResult,
+} from './plannerWorkflowSeams.js';
 
 /**
  * Canonical Execution Contract workflow-policy surface.
@@ -57,6 +64,8 @@ export type WorkflowState = {
     currentStepKind: WorkflowStepKind | null;
     stepCount: number;
     toolCallCount: number;
+    planCallCount: number;
+    reviewCallCount: number;
     deliberationCallCount: number;
     totalTokens: number;
 };
@@ -156,6 +165,13 @@ export type RunBoundedReviewWorkflowInput = {
         requestedModel: string | undefined
     ) => ReviewWorkflowUsageSummary;
     plannerStepRecord?: StepRecord;
+    plannerStepRequest?: PlannerStepRequest;
+    plannerStepExecutor?: PlannerStepExecutor;
+    plannerResultApplier?: PlannerResultApplier;
+    plannerApplicationInput?: Omit<
+        PlannerApplicationInput,
+        'plannerStepResult'
+    >;
     contextStepRequest?: ContextStepRequest;
     contextStepExecutor?: ContextStepExecutor;
 };
@@ -165,11 +181,13 @@ export type RunBoundedReviewWorkflowResult =
           outcome: 'generated';
           generationResult: GenerationResult;
           workflowLineage: WorkflowRecord;
+          plannerStepResult?: PlannerStepResult;
           contextStepResult?: ContextStepResult;
       }
     | {
           outcome: 'no_generation';
           workflowLineage: WorkflowRecord;
+          plannerStepResult?: PlannerStepResult;
           contextStepResult?: ContextStepResult;
       };
 
@@ -268,6 +286,8 @@ export const createInitialWorkflowState = (input: {
     currentStepKind: null,
     stepCount: 0,
     toolCallCount: 0,
+    planCallCount: 0,
+    reviewCallCount: 0,
     deliberationCallCount: 0,
     totalTokens: 0,
 });
@@ -302,6 +322,10 @@ export const applyStepExecutionToState = (
         currentStepKind: stepKind,
         stepCount: state.stepCount + 1,
         toolCallCount: state.toolCallCount + sanitizedToolCallsExecuted,
+        planCallCount: state.planCallCount + (stepKind === 'plan' ? 1 : 0),
+        reviewCallCount:
+            state.reviewCallCount +
+            (stepKind === 'assess' || stepKind === 'revise' ? 1 : 0),
         deliberationCallCount:
             state.deliberationCallCount + sanitizedDeliberationCallsExecuted,
         totalTokens: state.totalTokens + sanitizedUsageTokens,
@@ -336,6 +360,26 @@ export const isWithinExecutionLimits = (
         nextStepKind === 'plan' ||
         nextStepKind === 'assess' ||
         nextStepKind === 'revise';
+    const maxPlanCycles =
+        limits.maxPlanCycles ?? Math.max(0, limits.maxDeliberationCalls);
+    const maxReviewCycles =
+        limits.maxReviewCycles ??
+        Math.max(0, limits.maxDeliberationCalls - maxPlanCycles);
+    if (nextStepKind === 'plan' && state.planCallCount >= maxPlanCycles) {
+        return {
+            withinLimits: false,
+            exhaustedBy: 'maxDeliberationCalls',
+        };
+    }
+    if (
+        (nextStepKind === 'assess' || nextStepKind === 'revise') &&
+        state.reviewCallCount >= maxReviewCycles
+    ) {
+        return {
+            withinLimits: false,
+            exhaustedBy: 'maxDeliberationCalls',
+        };
+    }
     if (
         isNextStepDeliberative &&
         state.deliberationCallCount >= limits.maxDeliberationCalls
@@ -659,6 +703,8 @@ export const runBoundedReviewWorkflow = async ({
     parseReviewDecision,
     captureUsage,
     plannerStepRecord,
+    plannerStepRequest,
+    plannerStepExecutor,
     contextStepRequest,
     contextStepExecutor,
 }: RunBoundedReviewWorkflowInput): Promise<RunBoundedReviewWorkflowResult> => {
@@ -703,6 +749,7 @@ export const runBoundedReviewWorkflow = async ({
         stepCounter = 1;
         plannerRootStepId = plannerStepRecord.stepId;
     }
+    let plannerExecutionResult: PlannerStepResult | undefined;
     let terminationReason: WorkflowTerminationReason = 'budget_exhausted_steps';
     let workflowStatus: WorkflowRecord['status'] = 'degraded';
     let draftResult: GenerationResult | null = null;
@@ -729,6 +776,15 @@ export const runBoundedReviewWorkflow = async ({
             workflowConfig.executionLimits?.maxToolCalls ?? UNBOUNDED_LIMIT,
             UNBOUNDED_LIMIT
         ),
+        maxPlanCycles: sanitizeNonNegativeInteger(
+            workflowConfig.executionLimits?.maxPlanCycles ?? 1,
+            1
+        ),
+        maxReviewCycles: sanitizeNonNegativeInteger(
+            workflowConfig.executionLimits?.maxReviewCycles ??
+                Math.max(0, normalizedMaxIterations * 2 - 1),
+            Math.max(0, normalizedMaxIterations * 2 - 1)
+        ),
         maxDeliberationCalls: sanitizeNonNegativeInteger(
             workflowConfig.executionLimits?.maxDeliberationCalls ??
                 Math.max(1, normalizedMaxIterations * 2),
@@ -744,6 +800,11 @@ export const runBoundedReviewWorkflow = async ({
             normalizedMaxDurationMs
         ),
     };
+    executionLimits.maxDeliberationCalls = Math.max(
+        executionLimits.maxDeliberationCalls,
+        (executionLimits.maxPlanCycles ?? 0) +
+            (executionLimits.maxReviewCycles ?? 0)
+    );
     const effectiveMaxIterations =
         workflowConfig.executionLimits !== undefined
             ? Math.max(
@@ -845,6 +906,66 @@ export const runBoundedReviewWorkflow = async ({
         shouldStop = true;
         return true;
     };
+
+    if (
+        plannerRootStepId === undefined &&
+        plannerStepRequest !== undefined &&
+        plannerStepExecutor !== undefined
+    ) {
+        if (
+            !isTransitionAllowed(
+                workflowState.currentStepKind,
+                'plan',
+                workflowPolicy
+            )
+        ) {
+            terminationReason = 'transition_blocked_by_policy';
+            shouldStop = true;
+        } else if (!stopIfOverLimits('plan')) {
+            const plannerStartedAt = Date.now();
+            plannerExecutionResult = await plannerStepExecutor({
+                ...plannerStepRequest,
+                workflowId,
+                workflowName: workflowConfig.workflowName,
+                attempt: 1,
+            });
+            const plannerFinishedAt = Date.now();
+            const plannerStep = buildPlannerStepRecord({
+                stepId: 'step_1',
+                attempt: 1,
+                startedAtMs: plannerStartedAt,
+                finishedAtMs: plannerFinishedAt,
+                summary: {
+                    status: plannerExecutionResult.execution.status,
+                    ...(plannerExecutionResult.execution.reasonCode !==
+                        undefined && {
+                        reasonCode: plannerExecutionResult.execution.reasonCode,
+                    }),
+                    purpose: plannerExecutionResult.execution.purpose,
+                    contractType: plannerExecutionResult.execution.contractType,
+                    applyOutcome:
+                        plannerExecutionResult.execution.status === 'executed'
+                            ? 'applied'
+                            : 'not_applied',
+                    durationMs: plannerExecutionResult.execution.durationMs,
+                    action: plannerExecutionResult.plan.action,
+                    modality: plannerExecutionResult.plan.modality,
+                    requestedCapabilityProfile:
+                        plannerExecutionResult.plan.requestedCapabilityProfile,
+                },
+            });
+            workflowSteps.push(plannerStep);
+            stepCounter = 1;
+            plannerRootStepId = plannerStep.stepId;
+            workflowState = applyStepExecutionToState(
+                workflowState,
+                'plan',
+                0,
+                0,
+                1
+            );
+        }
+    }
 
     const injectContextMessagesIntoPrompt = (
         baseMessages: RuntimeMessage[],

--- a/packages/backend/src/services/workflowProfileContract.ts
+++ b/packages/backend/src/services/workflowProfileContract.ts
@@ -57,6 +57,8 @@ export type WorkflowProfilePolicyContract = {
 export type WorkflowProfileExecutionLimitsContract = {
     maxWorkflowSteps: number;
     maxToolCalls: number;
+    maxPlanCycles?: number;
+    maxReviewCycles?: number;
     maxDeliberationCalls: number;
     maxTokensTotal: number;
     maxDurationMs: number;

--- a/packages/backend/src/services/workflowProfileRegistry.ts
+++ b/packages/backend/src/services/workflowProfileRegistry.ts
@@ -620,10 +620,16 @@ export const resolveWorkflowRuntimeConfig = (input: {
     const defaultReviewCycles =
         workflowProfile.defaultLimits.maxReviewCycles ??
         Math.max(0, workflowProfile.defaultLimits.maxDeliberationCalls - 1);
+    const contractBudget = sanitizeNonNegativeInteger(
+        executionContract?.limits.maxDeliberationCalls ?? Infinity,
+        Infinity
+    );
     const resolvedMaxPlanCycles = Math.min(
         sanitizeNonNegativeInteger(defaultPlanCycles, defaultPlanCycles),
-        sanitizeNonNegativeInteger(modeMaxPlanCycles, modeMaxPlanCycles)
+        sanitizeNonNegativeInteger(modeMaxPlanCycles, modeMaxPlanCycles),
+        contractBudget
     );
+    const remainingBudget = Math.max(0, contractBudget - resolvedMaxPlanCycles);
     const resolvedMaxReviewCycles = Math.min(
         sanitizeNonNegativeInteger(
             executionContract?.limits.maxDeliberationCalls !== undefined
@@ -633,7 +639,8 @@ export const resolveWorkflowRuntimeConfig = (input: {
                   : input.maxIterations * 2,
             defaultReviewCycles
         ),
-        sanitizeNonNegativeInteger(modeMaxReviewCycles, modeMaxReviewCycles)
+        sanitizeNonNegativeInteger(modeMaxReviewCycles, modeMaxReviewCycles),
+        remainingBudget
     );
     const resolvedMaxDeliberationCalls =
         resolvedMaxPlanCycles + resolvedMaxReviewCycles;

--- a/packages/backend/src/services/workflowProfileRegistry.ts
+++ b/packages/backend/src/services/workflowProfileRegistry.ts
@@ -68,6 +68,8 @@ const QUALITY_GROUNDED_DEFAULT_LIMITS: Readonly<
 > = {
     maxWorkflowSteps: 4,
     maxToolCalls: 0,
+    maxPlanCycles: 1,
+    maxReviewCycles: 3,
     maxDeliberationCalls: 4,
     maxTokensTotal: Number.MAX_SAFE_INTEGER,
     maxDurationMs: 15000,
@@ -78,7 +80,9 @@ const FAST_DIRECT_DEFAULT_LIMITS: Readonly<
 > = {
     maxWorkflowSteps: 1,
     maxToolCalls: 0,
-    maxDeliberationCalls: 0,
+    maxPlanCycles: 1,
+    maxReviewCycles: 0,
+    maxDeliberationCalls: 1,
     maxTokensTotal: Number.MAX_SAFE_INTEGER,
     maxDurationMs: 15000,
 };
@@ -170,7 +174,9 @@ const WORKFLOW_MODE_BEHAVIOR_MAP: Readonly<
         reviseStep: 'disallowed',
         evidencePosture: 'minimal',
         maxWorkflowSteps: 1,
-        maxDeliberationCalls: 0,
+        maxPlanCycles: 1,
+        maxReviewCycles: 0,
+        maxDeliberationCalls: 1,
     },
     balanced: {
         executionContractPresetId: 'balanced',
@@ -181,6 +187,8 @@ const WORKFLOW_MODE_BEHAVIOR_MAP: Readonly<
         reviseStep: 'allowed',
         evidencePosture: 'balanced',
         maxWorkflowSteps: 4,
+        maxPlanCycles: 1,
+        maxReviewCycles: 1,
         maxDeliberationCalls: 2,
     },
     grounded: {
@@ -192,6 +200,8 @@ const WORKFLOW_MODE_BEHAVIOR_MAP: Readonly<
         reviseStep: 'allowed',
         evidencePosture: 'strict',
         maxWorkflowSteps: 8,
+        maxPlanCycles: 1,
+        maxReviewCycles: 3,
         maxDeliberationCalls: 4,
     },
 };
@@ -218,10 +228,13 @@ export const deriveReviewIntensityFromWorkflowBehavior = (
         return 'none';
     }
 
-    if (behavior.maxDeliberationCalls <= 1) {
+    const maxReviewCycles =
+        behavior.maxReviewCycles ??
+        Math.max(0, behavior.maxDeliberationCalls - 1);
+    if (maxReviewCycles <= 1) {
         return 'light';
     }
-    if (behavior.maxDeliberationCalls <= 3) {
+    if (maxReviewCycles <= 3) {
         return 'moderate';
     }
     return 'high';
@@ -595,6 +608,35 @@ export const resolveWorkflowRuntimeConfig = (input: {
         workflowProfile.policy.enableAssessment === false
             ? 1
             : Math.max(1, profileDefaultMaxIterations * 2);
+    const modeMaxPlanCycles =
+        modeDecision.behavior.maxPlanCycles ??
+        (modeDecision.behavior.workflowExecution === 'disabled' ? 0 : 1);
+    const modeMaxReviewCycles =
+        modeDecision.behavior.maxReviewCycles ??
+        Math.max(0, modeDecision.behavior.maxDeliberationCalls - 1);
+    const defaultPlanCycles =
+        workflowProfile.defaultLimits.maxPlanCycles ??
+        (workflowProfile.requiredHooks.forceWorkflowExecution ? 1 : 0);
+    const defaultReviewCycles =
+        workflowProfile.defaultLimits.maxReviewCycles ??
+        Math.max(0, workflowProfile.defaultLimits.maxDeliberationCalls - 1);
+    const resolvedMaxPlanCycles = Math.min(
+        sanitizeNonNegativeInteger(defaultPlanCycles, defaultPlanCycles),
+        sanitizeNonNegativeInteger(modeMaxPlanCycles, modeMaxPlanCycles)
+    );
+    const resolvedMaxReviewCycles = Math.min(
+        sanitizeNonNegativeInteger(
+            executionContract?.limits.maxDeliberationCalls !== undefined
+                ? Math.max(0, executionContract.limits.maxDeliberationCalls - 1)
+                : workflowProfile.policy.enableAssessment === false
+                  ? 0
+                  : input.maxIterations * 2,
+            defaultReviewCycles
+        ),
+        sanitizeNonNegativeInteger(modeMaxReviewCycles, modeMaxReviewCycles)
+    );
+    const resolvedMaxDeliberationCalls =
+        resolvedMaxPlanCycles + resolvedMaxReviewCycles;
     const workflowExecutionLimits: RuntimeWorkflowProfile['defaultLimits'] = {
         maxWorkflowSteps: Math.min(
             sanitizePositiveInteger(
@@ -611,16 +653,9 @@ export const resolveWorkflowRuntimeConfig = (input: {
                 workflowProfile.defaultLimits.maxToolCalls,
             workflowProfile.defaultLimits.maxToolCalls
         ),
-        maxDeliberationCalls: Math.min(
-            sanitizeNonNegativeInteger(
-                executionContract?.limits.maxDeliberationCalls ??
-                    (workflowProfile.policy.enableAssessment === false
-                        ? 0
-                        : input.maxIterations * 2),
-                workflowProfile.defaultLimits.maxDeliberationCalls
-            ),
-            modeDecision.behavior.maxDeliberationCalls
-        ),
+        maxPlanCycles: resolvedMaxPlanCycles,
+        maxReviewCycles: resolvedMaxReviewCycles,
+        maxDeliberationCalls: resolvedMaxDeliberationCalls,
         maxTokensTotal: sanitizeNonNegativeInteger(
             executionContract?.limits.maxTokensTotal ??
                 workflowProfile.defaultLimits.maxTokensTotal,

--- a/packages/backend/test/chatOrchestrator.test.ts
+++ b/packages/backend/test/chatOrchestrator.test.ts
@@ -248,6 +248,45 @@ test('message plans pass planner generation options into chatService', async () 
     );
 });
 
+test('planner invocation remains pre-workflow in current groundwork branch', async () => {
+    const callOrder: string[] = [];
+    const orchestrator = createChatOrchestrator({
+        generationRuntime: createGenerationRuntime(async (request) => {
+            if (request.maxOutputTokens === PLANNER_TOKEN_SENTINEL) {
+                callOrder.push('planner');
+                return {
+                    text: JSON.stringify({
+                        action: 'message',
+                        modality: 'text',
+                        safetyTier: 'Low',
+                        reasoning: 'Plan first.',
+                        generation: {
+                            reasoningEffort: 'low',
+                            verbosity: 'low',
+                        },
+                    }),
+                    model: 'gpt-5-mini',
+                };
+            }
+            callOrder.push('generation');
+            return {
+                text: 'ok',
+                model: 'gpt-5-mini',
+                provenance: 'Inferred',
+                citations: [],
+            };
+        }),
+        storeTrace: async () => undefined,
+        buildResponseMetadata: () => createMetadata(),
+        defaultModel: 'gpt-5-mini',
+        recordUsage: () => undefined,
+    });
+
+    const response = await orchestrator.runChat(createChatRequest());
+    assert.equal(response.action, 'message');
+    assert.deepEqual(callOrder, ['planner', 'generation']);
+});
+
 test('orchestrator carries resolved Execution Contract policy payload through service runtime seam', async () => {
     let capturedConversationSnapshot: string | undefined;
     const orchestrator = createChatOrchestrator({

--- a/packages/backend/test/chatOrchestrator.test.ts
+++ b/packages/backend/test/chatOrchestrator.test.ts
@@ -162,6 +162,82 @@ test('discord requests preserve non-message planner actions', async () => {
     assert.equal(response.imageRequest.prompt, 'draw a chative skyline');
 });
 
+test('discord requests preserve planner react action without generation call', async () => {
+    let callCount = 0;
+    const orchestrator = createChatOrchestrator({
+        generationRuntime: createGenerationRuntime(
+            async ({ maxOutputTokens }) => {
+                callCount += 1;
+                if (maxOutputTokens === PLANNER_TOKEN_SENTINEL) {
+                    return {
+                        text: JSON.stringify({
+                            action: 'react',
+                            modality: 'text',
+                            reaction: '🔥',
+                            safetyTier: 'Low',
+                            reasoning: 'Reaction is enough.',
+                            generation: {
+                                reasoningEffort: 'low',
+                                verbosity: 'low',
+                            },
+                        }),
+                        model: 'gpt-5-mini',
+                    };
+                }
+                throw new Error(
+                    'message generation should not run for react actions'
+                );
+            }
+        ),
+        storeTrace: async () => undefined,
+        buildResponseMetadata: () => createMetadata(),
+        defaultModel: 'gpt-5-mini',
+        recordUsage: () => undefined,
+    });
+
+    const response = await orchestrator.runChat(createChatRequest());
+    assert.equal(callCount, 1);
+    assert.equal(response.action, 'react');
+    assert.equal(response.reaction, '🔥');
+});
+
+test('discord requests preserve planner ignore action without generation call', async () => {
+    let callCount = 0;
+    const orchestrator = createChatOrchestrator({
+        generationRuntime: createGenerationRuntime(
+            async ({ maxOutputTokens }) => {
+                callCount += 1;
+                if (maxOutputTokens === PLANNER_TOKEN_SENTINEL) {
+                    return {
+                        text: JSON.stringify({
+                            action: 'ignore',
+                            modality: 'text',
+                            safetyTier: 'Low',
+                            reasoning: 'No response needed.',
+                            generation: {
+                                reasoningEffort: 'low',
+                                verbosity: 'low',
+                            },
+                        }),
+                        model: 'gpt-5-mini',
+                    };
+                }
+                throw new Error(
+                    'message generation should not run for ignore actions'
+                );
+            }
+        ),
+        storeTrace: async () => undefined,
+        buildResponseMetadata: () => createMetadata(),
+        defaultModel: 'gpt-5-mini',
+        recordUsage: () => undefined,
+    });
+
+    const response = await orchestrator.runChat(createChatRequest());
+    assert.equal(callCount, 1);
+    assert.equal(response.action, 'ignore');
+});
+
 test('message plans pass planner generation options into chatService', async () => {
     let finalMessages: Array<{ role: string; content: string }> = [];
     const expectedResponseProfile =

--- a/packages/backend/test/chatService.test.ts
+++ b/packages/backend/test/chatService.test.ts
@@ -2257,3 +2257,147 @@ test('runChatMessages preserves local response authority when TrustGraph ownersh
     assert.equal(trustGraph?.terminalAuthority, 'backend_execution_contract');
     assert.equal(trustGraph?.failOpenBehavior, 'local_behavior');
 });
+
+test('runChatMessages surfaces workflow terminal react outcome as terminal action response', async () => {
+    const chatService = createChatService({
+        generationRuntime: createRuntime(),
+        storeTrace: async () => undefined,
+        buildResponseMetadata: () => createMetadata(),
+        defaultModel: 'gpt-5-mini',
+        recordUsage: () => undefined,
+        runReviewWorkflow: async (input) =>
+            ({
+                outcome: 'terminal_action',
+                terminalAction: {
+                    responseAction: 'react',
+                    reaction: '🔥',
+                },
+                workflowLineage: {
+                    workflowId: 'wf_terminal_react',
+                    workflowName: input.workflowConfig.workflowName,
+                    status: 'completed',
+                    terminationReason: 'goal_satisfied',
+                    stepCount: 1,
+                    maxSteps: 2,
+                    maxDurationMs: input.workflowConfig.maxDurationMs,
+                    steps: [],
+                },
+            }) satisfies RunBoundedReviewWorkflowResult,
+    });
+
+    const result = await chatService.runChatMessagesWithOutcome({
+        messages: [{ role: 'user', content: 'React only' }],
+        conversationSnapshot: 'React only',
+        plannerActionOutcome: {
+            kind: 'terminal_action',
+            terminalAction: {
+                responseAction: 'react',
+                reaction: '🔥',
+            },
+        },
+    });
+
+    assert.equal(result.kind, 'terminal_action');
+    if (result.kind !== 'terminal_action') {
+        throw new Error('Expected terminal_action result');
+    }
+    assert.equal(result.response.action, 'react');
+});
+
+test('runChatMessages surfaces workflow terminal ignore outcome as terminal action response', async () => {
+    const chatService = createChatService({
+        generationRuntime: createRuntime(),
+        storeTrace: async () => undefined,
+        buildResponseMetadata: () => createMetadata(),
+        defaultModel: 'gpt-5-mini',
+        recordUsage: () => undefined,
+        runReviewWorkflow: async (input) =>
+            ({
+                outcome: 'terminal_action',
+                terminalAction: {
+                    responseAction: 'ignore',
+                },
+                workflowLineage: {
+                    workflowId: 'wf_terminal_ignore',
+                    workflowName: input.workflowConfig.workflowName,
+                    status: 'completed',
+                    terminationReason: 'goal_satisfied',
+                    stepCount: 1,
+                    maxSteps: 2,
+                    maxDurationMs: input.workflowConfig.maxDurationMs,
+                    steps: [],
+                },
+            }) satisfies RunBoundedReviewWorkflowResult,
+    });
+
+    const result = await chatService.runChatMessagesWithOutcome({
+        messages: [{ role: 'user', content: 'Ignore this' }],
+        conversationSnapshot: 'Ignore this',
+        plannerActionOutcome: {
+            kind: 'terminal_action',
+            terminalAction: {
+                responseAction: 'ignore',
+            },
+        },
+    });
+
+    assert.equal(result.kind, 'terminal_action');
+    if (result.kind !== 'terminal_action') {
+        throw new Error('Expected terminal_action result');
+    }
+    assert.equal(result.response.action, 'ignore');
+});
+
+test('runChatMessages surfaces workflow terminal image outcome as terminal action response', async () => {
+    const chatService = createChatService({
+        generationRuntime: createRuntime(),
+        storeTrace: async () => undefined,
+        buildResponseMetadata: () => createMetadata(),
+        defaultModel: 'gpt-5-mini',
+        recordUsage: () => undefined,
+        runReviewWorkflow: async (input) =>
+            ({
+                outcome: 'terminal_action',
+                terminalAction: {
+                    responseAction: 'image',
+                    imageRequest: {
+                        prompt: 'Draw a skyline',
+                    },
+                },
+                workflowLineage: {
+                    workflowId: 'wf_terminal_image',
+                    workflowName: input.workflowConfig.workflowName,
+                    status: 'completed',
+                    terminationReason: 'goal_satisfied',
+                    stepCount: 1,
+                    maxSteps: 2,
+                    maxDurationMs: input.workflowConfig.maxDurationMs,
+                    steps: [],
+                },
+            }) satisfies RunBoundedReviewWorkflowResult,
+    });
+
+    const result = await chatService.runChatMessagesWithOutcome({
+        messages: [{ role: 'user', content: 'Generate image' }],
+        conversationSnapshot: 'Generate image',
+        plannerActionOutcome: {
+            kind: 'terminal_action',
+            terminalAction: {
+                responseAction: 'image',
+                imageRequest: {
+                    prompt: 'Draw a skyline',
+                },
+            },
+        },
+    });
+
+    assert.equal(result.kind, 'terminal_action');
+    if (result.kind !== 'terminal_action') {
+        throw new Error('Expected terminal_action result');
+    }
+    assert.equal(result.response.action, 'image');
+    if (result.response.action !== 'image') {
+        throw new Error('Expected image action');
+    }
+    assert.equal(result.response.imageRequest.prompt, 'Draw a skyline');
+});

--- a/packages/backend/test/plannerActionOutcome.test.ts
+++ b/packages/backend/test/plannerActionOutcome.test.ts
@@ -1,0 +1,106 @@
+/**
+ * @description: Verifies planner action outcome classification for terminal and message-continuation paths.
+ * @footnote-scope: test
+ * @footnote-module: PlannerActionOutcomeTests
+ * @footnote-risk: medium - Incorrect action classification can break non-message routing parity.
+ * @footnote-ethics: medium - Action outcome routing changes user-visible response behavior.
+ */
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import type { PostChatRequest } from '@footnote/contracts/web';
+import type { ChatPlan } from '../src/services/chatPlanner.js';
+import { resolvePlannerActionOutcome } from '../src/services/chatService/plannerActionOutcome.js';
+
+const createRequest = (): PostChatRequest => ({
+    surface: 'discord',
+    trigger: { kind: 'direct' },
+    latestUserInput: 'hello',
+    conversation: [{ role: 'user', content: 'hello' }],
+    capabilities: {
+        canReact: true,
+        canGenerateImages: true,
+        canUseTts: true,
+    },
+});
+
+const createPlan = (overrides: Partial<ChatPlan> = {}): ChatPlan => ({
+    action: 'message',
+    modality: 'text',
+    safetyTier: 'Low',
+    reasoning: 'reason',
+    generation: {
+        reasoningEffort: 'low',
+        verbosity: 'low',
+    },
+    ...overrides,
+});
+
+test('resolvePlannerActionOutcome returns continue_message for message actions', () => {
+    const outcome = resolvePlannerActionOutcome({
+        executionPlan: createPlan(),
+        normalizedRequest: createRequest(),
+    });
+    assert.equal(outcome.kind, 'continue_message');
+});
+
+test('resolvePlannerActionOutcome returns terminal react action', () => {
+    const outcome = resolvePlannerActionOutcome({
+        executionPlan: createPlan({ action: 'react', reaction: '🔥' }),
+        normalizedRequest: createRequest(),
+    });
+    assert.equal(outcome.kind, 'terminal_action');
+    if (outcome.kind !== 'terminal_action') {
+        throw new Error('Expected terminal action');
+    }
+    assert.equal(outcome.terminalAction.responseAction, 'react');
+    assert.equal(outcome.terminalAction.response.action, 'react');
+    if (outcome.terminalAction.response.action !== 'react') {
+        throw new Error('Expected react response');
+    }
+    assert.equal(outcome.terminalAction.response.reaction, '🔥');
+});
+
+test('resolvePlannerActionOutcome returns terminal ignore action', () => {
+    const outcome = resolvePlannerActionOutcome({
+        executionPlan: createPlan({ action: 'ignore' }),
+        normalizedRequest: createRequest(),
+    });
+    assert.equal(outcome.kind, 'terminal_action');
+    if (outcome.kind !== 'terminal_action') {
+        throw new Error('Expected terminal action');
+    }
+    assert.equal(outcome.terminalAction.responseAction, 'ignore');
+    assert.equal(outcome.terminalAction.response.action, 'ignore');
+});
+
+test('resolvePlannerActionOutcome returns terminal image action', () => {
+    const outcome = resolvePlannerActionOutcome({
+        executionPlan: createPlan({
+            action: 'image',
+            imageRequest: {
+                prompt: 'draw a skyline',
+            },
+        }),
+        normalizedRequest: createRequest(),
+    });
+    assert.equal(outcome.kind, 'terminal_action');
+    if (outcome.kind !== 'terminal_action') {
+        throw new Error('Expected terminal action');
+    }
+    assert.equal(outcome.terminalAction.responseAction, 'image');
+    assert.equal(outcome.terminalAction.response.action, 'image');
+});
+
+test('resolvePlannerActionOutcome fails open to ignore for image action without imageRequest', () => {
+    const outcome = resolvePlannerActionOutcome({
+        executionPlan: createPlan({ action: 'image', imageRequest: undefined }),
+        normalizedRequest: createRequest(),
+    });
+    assert.equal(outcome.kind, 'terminal_action');
+    if (outcome.kind !== 'terminal_action') {
+        throw new Error('Expected terminal action');
+    }
+    assert.equal(outcome.terminalAction.responseAction, 'ignore');
+    assert.equal(outcome.terminalAction.response.action, 'ignore');
+    assert.equal(outcome.fallbackReason, 'image_action_missing_image_request');
+});

--- a/packages/backend/test/plannerActionOutcome.test.ts
+++ b/packages/backend/test/plannerActionOutcome.test.ts
@@ -53,11 +53,10 @@ test('resolvePlannerActionOutcome returns terminal react action', () => {
         throw new Error('Expected terminal action');
     }
     assert.equal(outcome.terminalAction.responseAction, 'react');
-    assert.equal(outcome.terminalAction.response.action, 'react');
-    if (outcome.terminalAction.response.action !== 'react') {
+    if (outcome.terminalAction.responseAction !== 'react') {
         throw new Error('Expected react response');
     }
-    assert.equal(outcome.terminalAction.response.reaction, '🔥');
+    assert.equal(outcome.terminalAction.reaction, '🔥');
 });
 
 test('resolvePlannerActionOutcome returns terminal ignore action', () => {
@@ -70,7 +69,6 @@ test('resolvePlannerActionOutcome returns terminal ignore action', () => {
         throw new Error('Expected terminal action');
     }
     assert.equal(outcome.terminalAction.responseAction, 'ignore');
-    assert.equal(outcome.terminalAction.response.action, 'ignore');
 });
 
 test('resolvePlannerActionOutcome returns terminal image action', () => {
@@ -88,7 +86,10 @@ test('resolvePlannerActionOutcome returns terminal image action', () => {
         throw new Error('Expected terminal action');
     }
     assert.equal(outcome.terminalAction.responseAction, 'image');
-    assert.equal(outcome.terminalAction.response.action, 'image');
+    if (outcome.terminalAction.responseAction !== 'image') {
+        throw new Error('Expected image response');
+    }
+    assert.equal(outcome.terminalAction.imageRequest.prompt, 'draw a skyline');
 });
 
 test('resolvePlannerActionOutcome fails open to ignore for image action without imageRequest', () => {
@@ -101,6 +102,5 @@ test('resolvePlannerActionOutcome fails open to ignore for image action without 
         throw new Error('Expected terminal action');
     }
     assert.equal(outcome.terminalAction.responseAction, 'ignore');
-    assert.equal(outcome.terminalAction.response.action, 'ignore');
     assert.equal(outcome.fallbackReason, 'image_action_missing_image_request');
 });

--- a/packages/backend/test/plannerResultApplier.test.ts
+++ b/packages/backend/test/plannerResultApplier.test.ts
@@ -1,0 +1,196 @@
+/**
+ * @description: Verifies planner-result policy application seam behavior.
+ * @footnote-scope: test
+ * @footnote-module: PlannerResultApplierTests
+ * @footnote-risk: medium - Regressions here can misapply planner suggestions and alter routing.
+ * @footnote-ethics: high - This seam enforces planner-advisory boundaries under backend policy.
+ */
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import type { PostChatRequest } from '@footnote/contracts/web';
+import { runtimeConfig } from '../src/config.js';
+import { resolveExecutionContract } from '../src/services/executionContractResolver.js';
+import { createPlannerResultApplier } from '../src/services/chatOrchestrator/plannerResultApplier.js';
+import type { PlannerStepResult } from '../src/services/plannerWorkflowSeams.js';
+
+const createChatRequest = (
+    overrides: Partial<PostChatRequest> = {}
+): PostChatRequest => ({
+    surface: 'discord',
+    trigger: { kind: 'direct' },
+    latestUserInput: 'Weather in Paris please',
+    conversation: [{ role: 'user', content: 'Weather in Paris please' }],
+    capabilities: {
+        canReact: true,
+        canGenerateImages: true,
+        canUseTts: true,
+    },
+    ...overrides,
+});
+
+const createPlannerStepResult = (
+    overrides: Partial<PlannerStepResult> = {}
+): PlannerStepResult => ({
+    plan: {
+        action: 'message',
+        modality: 'text',
+        requestedCapabilityProfile: 'strict-review',
+        safetyTier: 'Low',
+        reasoning: 'Need weather details.',
+        generation: {
+            reasoningEffort: 'low',
+            verbosity: 'low',
+            toolIntent: {
+                toolName: 'weather_forecast',
+                requested: true,
+                input: {
+                    location: {
+                        type: 'place_query',
+                        query: 'Paris',
+                    },
+                },
+            },
+            search: {
+                query: 'Paris weather',
+                contextSize: 'low',
+                intent: 'current_facts',
+            },
+        },
+    },
+    execution: {
+        status: 'executed',
+        purpose: 'chat_orchestrator_action_selection',
+        contractType: 'text_json',
+        durationMs: 12,
+    },
+    ingestion: {
+        outputApplyOutcome: 'accepted',
+        fallbackTier: 'none',
+        correctionCodes: [],
+        outOfContractFields: [],
+        authorityFieldAttempts: [],
+    },
+    diagnostics: {
+        rawToolIntentPresent: true,
+        normalizedToolIntentPresent: true,
+        toolIntentRejected: false,
+        toolIntentRejectionReasons: [],
+        rawToolIntentName: 'weather_forecast',
+        normalizedToolIntentName: 'weather_forecast',
+    },
+    ...overrides,
+});
+
+const createApplier = () => {
+    const enabledProfiles = runtimeConfig.modelProfiles.catalog.filter(
+        (profile) => profile.enabled
+    );
+    const searchCapableProfiles = enabledProfiles.filter(
+        (profile) => profile.capabilities.canUseSearch
+    );
+    const enabledProfilesById = new Map(
+        enabledProfiles.map((profile) => [profile.id, profile])
+    );
+    const defaultResponseProfile =
+        enabledProfiles.find(
+            (profile) =>
+                profile.id === runtimeConfig.modelProfiles.defaultProfileId
+        ) ?? enabledProfiles[0];
+    assert.ok(defaultResponseProfile);
+
+    return createPlannerResultApplier({
+        enabledProfiles,
+        searchCapableProfiles,
+        enabledProfilesById,
+        defaultResponseProfile,
+        logger: {
+            debug: () => undefined,
+            warn: () => undefined,
+        },
+    });
+};
+
+test('PlannerResultApplier applies surface coercion for web requests', () => {
+    const applier = createApplier();
+    const output = applier({
+        normalizedRequest: createChatRequest({ surface: 'web' }),
+        plannerStepResult: createPlannerStepResult({
+            plan: {
+                ...createPlannerStepResult().plan,
+                action: 'react',
+                reaction: '👍',
+            },
+        }),
+        clarificationContinuation: { kind: 'none' },
+        resolvedExecutionPolicy: resolveExecutionContract({
+            presetId: 'fast-direct',
+        }).policyContract,
+    });
+
+    assert.equal(output.plan.action, 'message');
+    assert.ok(output.surfacePolicy);
+    assert.equal(output.plannerApplyOutcome, 'adjusted_by_policy');
+});
+
+test('PlannerResultApplier merges request generation overrides', () => {
+    const applier = createApplier();
+    const output = applier({
+        normalizedRequest: createChatRequest({
+            generation: {
+                reasoningEffort: 'high',
+                verbosity: 'high',
+            },
+        }),
+        plannerStepResult: createPlannerStepResult(),
+        clarificationContinuation: { kind: 'none' },
+        resolvedExecutionPolicy: resolveExecutionContract({
+            presetId: 'balanced',
+        }).policyContract,
+    });
+
+    assert.equal(output.generationForExecution.reasoningEffort, 'high');
+    assert.equal(output.generationForExecution.verbosity, 'high');
+});
+
+test('PlannerResultApplier enforces single-tool policy and derives weather context-step request', () => {
+    const applier = createApplier();
+    const output = applier({
+        normalizedRequest: createChatRequest(),
+        plannerStepResult: createPlannerStepResult(),
+        clarificationContinuation: { kind: 'none' },
+        resolvedExecutionPolicy: resolveExecutionContract({
+            presetId: 'quality-grounded',
+        }).policyContract,
+    });
+
+    assert.equal(output.toolRequestContext.toolName, 'weather_forecast');
+    assert.equal(output.toolRequestContext.requested, true);
+    assert.equal(
+        output.contextStepRequest?.integrationName,
+        'weather_forecast'
+    );
+    assert.equal(output.generationForExecution.search, undefined);
+});
+
+test('PlannerResultApplier resolves profile and keeps planner suggestions non-authoritative', () => {
+    const applier = createApplier();
+    const output = applier({
+        normalizedRequest: createChatRequest({
+            profileId: runtimeConfig.modelProfiles.defaultProfileId,
+        }),
+        plannerStepResult: createPlannerStepResult({
+            plan: {
+                ...createPlannerStepResult().plan,
+                requestedCapabilityProfile: 'strict-review',
+            },
+        }),
+        clarificationContinuation: { kind: 'none' },
+        resolvedExecutionPolicy: resolveExecutionContract({
+            presetId: 'fast-direct',
+        }).policyContract,
+    });
+
+    assert.equal(typeof output.selectedResponseProfile.id, 'string');
+    assert.equal(output.plan.profileId, output.selectedResponseProfile.id);
+    assert.equal(output.plannerApplyOutcome, 'adjusted_by_policy');
+});

--- a/packages/backend/test/postPlanAssembly.test.ts
+++ b/packages/backend/test/postPlanAssembly.test.ts
@@ -1,0 +1,111 @@
+/**
+ * @description: Verifies post-plan message and snapshot assembly remains stable.
+ * @footnote-scope: test
+ * @footnote-module: PostPlanAssemblyTests
+ * @footnote-risk: medium - Assembly drift can break planner payload ordering and runtime grounding hints.
+ * @footnote-ethics: medium - Stable assembly preserves auditable planner-to-generation boundaries.
+ */
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import type { PostChatRequest } from '@footnote/contracts/web';
+import { assemblePostPlanGenerationInput } from '../src/services/chatService/postPlanAssembly.js';
+
+const createRequest = (): PostChatRequest => ({
+    surface: 'discord',
+    trigger: { kind: 'direct' },
+    latestUserInput: 'hello',
+    conversation: [{ role: 'user', content: 'hello' }],
+    capabilities: {
+        canReact: true,
+        canGenerateImages: true,
+        canUseTts: true,
+    },
+});
+
+test('assemblePostPlanGenerationInput appends planner payload and preserves message ordering', () => {
+    const result = assemblePostPlanGenerationInput({
+        systemPrompt: 'system prompt',
+        personaPrompt: 'persona prompt',
+        normalizedConversation: [{ role: 'user', content: 'hello' }],
+        executionPlanForPrompt: {
+            action: 'message',
+            modality: 'text',
+            safetyTier: 'Low',
+            reasoning: 'reason',
+            generation: {
+                reasoningEffort: 'low',
+                verbosity: 'low',
+            },
+            profileId: 'generate-only',
+        },
+        normalizedRequest: createRequest(),
+        orchestrationSafetyTier: 'Low',
+        toolRequestContext: {
+            toolName: 'weather_forecast',
+            requested: false,
+            eligible: false,
+            reasonCode: 'tool_not_requested',
+        },
+        executionContract: {
+            policyId: 'policy-test',
+            policyVersion: '1',
+        },
+    });
+
+    assert.equal(result.conversationMessages.length, 4);
+    assert.equal(result.conversationMessages[0]?.content, 'system prompt');
+    assert.equal(result.conversationMessages[1]?.content, 'persona prompt');
+    assert.equal(result.conversationMessages[2]?.content, 'hello');
+    assert.match(
+        result.conversationMessages[3]?.content ?? '',
+        /BEGIN Planner Output/
+    );
+    assert.match(
+        result.conversationMessages[3]?.content ?? '',
+        /END Planner Output/
+    );
+});
+
+test('assemblePostPlanGenerationInput includes planner snapshot payload fields', () => {
+    const result = assemblePostPlanGenerationInput({
+        systemPrompt: 'system prompt',
+        personaPrompt: 'persona prompt',
+        normalizedConversation: [{ role: 'user', content: 'hello' }],
+        executionPlanForPrompt: {
+            action: 'message',
+            modality: 'text',
+            safetyTier: 'Low',
+            reasoning: 'reason',
+            generation: {
+                reasoningEffort: 'low',
+                verbosity: 'low',
+            },
+            profileId: 'generate-only',
+        },
+        normalizedRequest: createRequest(),
+        orchestrationSafetyTier: 'Low',
+        toolIntent: {
+            toolName: 'weather_forecast',
+            requested: true,
+        },
+        toolRequestContext: {
+            toolName: 'weather_forecast',
+            requested: true,
+            eligible: true,
+        },
+        executionContract: {
+            policyId: 'policy-test',
+            policyVersion: '1',
+        },
+    });
+    const snapshot = JSON.parse(result.conversationSnapshot) as {
+        planner?: {
+            toolIntent?: { toolName?: string };
+            toolRequest?: { toolName?: string };
+        };
+        executionContract?: { policyId?: string };
+    };
+    assert.equal(snapshot.planner?.toolIntent?.toolName, 'weather_forecast');
+    assert.equal(snapshot.planner?.toolRequest?.toolName, 'weather_forecast');
+    assert.equal(snapshot.executionContract?.policyId, 'policy-test');
+});

--- a/packages/backend/test/workflowEngine.test.ts
+++ b/packages/backend/test/workflowEngine.test.ts
@@ -7,6 +7,8 @@
  */
 import test from 'node:test';
 import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
 
 import {
     applyStepExecutionToState,
@@ -43,6 +45,26 @@ const createLimits = (): ExecutionLimits => ({
     maxDeliberationCalls: 3,
     maxTokensTotal: 100,
     maxDurationMs: 1000,
+});
+
+test('workflowEngine remains policy/runtime neutral and avoids orchestrator policy imports', () => {
+    const workflowEngineSource = readFileSync(
+        join(process.cwd(), 'src', 'services', 'workflowEngine.ts'),
+        'utf8'
+    );
+    assert.equal(
+        workflowEngineSource.includes(
+            "from './chatOrchestrator/plannerResultApplier"
+        ),
+        false
+    );
+    assert.equal(
+        workflowEngineSource.includes(
+            "from './chatOrchestrator/profileResolution"
+        ),
+        false
+    );
+    assert.equal(workflowEngineSource.includes("from './chatPlanner"), false);
 });
 
 test('isTransitionAllowed permits only plan/generate from initial state', () => {
@@ -177,6 +199,8 @@ test('isWithinExecutionLimits reports each exhausted limit key', () => {
             currentStepKind: 'generate',
             stepCount: 5,
             toolCallCount: 0,
+            planCallCount: 0,
+            reviewCallCount: 0,
             deliberationCallCount: 0,
             totalTokens: 0,
         },
@@ -194,6 +218,8 @@ test('isWithinExecutionLimits reports each exhausted limit key', () => {
             currentStepKind: 'generate',
             stepCount: 0,
             toolCallCount: 2,
+            planCallCount: 0,
+            reviewCallCount: 0,
             deliberationCallCount: 0,
             totalTokens: 0,
         },
@@ -212,6 +238,8 @@ test('isWithinExecutionLimits reports each exhausted limit key', () => {
             currentStepKind: 'assess',
             stepCount: 0,
             toolCallCount: 0,
+            planCallCount: 1,
+            reviewCallCount: 2,
             deliberationCallCount: 3,
             totalTokens: 0,
         },
@@ -230,6 +258,8 @@ test('isWithinExecutionLimits reports each exhausted limit key', () => {
             currentStepKind: 'assess',
             stepCount: 0,
             toolCallCount: 0,
+            planCallCount: 0,
+            reviewCallCount: 0,
             deliberationCallCount: 0,
             totalTokens: 100,
         },
@@ -247,6 +277,8 @@ test('isWithinExecutionLimits reports each exhausted limit key', () => {
             currentStepKind: 'assess',
             stepCount: 0,
             toolCallCount: 0,
+            planCallCount: 0,
+            reviewCallCount: 0,
             deliberationCallCount: 0,
             totalTokens: 0,
         },

--- a/packages/backend/test/workflowEngine.test.ts
+++ b/packages/backend/test/workflowEngine.test.ts
@@ -1404,3 +1404,120 @@ test('runBoundedReviewWorkflow stops before generation when injected context ste
         'ambiguous_location'
     );
 });
+
+test('runBoundedReviewWorkflow returns terminal planner action outcome without generation', async () => {
+    let generationCalls = 0;
+    const generationRuntime: GenerationRuntime = {
+        kind: 'test-runtime',
+        async generate() {
+            generationCalls += 1;
+            return {
+                text: 'should not run',
+                model: 'gpt-5-mini',
+                provenance: 'Inferred',
+                citations: [],
+            };
+        },
+    };
+
+    const result = await runBoundedReviewWorkflow({
+        generationRuntime,
+        generationRequest: {
+            model: 'gpt-5-mini',
+            messages: [{ role: 'user', content: 'Send a reaction' }],
+        },
+        messagesWithHints: [{ role: 'user', content: 'Send a reaction' }],
+        generationStartedAtMs: Date.now(),
+        workflowConfig: {
+            workflowName: 'generate-only',
+            maxIterations: 0,
+            maxDurationMs: 15000,
+        },
+        workflowPolicy: {
+            enablePlanning: true,
+            enableToolUse: false,
+            enableReplanning: false,
+            enableGeneration: true,
+            enableAssessment: false,
+            enableRevision: false,
+        },
+        plannerStepRequest: {
+            workflowId: 'wf_test',
+            workflowName: 'generate-only',
+            attempt: 1,
+            request: {
+                surface: 'web',
+                trigger: { kind: 'submit' },
+                latestUserInput: 'Send a reaction',
+                conversation: [{ role: 'user', content: 'Send a reaction' }],
+            },
+            invocationContext: {
+                owner: 'workflow',
+                workflowName: 'generate-only',
+                stepKind: 'plan',
+                purpose: 'chat_orchestrator_action_selection',
+            },
+            capabilityProfiles: [],
+        },
+        plannerStepExecutor: async () => ({
+            plan: {
+                action: 'react',
+                modality: 'text',
+                reaction: '🔥',
+                safetyTier: 'Low',
+                reasoning: 'Reaction is sufficient.',
+                generation: { reasoningEffort: 'low', verbosity: 'low' },
+            },
+            execution: {
+                status: 'executed',
+                purpose: 'chat_orchestrator_action_selection',
+                contractType: 'structured',
+                durationMs: 1,
+            },
+            ingestion: {
+                outputApplyOutcome: 'accepted',
+                fallbackTier: 'none',
+                correctionCodes: [],
+                outOfContractFields: [],
+                authorityFieldAttempts: [],
+            },
+            diagnostics: {
+                rawToolIntentPresent: false,
+                normalizedToolIntentPresent: false,
+                toolIntentRejected: false,
+                toolIntentRejectionReasons: [],
+            },
+        }),
+        postPlannerWorkflowAdapter: ({
+            plannerStepResult,
+            baseMessagesWithHints,
+            baseGenerationRequest,
+        }) => ({
+            terminalAction:
+                plannerStepResult.plan.action === 'react'
+                    ? { responseAction: 'react', reaction: '🔥' }
+                    : { responseAction: 'ignore' },
+            messagesWithHints: baseMessagesWithHints,
+            generationRequest: baseGenerationRequest,
+        }),
+        captureUsage: () => ({
+            model: 'gpt-5-mini',
+            promptTokens: 0,
+            completionTokens: 0,
+            totalTokens: 0,
+            estimatedCost: {
+                inputCostUsd: 0,
+                outputCostUsd: 0,
+                totalCostUsd: 0,
+            },
+        }),
+    });
+
+    assert.equal(generationCalls, 0);
+    assert.equal(result.outcome, 'terminal_action');
+    if (result.outcome !== 'terminal_action') {
+        throw new Error('Expected terminal action outcome');
+    }
+    assert.equal(result.terminalAction.responseAction, 'react');
+    assert.equal(result.workflowLineage.terminationReason, 'goal_satisfied');
+});

--- a/packages/backend/test/workflowProfileRegistry.test.ts
+++ b/packages/backend/test/workflowProfileRegistry.test.ts
@@ -118,9 +118,11 @@ test('resolveWorkflowRuntimeConfig applies forceWorkflowExecution and review-loo
     assert.equal(fastRuntimeConfig.profileId, 'generate-only');
     assert.equal(fastRuntimeConfig.workflowExecutionEnabled, true);
     assert.equal(fastRuntimeConfig.workflowExecutionLimits.maxWorkflowSteps, 1);
+    assert.equal(fastRuntimeConfig.workflowExecutionLimits.maxPlanCycles, 1);
+    assert.equal(fastRuntimeConfig.workflowExecutionLimits.maxReviewCycles, 0);
     assert.equal(
         fastRuntimeConfig.workflowExecutionLimits.maxDeliberationCalls,
-        0
+        1
     );
     assert.equal(fastRuntimeConfig.workflowExecutionLimits.maxDurationMs, 9000);
 
@@ -135,6 +137,14 @@ test('resolveWorkflowRuntimeConfig applies forceWorkflowExecution and review-loo
     assert.equal(
         groundedRuntimeConfig.workflowExecutionLimits.maxWorkflowSteps,
         8
+    );
+    assert.equal(
+        groundedRuntimeConfig.workflowExecutionLimits.maxPlanCycles,
+        1
+    );
+    assert.equal(
+        groundedRuntimeConfig.workflowExecutionLimits.maxReviewCycles,
+        3
     );
     assert.equal(
         groundedRuntimeConfig.workflowExecutionLimits.maxDeliberationCalls,
@@ -280,6 +290,8 @@ test('deriveReviewIntensityFromWorkflowBehavior centralizes review intensity map
             reviseStep: 'disallowed',
             evidencePosture: 'minimal',
             maxWorkflowSteps: 1,
+            maxPlanCycles: 1,
+            maxReviewCycles: 0,
             maxDeliberationCalls: 0,
         }),
         'none'
@@ -294,6 +306,8 @@ test('deriveReviewIntensityFromWorkflowBehavior centralizes review intensity map
             reviseStep: 'allowed',
             evidencePosture: 'balanced',
             maxWorkflowSteps: 4,
+            maxPlanCycles: 1,
+            maxReviewCycles: 1,
             maxDeliberationCalls: 1,
         }),
         'light'
@@ -308,6 +322,8 @@ test('deriveReviewIntensityFromWorkflowBehavior centralizes review intensity map
             reviseStep: 'allowed',
             evidencePosture: 'balanced',
             maxWorkflowSteps: 4,
+            maxPlanCycles: 1,
+            maxReviewCycles: 2,
             maxDeliberationCalls: 2,
         }),
         'moderate'
@@ -322,8 +338,36 @@ test('deriveReviewIntensityFromWorkflowBehavior centralizes review intensity map
             reviseStep: 'allowed',
             evidencePosture: 'strict',
             maxWorkflowSteps: 8,
+            maxPlanCycles: 1,
+            maxReviewCycles: 4,
             maxDeliberationCalls: 4,
         }),
         'high'
+    );
+});
+
+test('resolveWorkflowRuntimeConfig keeps maxDeliberationCalls compatibility mapped from plan/review cycles', () => {
+    const fast = resolveWorkflowRuntimeConfig({
+        modeId: 'fast',
+        reviewLoopEnabled: true,
+        maxIterations: 5,
+        maxDurationMs: 9000,
+    });
+    assert.equal(
+        fast.workflowExecutionLimits.maxDeliberationCalls,
+        (fast.workflowExecutionLimits.maxPlanCycles ?? 0) +
+            (fast.workflowExecutionLimits.maxReviewCycles ?? 0)
+    );
+
+    const balanced = resolveWorkflowRuntimeConfig({
+        modeId: 'balanced',
+        reviewLoopEnabled: true,
+        maxIterations: 5,
+        maxDurationMs: 9000,
+    });
+    assert.equal(
+        balanced.workflowExecutionLimits.maxDeliberationCalls,
+        (balanced.workflowExecutionLimits.maxPlanCycles ?? 0) +
+            (balanced.workflowExecutionLimits.maxReviewCycles ?? 0)
     );
 });

--- a/packages/contracts/src/ethics-core/types.ts
+++ b/packages/contracts/src/ethics-core/types.ts
@@ -519,6 +519,8 @@ export type WorkflowModeBehavior = {
     reviseStep: 'allowed' | 'disallowed';
     evidencePosture: WorkflowModeEvidencePosture;
     maxWorkflowSteps: number;
+    maxPlanCycles?: number;
+    maxReviewCycles?: number;
     maxDeliberationCalls: number;
 };
 

--- a/packages/contracts/src/web/schemas.ts
+++ b/packages/contracts/src/web/schemas.ts
@@ -710,6 +710,8 @@ const WorkflowModeBehaviorSchema = z
         reviseStep: z.enum(['allowed', 'disallowed']),
         evidencePosture: z.enum(['minimal', 'balanced', 'strict']),
         maxWorkflowSteps: z.number().int().positive(),
+        maxPlanCycles: z.number().int().nonnegative().optional(),
+        maxReviewCycles: z.number().int().nonnegative().optional(),
         maxDeliberationCalls: z.number().int().nonnegative(),
     })
     .strict();
@@ -842,7 +844,9 @@ const ImageGenerationMetadataSchema = z
     .strict();
 
 type _AssertImageGenerationMetadata =
-    z.infer<typeof ImageGenerationMetadataSchema> extends ImageGenerationMetadata
+    z.infer<
+        typeof ImageGenerationMetadataSchema
+    > extends ImageGenerationMetadata
         ? ImageGenerationMetadata extends z.infer<
               typeof ImageGenerationMetadataSchema
           >


### PR DESCRIPTION
## Summary

This branch adds foundational seams for the future planner timing cutover without moving planner timing into workflow execution. It reframes the branch as 'groundwork' in preparation for merge.

## Changes

- **PlannerResultApplier**: Policy-owned post-planner application seam
- **postPlanAssembly**: Moves planner payload assembly into chatService
- **plannerActionOutcome**: Classifies terminal vs message continuation
- **PostPlannerWorkflowAdapter**: Contract defined (not wired yet)
- **terminal_action outcome**: Added as workflow outcome type
- **Planning budgets**: maxPlanCycles/maxReviewCycles with maxDeliberationCalls mapping

## What This Branch Does NOT Do

- Planner timing still runs before workflow in chatOrchestrator
- Planner lineage bridge still remains
- web_search not migrated
- Weather context-step unchanged

## Next Branch

Suggested: workflow-planner-timing-injection - wire adapter into workflow path

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Workflow execution now supports separate cycle limits for planning and review phases (`maxPlanCycles`, `maxReviewCycles`).
  * Planner can now return terminal actions—react with emoji, ignore, or image generation—to end conversations early without additional message generation.

* **Documentation**
  * Updated architecture documentation describing new workflow seams and revised execution limits.
  * Updated rollout status reflecting completion of cycle-based budgeting and planner policy application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->