### PR TITLE
feat(backend): support parallel context-step execution

### DIFF
--- a/packages/backend/src/services/chatOrchestrator.ts
+++ b/packages/backend/src/services/chatOrchestrator.ts
@@ -594,8 +594,17 @@ export const createChatOrchestrator = ({
                 },
                 plannerTemperament: executionPlan.generation.temperament,
                 conversationSnapshot: postPlanAssembly.conversationSnapshot,
-                ...(plannerApplication.contextStepRequest !== undefined && {
-                    contextStepRequest: plannerApplication.contextStepRequest,
+                ...((plannerApplication.contextStepRequests !== undefined ||
+                    plannerApplication.contextStepRequest !== undefined) && {
+                    ...(plannerApplication.contextStepRequest !== undefined && {
+                        contextStepRequest:
+                            plannerApplication.contextStepRequest,
+                    }),
+                    contextStepRequests:
+                        plannerApplication.contextStepRequests ??
+                        (plannerApplication.contextStepRequest !== undefined
+                            ? [plannerApplication.contextStepRequest]
+                            : []),
                 }),
                 plannerSummary: buildPlannerSummary({
                     plannerStepResult: input.plannerStepResult,

--- a/packages/backend/src/services/chatService.ts
+++ b/packages/backend/src/services/chatService.ts
@@ -88,22 +88,18 @@ const SURFACED_NO_GENERATION_MESSAGE =
  * The short-circuit branch can return early when a context step asks for user
  * clarification or reports a known tool failure pattern.
  *
- * Compatibility rule: this branch reads one effective context-step execution
- * context (the existing single-result shape) for clarification/failure routing.
- * This keeps older callers stable while multi-context execution is available.
+ * Compatibility rule: this branch prefers the full context-step result list
+ * when available, and falls back to the legacy single-result field for older
+ * callers.
  *
  * Citation rule: when generation continues, citations from all executed context
  * integrations are merged later into assistant metadata. This helper does not
  * own that merge.
  *
- * TODO: This helper currently checks only one context-step result when deciding
- * whether to short-circuit for clarification or known tool failure. Update it
- * to evaluate the full list of context-step results so short-circuit decisions
- * reflect every executed integration, then remove this single-result
- * compatibility behavior.
  */
 const buildContextStepShortCircuit = ({
     workflowContextStepResult,
+    workflowContextStepResults,
     executionContext,
     toolRequest,
     model,
@@ -113,6 +109,7 @@ const buildContextStepShortCircuit = ({
     buildResponseMetadata,
 }: {
     workflowContextStepResult: ContextStepResult | undefined;
+    workflowContextStepResults?: ContextStepResult[];
     executionContext: ResponseMetadataRuntimeContext['executionContext'];
     toolRequest: ToolInvocationRequest | undefined;
     model: string | undefined;
@@ -129,12 +126,14 @@ const buildContextStepShortCircuit = ({
           telemetry: FinalToolExecutionTelemetry;
       }
     | undefined => {
-    if (workflowContextStepResult === undefined) {
+    const effectiveContextStepResults =
+        workflowContextStepResults ??
+        (workflowContextStepResult !== undefined
+            ? [workflowContextStepResult]
+            : []);
+    if (effectiveContextStepResults.length === 0) {
         return undefined;
     }
-
-    const { executionContext: contextExecutionContext } =
-        workflowContextStepResult;
 
     const buildGenerationMetadataContext = () => ({
         modelVersion: model ?? defaultModel,
@@ -167,60 +166,63 @@ const buildContextStepShortCircuit = ({
 
     const generationMetadataContext = buildGenerationMetadataContext();
 
-    if (contextExecutionContext.clarification !== undefined) {
-        const clarificationResponse = buildToolClarificationResponse({
-            toolContext: contextExecutionContext,
-            metadataContext: generationMetadataContext as Parameters<
-                typeof buildToolClarificationResponse
-            >[0]['metadataContext'],
-            buildResponseMetadata,
-        });
-        return {
-            response: clarificationResponse,
-            telemetry: {
-                toolName: contextExecutionContext.toolName,
-                status: contextExecutionContext.status,
-                ...(contextExecutionContext.reasonCode !== undefined && {
-                    reasonCode: contextExecutionContext.reasonCode,
-                }),
-                ...(toolRequest !== undefined && {
-                    eligible: toolRequest.eligible,
-                }),
-                ...(toolRequest?.reasonCode !== undefined && {
-                    requestReasonCode: toolRequest.reasonCode,
-                }),
-            },
-        };
-    }
+    for (const contextStepResult of effectiveContextStepResults) {
+        const contextExecutionContext = contextStepResult.executionContext;
+        if (contextExecutionContext.clarification !== undefined) {
+            const clarificationResponse = buildToolClarificationResponse({
+                toolContext: contextExecutionContext,
+                metadataContext: generationMetadataContext as Parameters<
+                    typeof buildToolClarificationResponse
+                >[0]['metadataContext'],
+                buildResponseMetadata,
+            });
+            return {
+                response: clarificationResponse,
+                telemetry: {
+                    toolName: contextExecutionContext.toolName,
+                    status: contextExecutionContext.status,
+                    ...(contextExecutionContext.reasonCode !== undefined && {
+                        reasonCode: contextExecutionContext.reasonCode,
+                    }),
+                    ...(toolRequest !== undefined && {
+                        eligible: toolRequest.eligible,
+                    }),
+                    ...(toolRequest?.reasonCode !== undefined && {
+                        requestReasonCode: toolRequest.reasonCode,
+                    }),
+                },
+            };
+        }
 
-    if (
-        contextExecutionContext.toolName === 'weather_forecast' &&
-        contextExecutionContext.status === 'failed'
-    ) {
-        const failureResponse = buildWeatherToolFailureResponse({
-            toolContext: contextExecutionContext,
-            metadataContext: generationMetadataContext as Parameters<
-                typeof buildWeatherToolFailureResponse
-            >[0]['metadataContext'],
-            latestUserInput: latestUserInput ?? conversationSnapshot,
-            buildResponseMetadata,
-        });
-        return {
-            response: failureResponse,
-            telemetry: {
-                toolName: contextExecutionContext.toolName,
-                status: contextExecutionContext.status,
-                ...(contextExecutionContext.reasonCode !== undefined && {
-                    reasonCode: contextExecutionContext.reasonCode,
-                }),
-                ...(toolRequest !== undefined && {
-                    eligible: toolRequest.eligible,
-                }),
-                ...(toolRequest?.reasonCode !== undefined && {
-                    requestReasonCode: toolRequest.reasonCode,
-                }),
-            },
-        };
+        if (
+            contextExecutionContext.toolName === 'weather_forecast' &&
+            contextExecutionContext.status === 'failed'
+        ) {
+            const failureResponse = buildWeatherToolFailureResponse({
+                toolContext: contextExecutionContext,
+                metadataContext: generationMetadataContext as Parameters<
+                    typeof buildWeatherToolFailureResponse
+                >[0]['metadataContext'],
+                latestUserInput: latestUserInput ?? conversationSnapshot,
+                buildResponseMetadata,
+            });
+            return {
+                response: failureResponse,
+                telemetry: {
+                    toolName: contextExecutionContext.toolName,
+                    status: contextExecutionContext.status,
+                    ...(contextExecutionContext.reasonCode !== undefined && {
+                        reasonCode: contextExecutionContext.reasonCode,
+                    }),
+                    ...(toolRequest !== undefined && {
+                        eligible: toolRequest.eligible,
+                    }),
+                    ...(toolRequest?.reasonCode !== undefined && {
+                        requestReasonCode: toolRequest.reasonCode,
+                    }),
+                },
+            };
+        }
     }
 
     return undefined;
@@ -876,6 +878,7 @@ export const createChatService = ({
                     workflowLineage = workflowResult.workflowLineage;
                     const generatedShortCircuit = buildContextStepShortCircuit({
                         workflowContextStepResult,
+                        workflowContextStepResults,
                         executionContext,
                         toolRequest,
                         model,
@@ -911,6 +914,7 @@ export const createChatService = ({
                     workflowLineage = workflowResult.workflowLineage;
                     const noGenShortCircuit = buildContextStepShortCircuit({
                         workflowContextStepResult,
+                        workflowContextStepResults,
                         executionContext,
                         toolRequest,
                         model,

--- a/packages/backend/src/services/chatService.ts
+++ b/packages/backend/src/services/chatService.ts
@@ -82,6 +82,13 @@ import { buildWeatherToolFailureResponse } from './tools/weatherToolFailureRespo
 const SURFACED_NO_GENERATION_MESSAGE =
     'I could not generate a response for this request.';
 
+/**
+ * Builds the fail-open short-circuit response surface for context-step outcomes.
+ *
+ * For compatibility, short-circuit branching uses one effective context-step
+ * execution context (clarification/failure handling). Multi-step citation merge
+ * still happens in assistant metadata after generation.
+ */
 const buildContextStepShortCircuit = ({
     workflowContextStepResult,
     executionContext,
@@ -1071,6 +1078,8 @@ export const createChatService = ({
             });
         }
 
+        // Backend authority merges all context-integration citations so callers
+        // consume one canonical metadata citation surface.
         const contextStepSources =
             workflowContextStepResults?.flatMap(
                 (contextStepResult) => contextStepResult.sources ?? []

--- a/packages/backend/src/services/chatService.ts
+++ b/packages/backend/src/services/chatService.ts
@@ -95,6 +95,12 @@ const SURFACED_NO_GENERATION_MESSAGE =
  * Citation rule: when generation continues, citations from all executed context
  * integrations are merged later into assistant metadata. This helper does not
  * own that merge.
+ *
+ * TODO: This helper currently checks only one context-step result when deciding
+ * whether to short-circuit for clarification or known tool failure. Update it
+ * to evaluate the full list of context-step results so short-circuit decisions
+ * reflect every executed integration, then remove this single-result
+ * compatibility behavior.
  */
 const buildContextStepShortCircuit = ({
     workflowContextStepResult,

--- a/packages/backend/src/services/chatService.ts
+++ b/packages/backend/src/services/chatService.ts
@@ -520,7 +520,9 @@ export type RunChatMessagesInput = {
     workflowModeEscalationRequest?: WorkflowModeEscalationRequest;
     toolRequest?: ToolInvocationRequest;
     contextStepRequest?: ContextStepRequest;
+    contextStepRequests?: ContextStepRequest[];
     contextStepExecutor?: ContextStepExecutor;
+    contextStepExecutorRegistry?: Record<string, ContextStepExecutor>;
     plannerStepRequest?: PlannerStepRequest;
     plannerStepExecutor?: PlannerStepExecutor;
     planContinuationBuilder?: PlanContinuationBuilder;
@@ -680,7 +682,9 @@ export const createChatService = ({
         workflowModeEscalationRequest,
         toolRequest,
         contextStepRequest,
+        contextStepRequests,
         contextStepExecutor,
+        contextStepExecutorRegistry,
         plannerStepRequest,
         plannerStepExecutor,
         planContinuationBuilder,
@@ -776,6 +780,7 @@ export const createChatService = ({
         let generationResult: GenerationResult;
         let workflowLineage: WorkflowRecord | undefined;
         let workflowContextStepResult: ContextStepResult | undefined;
+        let workflowContextStepResults: ContextStepResult[] | undefined;
         let workflowPlannerSummary: AppliedPlanState | undefined;
         let workflowPlannerStepResult: PlannerStepResult | undefined;
         let workflowConversationSnapshot: string | undefined;
@@ -817,7 +822,9 @@ export const createChatService = ({
                 plannerStepExecutor: effectivePlannerStepExecutor,
                 planContinuationBuilder,
                 contextStepRequest,
+                contextStepRequests,
                 contextStepExecutor,
+                contextStepExecutorRegistry,
             });
             workflowPlannerStepResult = workflowResult.plannerStepResult;
             workflowPlannerSummary =
@@ -842,6 +849,7 @@ export const createChatService = ({
                 workflowConversationSnapshot = undefined;
             }
             workflowContextStepResult = workflowResult.contextStepResult;
+            workflowContextStepResults = workflowResult.contextStepResults;
             switch (workflowResult.outcome) {
                 case 'generated': {
                     generationResult = workflowResult.generationResult;
@@ -1063,7 +1071,10 @@ export const createChatService = ({
             });
         }
 
-        const contextStepSources = workflowContextStepResult?.sources;
+        const contextStepSources =
+            workflowContextStepResults?.flatMap(
+                (contextStepResult) => contextStepResult.sources ?? []
+            ) ?? workflowContextStepResult?.sources;
         const assistantMetadata = buildAssistantMetadata(
             generationResult,
             effectiveNormalizedGeneration,

--- a/packages/backend/src/services/chatService.ts
+++ b/packages/backend/src/services/chatService.ts
@@ -85,9 +85,16 @@ const SURFACED_NO_GENERATION_MESSAGE =
 /**
  * Builds the fail-open short-circuit response surface for context-step outcomes.
  *
- * For compatibility, short-circuit branching uses one effective context-step
- * execution context (clarification/failure handling). Multi-step citation merge
- * still happens in assistant metadata after generation.
+ * The short-circuit branch can return early when a context step asks for user
+ * clarification or reports a known tool failure pattern.
+ *
+ * Compatibility rule: this branch reads one effective context-step execution
+ * context (the existing single-result shape) for clarification/failure routing.
+ * This keeps older callers stable while multi-context execution is available.
+ *
+ * Citation rule: when generation continues, citations from all executed context
+ * integrations are merged later into assistant metadata. This helper does not
+ * own that merge.
  */
 const buildContextStepShortCircuit = ({
     workflowContextStepResult,

--- a/packages/backend/src/services/plannerWorkflowSeams.ts
+++ b/packages/backend/src/services/plannerWorkflowSeams.ts
@@ -114,6 +114,7 @@ export type PlannerApplicationResult = {
     toolRequestContext: ToolInvocationRequest;
     toolExecutionContext?: ToolExecutionContext;
     contextStepRequest?: ContextStepRequest;
+    contextStepRequests?: ContextStepRequest[];
     plannerApplyOutcome: PlannerExecutionApplyOutcome;
     plannerMattered: boolean;
     plannerMatteredControlIds: SteerabilityControlId[];

--- a/packages/backend/src/services/plannerWorkflowSeams.ts
+++ b/packages/backend/src/services/plannerWorkflowSeams.ts
@@ -183,6 +183,7 @@ export type PlanContinuation = {
           plannerTemperament?: PartialResponseTemperament;
           conversationSnapshot: string;
           contextStepRequest?: ContextStepRequest;
+          contextStepRequests?: ContextStepRequest[];
       }
 );
 

--- a/packages/backend/src/services/plannerWorkflowSeams.ts
+++ b/packages/backend/src/services/plannerWorkflowSeams.ts
@@ -182,7 +182,9 @@ export type PlanContinuation = {
           generationRequest: GenerationRequest;
           plannerTemperament?: PartialResponseTemperament;
           conversationSnapshot: string;
+          // Backward-compatible single integration field for existing callers.
           contextStepRequest?: ContextStepRequest;
+          // Preferred multi-integration field consumed by parallel context-step execution.
           contextStepRequests?: ContextStepRequest[];
       }
 );

--- a/packages/backend/src/services/workflowEngine.ts
+++ b/packages/backend/src/services/workflowEngine.ts
@@ -1220,9 +1220,9 @@ export const runBoundedReviewWorkflow = async ({
             );
             for (const contextStepOutcome of contextStepOutcomes) {
                 if (contextStepOutcome.blockedByLimit === true) {
-                    exhaustedLimitKey = 'max_tool_calls';
+                    exhaustedLimitKey = 'maxToolCalls';
                     terminationReason =
-                        mapExhaustedLimitToTerminationReason(exhaustedLimitKey);
+                        mapExhaustedLimitToTerminationReason('maxToolCalls');
                     workflowStatus = 'degraded';
                     shouldStop = true;
                     continue;

--- a/packages/backend/src/services/workflowEngine.ts
+++ b/packages/backend/src/services/workflowEngine.ts
@@ -172,9 +172,13 @@ export type RunBoundedReviewWorkflowInput = {
     plannerStepExecutor?: PlannerStepExecutor;
     // Caller-owned policy application. Engine only consumes continuation output.
     planContinuationBuilder?: PlanContinuationBuilder;
+    // Backward-compatible single integration input used by current callers.
     contextStepRequest?: ContextStepRequest;
+    // Preferred multi-integration input. Engine executes eligible steps in parallel.
     contextStepRequests?: ContextStepRequest[];
+    // Backward-compatible default executor for single-integration callers.
     contextStepExecutor?: ContextStepExecutor;
+    // Preferred executor routing by integration name.
     contextStepExecutorRegistry?: Record<string, ContextStepExecutor>;
 };
 
@@ -1121,6 +1125,11 @@ export const runBoundedReviewWorkflow = async ({
         ];
     };
 
+    /**
+     * Resolve executor authority per context integration.
+     * Registry mapping is authoritative. Fallback executor preserves existing
+     * single-step call sites while migration to registry is in progress.
+     */
     const selectContextStepExecutor = (
         request: ContextStepRequest
     ): ContextStepExecutor | undefined => {
@@ -1151,6 +1160,8 @@ export const runBoundedReviewWorkflow = async ({
             terminationReason = 'transition_blocked_by_policy';
             shouldStop = true;
         } else if (!stopIfOverLimits('tool')) {
+            // Parallel execution keeps integration latency bounded while each
+            // outcome remains independently fail-open and lineage-recorded.
             const contextStepOutcomes = await Promise.all(
                 executableContextSteps.map(
                     async (request): Promise<ContextStepExecutionOutcome> => {
@@ -1326,6 +1337,7 @@ export const runBoundedReviewWorkflow = async ({
             const initialDraftStartedAt = generationStartedAtMs;
             messagesWithContext = injectContextMessagesIntoPrompt(
                 effectiveMessagesWithHints,
+                // Preserve deterministic context ordering by request list order.
                 executedContextStepResults.flatMap(
                     (contextStepResult) =>
                         contextStepResult.contextMessages ?? []

--- a/packages/backend/src/services/workflowEngine.ts
+++ b/packages/backend/src/services/workflowEngine.ts
@@ -240,6 +240,7 @@ type ContextStepExecutionOutcome = {
     request: ContextStepRequest;
     result?: ContextStepResult;
     error?: unknown;
+    blockedByLimit?: boolean;
     startedAtMs: number;
     finishedAtMs: number;
 };
@@ -1162,9 +1163,28 @@ export const runBoundedReviewWorkflow = async ({
         } else if (!stopIfOverLimits('tool')) {
             // Parallel execution keeps integration latency bounded while each
             // outcome remains independently fail-open and lineage-recorded.
+            const remainingToolCalls =
+                executionLimits.maxToolCalls === UNBOUNDED_LIMIT
+                    ? Number.POSITIVE_INFINITY
+                    : Math.max(
+                          0,
+                          executionLimits.maxToolCalls -
+                              workflowState.toolCallCount
+                      );
+            let reservedToolCallCount = 0;
             const contextStepOutcomes = await Promise.all(
                 executableContextSteps.map(
                     async (request): Promise<ContextStepExecutionOutcome> => {
+                        if (reservedToolCallCount >= remainingToolCalls) {
+                            const blockedAtMs = Date.now();
+                            return {
+                                request,
+                                blockedByLimit: true,
+                                startedAtMs: blockedAtMs,
+                                finishedAtMs: blockedAtMs,
+                            };
+                        }
+                        reservedToolCallCount += 1;
                         const executor = selectContextStepExecutor(request);
                         if (executor === undefined) {
                             return {
@@ -1199,6 +1219,14 @@ export const runBoundedReviewWorkflow = async ({
                 )
             );
             for (const contextStepOutcome of contextStepOutcomes) {
+                if (contextStepOutcome.blockedByLimit === true) {
+                    exhaustedLimitKey = 'max_tool_calls';
+                    terminationReason =
+                        mapExhaustedLimitToTerminationReason(exhaustedLimitKey);
+                    workflowStatus = 'degraded';
+                    shouldStop = true;
+                    continue;
+                }
                 if (contextStepOutcome.error !== undefined) {
                     logger.error(
                         'Context step execution failed; workflow continued fail-open without context.',

--- a/packages/backend/src/services/workflowEngine.ts
+++ b/packages/backend/src/services/workflowEngine.ts
@@ -173,7 +173,9 @@ export type RunBoundedReviewWorkflowInput = {
     // Caller-owned policy application. Engine only consumes continuation output.
     planContinuationBuilder?: PlanContinuationBuilder;
     contextStepRequest?: ContextStepRequest;
+    contextStepRequests?: ContextStepRequest[];
     contextStepExecutor?: ContextStepExecutor;
+    contextStepExecutorRegistry?: Record<string, ContextStepExecutor>;
 };
 
 export type RunBoundedReviewWorkflowResult =
@@ -184,6 +186,7 @@ export type RunBoundedReviewWorkflowResult =
           plannerStepResult?: PlannerStepResult;
           planContinuation?: PlanContinuation;
           contextStepResult?: ContextStepResult;
+          contextStepResults?: ContextStepResult[];
       }
     | {
           outcome: 'terminal_action';
@@ -192,6 +195,7 @@ export type RunBoundedReviewWorkflowResult =
           plannerStepResult?: PlannerStepResult;
           planContinuation?: PlanContinuation;
           contextStepResult?: ContextStepResult;
+          contextStepResults?: ContextStepResult[];
       }
     | {
           outcome: 'no_generation';
@@ -199,6 +203,7 @@ export type RunBoundedReviewWorkflowResult =
           plannerStepResult?: PlannerStepResult;
           planContinuation?: PlanContinuation;
           contextStepResult?: ContextStepResult;
+          contextStepResults?: ContextStepResult[];
       };
 
 export type ContextStepRequest = {
@@ -226,6 +231,14 @@ export type ContextStepExecutorInput = {
 export type ContextStepExecutor = (
     input: ContextStepExecutorInput
 ) => Promise<ContextStepResult>;
+
+type ContextStepExecutionOutcome = {
+    request: ContextStepRequest;
+    result?: ContextStepResult;
+    error?: unknown;
+    startedAtMs: number;
+    finishedAtMs: number;
+};
 
 const LEGAL_TRANSITIONS: Record<
     WorkflowStepKind,
@@ -718,7 +731,9 @@ export const runBoundedReviewWorkflow = async ({
     plannerStepExecutor,
     planContinuationBuilder,
     contextStepRequest,
+    contextStepRequests,
     contextStepExecutor,
+    contextStepExecutorRegistry,
 }: RunBoundedReviewWorkflowInput): Promise<RunBoundedReviewWorkflowResult> => {
     // NOTE: Concrete tool execution is still orchestrator/registry-owned.
     // This engine path currently executes only bounded review generation steps.
@@ -770,10 +785,12 @@ export const runBoundedReviewWorkflow = async ({
     let shouldStop = false;
     let exhaustedLimitKey: WorkflowLimitKey | undefined;
     let executedContextStepResult: ContextStepResult | undefined;
+    let executedContextStepResults: ContextStepResult[] = [];
     let messagesWithContext = messagesWithHints;
     let effectiveGenerationRequest = generationRequest;
     let effectiveMessagesWithHints = messagesWithHints;
     let effectiveContextStepRequest = contextStepRequest;
+    let effectiveContextStepRequests = contextStepRequests;
     let workflowTerminalAction: PlanTerminalAction | undefined;
     let planContinuation: PlanContinuation | undefined;
     const effectiveReviewDecisionPrompt =
@@ -1017,6 +1034,9 @@ export const runBoundedReviewWorkflow = async ({
                 effectiveContextStepRequest =
                     planContinuation.contextStepRequest ??
                     effectiveContextStepRequest;
+                effectiveContextStepRequests =
+                    planContinuation.contextStepRequests ??
+                    effectiveContextStepRequests;
             }
         } catch (error) {
             logger.warn(
@@ -1101,12 +1121,26 @@ export const runBoundedReviewWorkflow = async ({
         ];
     };
 
-    if (
-        !shouldStop &&
-        effectiveContextStepRequest?.requested === true &&
-        effectiveContextStepRequest.eligible &&
-        contextStepExecutor !== undefined
-    ) {
+    const selectContextStepExecutor = (
+        request: ContextStepRequest
+    ): ContextStepExecutor | undefined => {
+        const registryExecutor =
+            contextStepExecutorRegistry?.[request.integrationName];
+        if (registryExecutor !== undefined) {
+            return registryExecutor;
+        }
+        return contextStepExecutor;
+    };
+    const requestedContextSteps = (
+        effectiveContextStepRequests ??
+        (effectiveContextStepRequest !== undefined
+            ? [effectiveContextStepRequest]
+            : [])
+    ).filter((request) => request.requested === true && request.eligible);
+    const executableContextSteps = requestedContextSteps.filter(
+        (request) => selectContextStepExecutor(request) !== undefined
+    );
+    if (!shouldStop && executableContextSteps.length > 0) {
         if (
             !isTransitionAllowed(
                 workflowState.currentStepKind,
@@ -1117,37 +1151,114 @@ export const runBoundedReviewWorkflow = async ({
             terminationReason = 'transition_blocked_by_policy';
             shouldStop = true;
         } else if (!stopIfOverLimits('tool')) {
-            const contextStepStartedAt = Date.now();
-            try {
-                const contextStepResult = await contextStepExecutor({
-                    request: effectiveContextStepRequest,
-                    workflowId,
-                    workflowName: workflowConfig.workflowName,
-                    attempt: 1,
-                });
-                const contextStepFinishedAt = Date.now();
+            const contextStepOutcomes = await Promise.all(
+                executableContextSteps.map(
+                    async (request): Promise<ContextStepExecutionOutcome> => {
+                        const executor = selectContextStepExecutor(request);
+                        if (executor === undefined) {
+                            return {
+                                request,
+                                startedAtMs: Date.now(),
+                                finishedAtMs: Date.now(),
+                            };
+                        }
+                        const startedAtMs = Date.now();
+                        try {
+                            const result = await executor({
+                                request,
+                                workflowId,
+                                workflowName: workflowConfig.workflowName,
+                                attempt: 1,
+                            });
+                            return {
+                                request,
+                                result,
+                                startedAtMs,
+                                finishedAtMs: Date.now(),
+                            };
+                        } catch (error) {
+                            return {
+                                request,
+                                error,
+                                startedAtMs,
+                                finishedAtMs: Date.now(),
+                            };
+                        }
+                    }
+                )
+            );
+            for (const contextStepOutcome of contextStepOutcomes) {
+                if (contextStepOutcome.error !== undefined) {
+                    logger.error(
+                        'Context step execution failed; workflow continued fail-open without context.',
+                        {
+                            stepKind: 'tool',
+                            reasonCode: 'tool_execution_error',
+                            startedAtMs: contextStepOutcome.startedAtMs,
+                            finishedAtMs: contextStepOutcome.finishedAtMs,
+                            parentStepId: plannerRootStepId,
+                            attempt: 1,
+                            workflowName: workflowConfig.workflowName,
+                            workflowId,
+                            integrationName:
+                                contextStepOutcome.request.integrationName,
+                            error:
+                                contextStepOutcome.error instanceof Error
+                                    ? contextStepOutcome.error.message
+                                    : String(contextStepOutcome.error),
+                        }
+                    );
+                    captureStep({
+                        stepKind: 'tool',
+                        status: 'failed',
+                        summary:
+                            'Context step execution failed; workflow continued fail-open without context.',
+                        reasonCode: 'tool_execution_error',
+                        startedAtMs: contextStepOutcome.startedAtMs,
+                        finishedAtMs: contextStepOutcome.finishedAtMs,
+                        parentStepId: plannerRootStepId,
+                        attempt: 1,
+                    });
+                    workflowState = applyStepExecutionToState(
+                        workflowState,
+                        'tool',
+                        0,
+                        1,
+                        0
+                    );
+                    continue;
+                }
+                if (contextStepOutcome.result === undefined) {
+                    continue;
+                }
                 const normalizedExecutionContext: ToolExecutionContext = {
-                    ...contextStepResult.executionContext,
-                    toolName: contextStepResult.executionContext.toolName,
-                    ...(contextStepResult.executionContext.clarification ===
-                        undefined &&
-                        contextStepResult.clarification !== undefined && {
-                            clarification: contextStepResult.clarification,
+                    ...contextStepOutcome.result.executionContext,
+                    toolName:
+                        contextStepOutcome.result.executionContext.toolName,
+                    ...(contextStepOutcome.result.executionContext
+                        .clarification === undefined &&
+                        contextStepOutcome.result.clarification !==
+                            undefined && {
+                            clarification:
+                                contextStepOutcome.result.clarification,
                         }),
                 };
-                executedContextStepResult = {
+                const normalizedResult: ContextStepResult = {
                     executionContext: normalizedExecutionContext,
-                    ...(contextStepResult.contextMessages !== undefined && {
-                        contextMessages: contextStepResult.contextMessages,
+                    ...(contextStepOutcome.result.contextMessages !==
+                        undefined && {
+                        contextMessages:
+                            contextStepOutcome.result.contextMessages,
                     }),
                     ...(normalizedExecutionContext.clarification !==
                         undefined && {
                         clarification: normalizedExecutionContext.clarification,
                     }),
-                    ...(contextStepResult.sources !== undefined && {
-                        sources: contextStepResult.sources,
+                    ...(contextStepOutcome.result.sources !== undefined && {
+                        sources: contextStepOutcome.result.sources,
                     }),
                 };
+                executedContextStepResults.push(normalizedResult);
                 const status =
                     normalizedExecutionContext.status === 'failed'
                         ? 'failed'
@@ -1165,12 +1276,12 @@ export const runBoundedReviewWorkflow = async ({
                     ...(normalizedExecutionContext.reasonCode !== undefined && {
                         reasonCode: normalizedExecutionContext.reasonCode,
                     }),
-                    startedAtMs: contextStepStartedAt,
-                    finishedAtMs: contextStepFinishedAt,
+                    startedAtMs: contextStepOutcome.startedAtMs,
+                    finishedAtMs: contextStepOutcome.finishedAtMs,
                     parentStepId: plannerRootStepId,
                     attempt: 1,
-                    ...(contextStepResult.contextMessages !== undefined && {
-                        artifacts: contextStepResult.contextMessages,
+                    ...(normalizedResult.contextMessages !== undefined && {
+                        artifacts: normalizedResult.contextMessages,
                     }),
                     ...(normalizedExecutionContext.clarification !==
                         undefined && {
@@ -1196,44 +1307,8 @@ export const runBoundedReviewWorkflow = async ({
                     workflowStatus = 'completed';
                     shouldStop = true;
                 }
-            } catch (error) {
-                const contextStepFinishedAt = Date.now();
-                logger.error(
-                    'Context step execution failed; workflow continued fail-open without context.',
-                    {
-                        stepKind: 'tool',
-                        reasonCode: 'tool_execution_error',
-                        startedAtMs: contextStepStartedAt,
-                        finishedAtMs: contextStepFinishedAt,
-                        parentStepId: plannerRootStepId,
-                        attempt: 1,
-                        workflowName: workflowConfig.workflowName,
-                        workflowId,
-                        error:
-                            error instanceof Error
-                                ? error.message
-                                : String(error),
-                    }
-                );
-                captureStep({
-                    stepKind: 'tool',
-                    status: 'failed',
-                    summary:
-                        'Context step execution failed; workflow continued fail-open without context.',
-                    reasonCode: 'tool_execution_error',
-                    startedAtMs: contextStepStartedAt,
-                    finishedAtMs: contextStepFinishedAt,
-                    parentStepId: plannerRootStepId,
-                    attempt: 1,
-                });
-                workflowState = applyStepExecutionToState(
-                    workflowState,
-                    'tool',
-                    0,
-                    1,
-                    0
-                );
             }
+            executedContextStepResult = executedContextStepResults.at(0);
         }
     }
 
@@ -1251,7 +1326,10 @@ export const runBoundedReviewWorkflow = async ({
             const initialDraftStartedAt = generationStartedAtMs;
             messagesWithContext = injectContextMessagesIntoPrompt(
                 effectiveMessagesWithHints,
-                executedContextStepResult?.contextMessages
+                executedContextStepResults.flatMap(
+                    (contextStepResult) =>
+                        contextStepResult.contextMessages ?? []
+                )
             );
             try {
                 draftResult = await generationRuntime.generate({
@@ -1592,6 +1670,9 @@ export const runBoundedReviewWorkflow = async ({
             ...(executedContextStepResult !== undefined && {
                 contextStepResult: executedContextStepResult,
             }),
+            ...(executedContextStepResults.length > 0 && {
+                contextStepResults: executedContextStepResults,
+            }),
         };
     }
 
@@ -1608,6 +1689,9 @@ export const runBoundedReviewWorkflow = async ({
             ...(executedContextStepResult !== undefined && {
                 contextStepResult: executedContextStepResult,
             }),
+            ...(executedContextStepResults.length > 0 && {
+                contextStepResults: executedContextStepResults,
+            }),
         };
     }
 
@@ -1623,6 +1707,9 @@ export const runBoundedReviewWorkflow = async ({
         }),
         ...(executedContextStepResult !== undefined && {
             contextStepResult: executedContextStepResult,
+        }),
+        ...(executedContextStepResults.length > 0 && {
+            contextStepResults: executedContextStepResults,
         }),
     };
 };

--- a/packages/backend/test/workflowEngine.test.ts
+++ b/packages/backend/test/workflowEngine.test.ts
@@ -22,7 +22,10 @@ import {
     type ExecutionLimits,
     type WorkflowPolicy,
 } from '../src/services/workflowEngine.js';
-import type { GenerationRuntime } from '@footnote/agent-runtime';
+import type {
+    GenerationRuntime,
+    RuntimeMessage,
+} from '@footnote/agent-runtime';
 
 const permissivePolicy: WorkflowPolicy = {
     enablePlanning: true,
@@ -1345,6 +1348,119 @@ test('runBoundedReviewWorkflow executes injected context step and records contex
     assert.deepEqual(toolStep.outcome.artifacts, [
         'weather_context: clear skies',
     ]);
+});
+
+test('runBoundedReviewWorkflow executes eligible context steps in parallel and merges emitted context messages', async () => {
+    const observedMessages: RuntimeMessage[][] = [];
+    const generationRuntime: GenerationRuntime = {
+        kind: 'test-runtime',
+        async generate(input) {
+            observedMessages.push(input.messages);
+            return {
+                text: 'draft',
+                model: 'gpt-5-mini',
+                usage: {
+                    promptTokens: 10,
+                    completionTokens: 5,
+                    totalTokens: 15,
+                },
+                provenance: 'Inferred',
+                citations: [],
+            };
+        },
+    };
+    let weatherStartedAt = 0;
+    let webSearchStartedAt = 0;
+
+    const result = await runBoundedReviewWorkflow({
+        generationRuntime,
+        generationRequest: {
+            model: 'gpt-5-mini',
+            messages: [{ role: 'user', content: 'Need context' }],
+        },
+        messagesWithHints: [{ role: 'user', content: 'Need context' }],
+        generationStartedAtMs: Date.now(),
+        workflowConfig: {
+            workflowName: 'message_with_review_loop',
+            maxIterations: 1,
+            maxDurationMs: 15000,
+        },
+        workflowPolicy: {
+            enablePlanning: false,
+            enableToolUse: true,
+            enableReplanning: false,
+            enableGeneration: true,
+            enableAssessment: true,
+            enableRevision: true,
+        },
+        contextStepRequests: [
+            {
+                integrationName: 'weather_forecast',
+                requested: true,
+                eligible: true,
+            },
+            {
+                integrationName: 'web_search',
+                requested: true,
+                eligible: true,
+            },
+        ],
+        contextStepExecutorRegistry: {
+            weather_forecast: async () => {
+                weatherStartedAt = Date.now();
+                await new Promise((resolve) => setTimeout(resolve, 40));
+                return {
+                    executionContext: {
+                        toolName: 'weather_forecast',
+                        status: 'executed',
+                    },
+                    contextMessages: ['weather_context: clear skies'],
+                };
+            },
+            web_search: async () => {
+                webSearchStartedAt = Date.now();
+                await new Promise((resolve) => setTimeout(resolve, 40));
+                return {
+                    executionContext: {
+                        toolName: 'web_search',
+                        status: 'executed',
+                    },
+                    contextMessages: ['web_context: top result'],
+                };
+            },
+        },
+        captureUsage: (generationResult) => ({
+            model: generationResult.model ?? 'gpt-5-mini',
+            promptTokens: generationResult.usage?.promptTokens ?? 0,
+            completionTokens: generationResult.usage?.completionTokens ?? 0,
+            totalTokens: generationResult.usage?.totalTokens ?? 0,
+            estimatedCost: {
+                inputCostUsd: 0,
+                outputCostUsd: 0,
+                totalCostUsd: 0,
+            },
+        }),
+    });
+
+    assert.equal(result.outcome, 'generated');
+    assert.ok(Math.abs(weatherStartedAt - webSearchStartedAt) < 35);
+    assert.equal(result.contextStepResults?.length, 2);
+    assert.equal(
+        observedMessages[0]?.some(
+            (message) =>
+                message.role === 'system' &&
+                message.content === 'weather_context: clear skies'
+        ),
+        true
+    );
+    assert.equal(
+        observedMessages[0]?.some(
+            (message) =>
+                message.role === 'system' &&
+                message.content === 'web_context: top result'
+        ),
+        true
+    );
 });
 
 test('runBoundedReviewWorkflow records failed injected context step with reason and continues fail-open', async () => {

--- a/packages/backend/test/workflowEngine.test.ts
+++ b/packages/backend/test/workflowEngine.test.ts
@@ -1445,22 +1445,20 @@ test('runBoundedReviewWorkflow executes eligible context steps in parallel and m
     assert.equal(result.outcome, 'generated');
     assert.ok(Math.abs(weatherStartedAt - webSearchStartedAt) < 35);
     assert.equal(result.contextStepResults?.length, 2);
-    assert.equal(
-        observedMessages[0]?.some(
-            (message) =>
-                message.role === 'system' &&
-                message.content === 'weather_context: clear skies'
-        ),
-        true
+    const firstMessageBatch = observedMessages[0] ?? [];
+    const weatherContextMessageIndex = firstMessageBatch.findIndex(
+        (message) =>
+            message.role === 'system' &&
+            message.content === 'weather_context: clear skies'
     );
-    assert.equal(
-        observedMessages[0]?.some(
-            (message) =>
-                message.role === 'system' &&
-                message.content === 'web_context: top result'
-        ),
-        true
+    const webContextMessageIndex = firstMessageBatch.findIndex(
+        (message) =>
+            message.role === 'system' &&
+            message.content === 'web_context: top result'
     );
+    assert.ok(weatherContextMessageIndex >= 0);
+    assert.ok(webContextMessageIndex >= 0);
+    assert.ok(weatherContextMessageIndex < webContextMessageIndex);
 });
 
 test('runBoundedReviewWorkflow records failed injected context step with reason and continues fail-open', async () => {


### PR DESCRIPTION
## Summary

- Add parallel context-step execution support in the workflow engine.
- Add integration-name executor registry routing while preserving the single-step compatibility path.
- Aggregate context messages and citations across multiple context-step outcomes.
- Wire new context-step request/result fields through planner seams and chat service.
- Add workflow engine coverage for parallel context-step execution.
- Add follow-up docs and TODO clarifying single-result short-circuit compatibility behavior.

## Validation

- pnpm lint:fix
- pnpm lint
- pnpm validate-footnote-tags
- pnpm review
- pnpm --filter @footnote/backend test workflowEngine.test.ts

## Scope

- Row 1 only (#339).