### PR TITLE
feat(backend): migrate web_search to canonical context-step pipeline

### DIFF
--- a/docs/status/context-integration-architecture.md
+++ b/docs/status/context-integration-architecture.md
@@ -39,7 +39,7 @@ Before integrations can run in parallel with assess-driven cycling:
 | ---------------------- | ----------------------- | ---------------------------- |
 | `weather_forecast`     | context-step            | Implemented                  |
 | `trustgraph`           | evidence ingestion seam | Not migrated to context-step |
-| `web_search`           | tool-registry path      | Not migrated to context-step |
+| `web_search`           | context-step            | Implemented                  |
 | `image_scan`           | Discord bot layer       | Not migrated to context-step |
 | `file_scan`            | not implemented         | Not implemented              |
 | `reverse_image_search` | not implemented         | Not implemented              |
@@ -65,8 +65,8 @@ Before integrations can run in parallel with assess-driven cycling:
 **Issue #336** - Web search context-step migration
 
 - Implement as workflow context-step integration
-- Provider-neutral architecture (SearXNG, Brave)
-- Remove profile mutation and searchFallbackPolicy reroute logic
+- Provider/runtime protocol semantics stay at provider boundary only
+- Provider-policy scaffolding is in place (`mode`, `enabledProviders`, `providerOrder`) with OpenAI-only runtime availability until follow-up provider work lands
 
 **Issue #333** - Image scanning context-step migration
 
@@ -89,6 +89,14 @@ Before integrations can run in parallel with assess-driven cycling:
 ## Related Work
 
 **Issue #338** - Remove fast mode and keep reviewed execution as the default path. `balanced` and `grounded` now run the same reviewed workflow shape, with differences coming from behavior preset and limits.
+
+**Follow-up: Web search provider policy and multi-provider execution**
+
+- Add provider adapters for `brave` and `searxng` with OpenAI retained as a provider option
+- Apply provider policy modes (`auto`, `strict`, `preferred_order`) to execution candidate selection and fallback hops
+- Normalize citation/source output across providers for one metadata shape
+- Keep fail-open behavior when provider candidates are unavailable or fail
+- Add telemetry for provider chosen, fallback path, and terminal execution outcome
 
 ## Notes
 

--- a/docs/status/workflow-engine-rollout-status.md
+++ b/docs/status/workflow-engine-rollout-status.md
@@ -31,14 +31,8 @@ This file tracks the remaining rollout work. The canonical architecture is in
 
 ## Pending Work
 
-- **Tool/context-step expansion**: Only `weather_forecast` uses the workflow
-  context-step path. The infrastructure exists for additional tools, but none
-  are implemented yet.
-
-- **web_search**: Not migrated to context-step execution. It still uses the
-  current search/runtime path. The proposal in
-  [docs/proposals/web-search-context-integration.md](../proposals/web-search-context-integration.md)
-  describes the intended provider-neutral direction.
+- **Tool/context-step expansion**: `weather_forecast` and `web_search` now use
+  the workflow context-step path. Remaining integrations are still pending.
 
 ## Related Docs
 

--- a/packages/backend/src/config/buildRuntimeConfig.ts
+++ b/packages/backend/src/config/buildRuntimeConfig.ts
@@ -43,7 +43,8 @@ export const buildRuntimeConfig = (
     );
     const voltagent = buildVoltAgentSection(env, warn);
     const web = buildWebSection(env, warn);
-    const { reflect, trace, chatWorkflow } = buildServiceSections(env, warn);
+    const { reflect, trace, chatWorkflow, webSearchProviders } =
+        buildServiceSections(env, warn);
     const executionContractTrustGraph = buildExecutionContractTrustGraphSection(
         env,
         warn
@@ -73,6 +74,7 @@ export const buildRuntimeConfig = (
         reflect,
         trace,
         chatWorkflow,
+        webSearchProviders,
         executionContractTrustGraph,
         turnstile,
         rateLimits,

--- a/packages/backend/src/config/sections/services.ts
+++ b/packages/backend/src/config/sections/services.ts
@@ -10,6 +10,7 @@ import { envDefaultValues } from '@footnote/config-spec';
 import type { WorkflowModeId } from '@footnote/contracts/ethics-core';
 import {
     parseBooleanEnv,
+    parseCsvEnv,
     parseNonNegativeIntEnv,
     parseOptionalTrimmedString,
     parsePositiveIntEnv,
@@ -21,6 +22,44 @@ const CHAT_WORKFLOW_MODE_IDS: ReadonlySet<WorkflowModeId> = new Set([
     'balanced',
     'grounded',
 ]);
+const WEB_SEARCH_PROVIDER_MODES: ReadonlySet<
+    RuntimeConfig['webSearchProviders']['mode']
+> = new Set(['auto', 'strict', 'preferred_order']);
+const WEB_SEARCH_PROVIDER_IDS: ReadonlySet<
+    RuntimeConfig['webSearchProviders']['enabledProviders'][number]
+> = new Set(['openai', 'brave', 'searxng']);
+
+const parseWebSearchProviders = (
+    value: string[] | undefined,
+    fallback: RuntimeConfig['webSearchProviders']['enabledProviders'],
+    key: string,
+    warn: WarningSink
+): RuntimeConfig['webSearchProviders']['enabledProviders'] => {
+    const candidates = value ?? fallback;
+    const normalized = candidates
+        .map((entry) => entry.trim().toLowerCase())
+        .filter((entry) => entry.length > 0);
+    const validProviders = normalized.filter((entry) =>
+        WEB_SEARCH_PROVIDER_IDS.has(
+            entry as RuntimeConfig['webSearchProviders']['enabledProviders'][number]
+        )
+    ) as RuntimeConfig['webSearchProviders']['enabledProviders'];
+    const invalidProviders = normalized.filter(
+        (entry) =>
+            !WEB_SEARCH_PROVIDER_IDS.has(
+                entry as RuntimeConfig['webSearchProviders']['enabledProviders'][number]
+            )
+    );
+    if (invalidProviders.length > 0) {
+        warn(
+            `Ignoring invalid web search providers for ${key}: ${invalidProviders.join(', ')}.`
+        );
+    }
+    if (validProviders.length === 0) {
+        return [...fallback];
+    }
+    return [...new Set(validProviders)];
+};
 
 /**
  * Resolves auth tokens and body-size limits for trusted backend-only service
@@ -29,7 +68,10 @@ const CHAT_WORKFLOW_MODE_IDS: ReadonlySet<WorkflowModeId> = new Set([
 export const buildServiceSections = (
     env: NodeJS.ProcessEnv,
     warn: WarningSink
-): Pick<RuntimeConfig, 'reflect' | 'trace' | 'chatWorkflow'> => ({
+): Pick<
+    RuntimeConfig,
+    'reflect' | 'trace' | 'chatWorkflow' | 'webSearchProviders'
+> => ({
     reflect: {
         serviceToken: parseOptionalTrimmedString(env.REFLECT_SERVICE_TOKEN),
         maxBodyBytes: parsePositiveIntEnv(
@@ -72,6 +114,27 @@ export const buildServiceSections = (
             env.CHAT_REVIEW_LOOP_MAX_DURATION_MS,
             15000,
             'CHAT_REVIEW_LOOP_MAX_DURATION_MS',
+            warn
+        ),
+    },
+    webSearchProviders: {
+        mode: parseStringUnionEnv<RuntimeConfig['webSearchProviders']['mode']>(
+            env.WEB_SEARCH_PROVIDER_MODE,
+            'auto',
+            'WEB_SEARCH_PROVIDER_MODE',
+            WEB_SEARCH_PROVIDER_MODES,
+            warn
+        ),
+        enabledProviders: parseWebSearchProviders(
+            parseCsvEnv(env.WEB_SEARCH_ENABLED_PROVIDERS, ['openai']),
+            ['openai'],
+            'WEB_SEARCH_ENABLED_PROVIDERS',
+            warn
+        ),
+        providerOrder: parseWebSearchProviders(
+            parseCsvEnv(env.WEB_SEARCH_PROVIDER_ORDER, ['openai']),
+            ['openai'],
+            'WEB_SEARCH_PROVIDER_ORDER',
             warn
         ),
     },

--- a/packages/backend/src/config/types.ts
+++ b/packages/backend/src/config/types.ts
@@ -33,7 +33,19 @@ export type RateLimitConfig = {
     windowMs: number;
 };
 
+/**
+ * Supported web-search providers for Context Integration execution.
+ * - `openai`
+ * - `brave`
+ * - `searxng`
+ */
 export type WebSearchProviderId = 'openai' | 'brave' | 'searxng';
+/**
+ * Web-search provider policy mode.
+ * - `auto`: choose the best available provider and allow fallback behavior
+ * - `strict`: require ordered policy match with no fallback branch
+ * - `preferred_order`: prefer explicit provider order, then use enabled-order fallback
+ */
 export type WebSearchProviderMode = 'auto' | 'strict' | 'preferred_order';
 
 /**

--- a/packages/backend/src/config/types.ts
+++ b/packages/backend/src/config/types.ts
@@ -33,6 +33,9 @@ export type RateLimitConfig = {
     windowMs: number;
 };
 
+export type WebSearchProviderId = 'openai' | 'brave' | 'searxng';
+export type WebSearchProviderMode = 'auto' | 'strict' | 'preferred_order';
+
 /**
  * Canonical backend runtime config assembled from env parsing helpers.
  */
@@ -98,6 +101,11 @@ export type RuntimeConfig = {
         reviewLoopEnabled: boolean;
         maxIterations: number;
         maxDurationMs: number;
+    };
+    webSearchProviders: {
+        mode: WebSearchProviderMode;
+        enabledProviders: WebSearchProviderId[];
+        providerOrder: WebSearchProviderId[];
     };
     executionContractTrustGraph: {
         enabled: boolean;

--- a/packages/backend/src/services/chatOrchestrator.ts
+++ b/packages/backend/src/services/chatOrchestrator.ts
@@ -39,6 +39,7 @@ import { buildSteerabilityControls } from './steerabilityControls.js';
 import type { WeatherForecastTool } from './contextIntegrations/weather/index.js';
 import { resolveWeatherClarificationContinuation } from './tools/weatherClarificationContinuation.js';
 import { createWeatherForecastContextStepExecutor } from './contextIntegrations/weather/index.js';
+import { createWebSearchContextStepExecutor } from './contextIntegrations/webSearch/index.js';
 import { createPlannerResultApplier } from './chatOrchestrator/plannerResultApplier.js';
 import { runtimeConfig } from '../config.js';
 import { logger } from '../utils/logger.js';
@@ -401,6 +402,17 @@ export const createChatOrchestrator = ({
                     chatOrchestratorLogger.warn(message, meta);
                 },
             });
+        const webSearchContextStepExecutor = createWebSearchContextStepExecutor(
+            {
+                providerPolicy: runtimeConfig.webSearchProviders,
+            }
+        );
+        // Keep Context Integration registry assembly additive so parallel
+        // branches can append new integration executors with minimal conflicts.
+        const contextStepExecutorRegistry = {
+            weather_forecast: weatherContextStepExecutor,
+            web_search: webSearchContextStepExecutor,
+        } as const;
         const buildPlannerSummary = (input: {
             plannerStepResult: PlannerStepResult;
             plannerApplication: ReturnType<typeof plannerResultApplier>;
@@ -594,17 +606,8 @@ export const createChatOrchestrator = ({
                 },
                 plannerTemperament: executionPlan.generation.temperament,
                 conversationSnapshot: postPlanAssembly.conversationSnapshot,
-                ...((plannerApplication.contextStepRequests !== undefined ||
-                    plannerApplication.contextStepRequest !== undefined) && {
-                    ...(plannerApplication.contextStepRequest !== undefined && {
-                        contextStepRequest:
-                            plannerApplication.contextStepRequest,
-                    }),
-                    contextStepRequests:
-                        plannerApplication.contextStepRequests ??
-                        (plannerApplication.contextStepRequest !== undefined
-                            ? [plannerApplication.contextStepRequest]
-                            : []),
+                ...(plannerApplication.contextStepRequests !== undefined && {
+                    contextStepRequests: plannerApplication.contextStepRequests,
                 }),
                 plannerSummary: buildPlannerSummary({
                     plannerStepResult: input.plannerStepResult,
@@ -639,7 +642,7 @@ export const createChatOrchestrator = ({
             plannerStepRequest,
             plannerStepExecutor,
             planContinuationBuilder,
-            contextStepExecutor: weatherContextStepExecutor,
+            contextStepExecutorRegistry,
             latestUserInput: normalizedRequest.latestUserInput,
             ExecutionContract: resolvedExecutionContract,
             ...(executionContractScopeTuple !== undefined && {

--- a/packages/backend/src/services/chatOrchestrator.ts
+++ b/packages/backend/src/services/chatOrchestrator.ts
@@ -407,8 +407,6 @@ export const createChatOrchestrator = ({
                 providerPolicy: runtimeConfig.webSearchProviders,
             }
         );
-        // Keep Context Integration registry assembly additive so parallel
-        // branches can append new integration executors with minimal conflicts.
         const contextStepExecutorRegistry = {
             weather_forecast: weatherContextStepExecutor,
             web_search: webSearchContextStepExecutor,

--- a/packages/backend/src/services/chatOrchestrator.ts
+++ b/packages/backend/src/services/chatOrchestrator.ts
@@ -180,6 +180,19 @@ export const createChatOrchestrator = ({
         defaultModel: plannerProfile.providerModel,
         recordUsage,
     });
+    const weatherContextStepExecutor = createWeatherForecastContextStepExecutor(
+        {
+            weatherForecastTool,
+            onWarn: chatOrchestratorLogger.warn.bind(chatOrchestratorLogger),
+        }
+    );
+    const webSearchContextStepExecutor = createWebSearchContextStepExecutor({
+        providerPolicy: runtimeConfig.webSearchProviders,
+    });
+    const contextStepExecutorRegistry = {
+        weather_forecast: weatherContextStepExecutor,
+        web_search: webSearchContextStepExecutor,
+    } as const;
 
     /**
      * Runs one chat request end-to-end.
@@ -395,22 +408,6 @@ export const createChatOrchestrator = ({
         // Web keeps default prompt persona layers.
         const personaPrompt =
             backendOwnedProfileOverlay ?? promptLayers.personaPrompt;
-        const weatherContextStepExecutor =
-            createWeatherForecastContextStepExecutor({
-                weatherForecastTool,
-                onWarn: (message, meta) => {
-                    chatOrchestratorLogger.warn(message, meta);
-                },
-            });
-        const webSearchContextStepExecutor = createWebSearchContextStepExecutor(
-            {
-                providerPolicy: runtimeConfig.webSearchProviders,
-            }
-        );
-        const contextStepExecutorRegistry = {
-            weather_forecast: weatherContextStepExecutor,
-            web_search: webSearchContextStepExecutor,
-        } as const;
         const buildPlannerSummary = (input: {
             plannerStepResult: PlannerStepResult;
             plannerApplication: ReturnType<typeof plannerResultApplier>;

--- a/packages/backend/src/services/chatOrchestrator/plannerResultApplier.ts
+++ b/packages/backend/src/services/chatOrchestrator/plannerResultApplier.ts
@@ -52,23 +52,6 @@ export const createPlannerResultApplier = (
 ): ((
     plannerInput: PlannerApplicationInput & PlannerResultApplierBootstrap
 ) => PlannerApplicationResult) => {
-    const mergeContextStepRequests = (
-        requests: NonNullable<PlannerApplicationResult['contextStepRequests']>
-    ): NonNullable<PlannerApplicationResult['contextStepRequests']> => {
-        const seen = new Set<string>();
-        const merged: NonNullable<
-            PlannerApplicationResult['contextStepRequests']
-        > = [];
-        for (const request of requests) {
-            if (seen.has(request.integrationName)) {
-                continue;
-            }
-            seen.add(request.integrationName);
-            merged.push(request);
-        }
-        return merged;
-    };
-
     return (plannerInput) => {
         const plannerPlan = plannerInput.plannerStepResult.plan;
         const fallbackReasons: string[] = [];
@@ -169,7 +152,7 @@ export const createPlannerResultApplier = (
                 : undefined;
         const contextStepRequests =
             primaryContextStepRequest !== undefined
-                ? mergeContextStepRequests([primaryContextStepRequest])
+                ? [primaryContextStepRequest]
                 : undefined;
         const plannerApplyOutcome =
             plannerInput.plannerStepResult.execution.status !== 'executed'

--- a/packages/backend/src/services/chatOrchestrator/plannerResultApplier.ts
+++ b/packages/backend/src/services/chatOrchestrator/plannerResultApplier.ts
@@ -52,6 +52,23 @@ export const createPlannerResultApplier = (
 ): ((
     plannerInput: PlannerApplicationInput & PlannerResultApplierBootstrap
 ) => PlannerApplicationResult) => {
+    const mergeContextStepRequests = (
+        requests: NonNullable<PlannerApplicationResult['contextStepRequests']>
+    ): NonNullable<PlannerApplicationResult['contextStepRequests']> => {
+        const seen = new Set<string>();
+        const merged: NonNullable<
+            PlannerApplicationResult['contextStepRequests']
+        > = [];
+        for (const request of requests) {
+            if (seen.has(request.integrationName)) {
+                continue;
+            }
+            seen.add(request.integrationName);
+            merged.push(request);
+        }
+        return merged;
+    };
+
     return (plannerInput) => {
         const plannerPlan = plannerInput.plannerStepResult.plan;
         const fallbackReasons: string[] = [];
@@ -130,11 +147,12 @@ export const createPlannerResultApplier = (
             inheritedToolExecution: profileResolution.toolExecutionContext,
         });
 
-        const contextStepRequest =
-            toolSelection.toolRequest.toolName === 'weather_forecast' &&
+        const primaryContextStepRequest =
+            (toolSelection.toolRequest.toolName === 'weather_forecast' ||
+                toolSelection.toolRequest.toolName === 'web_search') &&
             toolSelection.toolRequest.requested
                 ? {
-                      integrationName: 'weather_forecast',
+                      integrationName: toolSelection.toolRequest.toolName,
                       requested: toolSelection.toolRequest.requested,
                       eligible: toolSelection.toolRequest.eligible,
                       ...(toolSelection.toolRequest.reasonCode !==
@@ -148,6 +166,10 @@ export const createPlannerResultApplier = (
                           >,
                       }),
                   }
+                : undefined;
+        const contextStepRequests =
+            primaryContextStepRequest !== undefined
+                ? mergeContextStepRequests([primaryContextStepRequest])
                 : undefined;
         const plannerApplyOutcome =
             plannerInput.plannerStepResult.execution.status !== 'executed'
@@ -186,7 +208,9 @@ export const createPlannerResultApplier = (
             }),
             toolRequestContext: toolSelection.toolRequest,
             toolExecutionContext: toolSelection.toolExecution,
-            contextStepRequest,
+            ...(contextStepRequests !== undefined && {
+                contextStepRequests,
+            }),
             plannerApplyOutcome,
             plannerMattered,
             plannerMatteredControlIds,

--- a/packages/backend/src/services/chatService.ts
+++ b/packages/backend/src/services/chatService.ts
@@ -88,17 +88,12 @@ const SURFACED_NO_GENERATION_MESSAGE =
  * The short-circuit branch can return early when a context step asks for user
  * clarification or reports a known tool failure pattern.
  *
- * Compatibility rule: this branch prefers the full context-step result list
- * when available, and falls back to the legacy single-result field for older
- * callers.
- *
  * Citation rule: when generation continues, citations from all executed context
  * integrations are merged later into assistant metadata. This helper does not
  * own that merge.
  *
  */
 const buildContextStepShortCircuit = ({
-    workflowContextStepResult,
     workflowContextStepResults,
     executionContext,
     toolRequest,
@@ -108,7 +103,6 @@ const buildContextStepShortCircuit = ({
     latestUserInput,
     buildResponseMetadata,
 }: {
-    workflowContextStepResult: ContextStepResult | undefined;
     workflowContextStepResults?: ContextStepResult[];
     executionContext: ResponseMetadataRuntimeContext['executionContext'];
     toolRequest: ToolInvocationRequest | undefined;
@@ -126,11 +120,7 @@ const buildContextStepShortCircuit = ({
           telemetry: FinalToolExecutionTelemetry;
       }
     | undefined => {
-    const effectiveContextStepResults =
-        workflowContextStepResults ??
-        (workflowContextStepResult !== undefined
-            ? [workflowContextStepResult]
-            : []);
+    const effectiveContextStepResults = workflowContextStepResults ?? [];
     if (effectiveContextStepResults.length === 0) {
         return undefined;
     }
@@ -541,9 +531,7 @@ export type RunChatMessagesInput = {
     workflowModeId?: string;
     workflowModeEscalationRequest?: WorkflowModeEscalationRequest;
     toolRequest?: ToolInvocationRequest;
-    contextStepRequest?: ContextStepRequest;
     contextStepRequests?: ContextStepRequest[];
-    contextStepExecutor?: ContextStepExecutor;
     contextStepExecutorRegistry?: Record<string, ContextStepExecutor>;
     plannerStepRequest?: PlannerStepRequest;
     plannerStepExecutor?: PlannerStepExecutor;
@@ -703,9 +691,7 @@ export const createChatService = ({
         workflowModeId,
         workflowModeEscalationRequest,
         toolRequest,
-        contextStepRequest,
         contextStepRequests,
-        contextStepExecutor,
         contextStepExecutorRegistry,
         plannerStepRequest,
         plannerStepExecutor,
@@ -800,7 +786,6 @@ export const createChatService = ({
 
         let generationResult: GenerationResult;
         let workflowLineage: WorkflowRecord | undefined;
-        let workflowContextStepResult: ContextStepResult | undefined;
         let workflowContextStepResults: ContextStepResult[] | undefined;
         let workflowPlannerSummary: AppliedPlanState | undefined;
         let workflowPlannerStepResult: PlannerStepResult | undefined;
@@ -842,9 +827,7 @@ export const createChatService = ({
                 plannerStepRequest: effectivePlannerStepRequest,
                 plannerStepExecutor: effectivePlannerStepExecutor,
                 planContinuationBuilder,
-                contextStepRequest,
                 contextStepRequests,
-                contextStepExecutor,
                 contextStepExecutorRegistry,
             });
             workflowPlannerStepResult = workflowResult.plannerStepResult;
@@ -869,14 +852,12 @@ export const createChatService = ({
             } else {
                 workflowConversationSnapshot = undefined;
             }
-            workflowContextStepResult = workflowResult.contextStepResult;
             workflowContextStepResults = workflowResult.contextStepResults;
             switch (workflowResult.outcome) {
                 case 'generated': {
                     generationResult = workflowResult.generationResult;
                     workflowLineage = workflowResult.workflowLineage;
                     const generatedShortCircuit = buildContextStepShortCircuit({
-                        workflowContextStepResult,
                         workflowContextStepResults,
                         executionContext,
                         toolRequest,
@@ -912,7 +893,6 @@ export const createChatService = ({
                 case 'no_generation': {
                     workflowLineage = workflowResult.workflowLineage;
                     const noGenShortCircuit = buildContextStepShortCircuit({
-                        workflowContextStepResult,
                         workflowContextStepResults,
                         executionContext,
                         toolRequest,
@@ -1096,10 +1076,9 @@ export const createChatService = ({
 
         // Backend authority merges all context-integration citations so callers
         // consume one canonical metadata citation surface.
-        const contextStepSources =
-            workflowContextStepResults?.flatMap(
-                (contextStepResult) => contextStepResult.sources ?? []
-            ) ?? workflowContextStepResult?.sources;
+        const contextStepSources = workflowContextStepResults?.flatMap(
+            (contextStepResult) => contextStepResult.sources ?? []
+        );
         const assistantMetadata = buildAssistantMetadata(
             generationResult,
             effectiveNormalizedGeneration,
@@ -1140,11 +1119,8 @@ export const createChatService = ({
             ) === true;
         // Any mode escalation lineage is resolved by workflowProfileRegistry.
         // Runtime metadata here only carries the resolved decision payload.
-        const hasSearchIntent =
-            effectiveNormalizedGeneration?.search !== undefined;
         const upstreamToolExecution =
             executionContext?.tool ??
-            workflowContextStepResult?.executionContext ??
             workflowPlannerSummary?.toolExecutionContext;
         const effectiveToolExecutionContext:
             | NonNullable<
@@ -1153,46 +1129,7 @@ export const createChatService = ({
             | undefined =
             // Respect explicit upstream tool outcomes first (for example,
             // orchestrator-level fail-open policy decisions).
-            upstreamToolExecution
-                ? hasSearchIntent &&
-                  upstreamToolExecution.toolName === 'web_search'
-                    ? {
-                          ...upstreamToolExecution,
-                          status: retrievalUsed ? 'executed' : 'skipped',
-                          ...(retrievalUsed
-                              ? upstreamToolExecution.reasonCode !== undefined
-                                  ? {
-                                        // Keep policy reason codes when
-                                        // runtime confirms tool execution.
-                                        reasonCode:
-                                            upstreamToolExecution.reasonCode,
-                                    }
-                                  : {}
-                              : {
-                                    reasonCode:
-                                        upstreamToolExecution.reasonCode ??
-                                        'tool_not_used',
-                                }),
-                      }
-                    : upstreamToolExecution
-                : generationResult.toolExecution
-                  ? generationResult.toolExecution
-                  : hasSearchIntent
-                    ? ({
-                          // TODO(backend): Replace retrieval-signal inference
-                          // with explicit runtime tool execution signals once
-                          // they are always present for search requests.
-                          // When search was requested, infer tool execution from
-                          // retrieval usage signals reported by the runtime.
-                          toolName: 'web_search',
-                          status: retrievalUsed ? 'executed' : 'skipped',
-                          ...(retrievalUsed
-                              ? {}
-                              : {
-                                    reasonCode: 'tool_not_used',
-                                }),
-                      } satisfies ToolExecutionContext)
-                    : undefined;
+            upstreamToolExecution ?? generationResult.toolExecution;
 
         const usageModel = assistantMetadata.model || defaultModel;
         type GenerationExecutionContext = NonNullable<
@@ -1325,7 +1262,7 @@ export const createChatService = ({
             },
             ...(steerabilityControls !== undefined && { steerabilityControls }),
             retrieval: {
-                requested: hasSearchIntent,
+                requested: effectiveNormalizedGeneration?.search !== undefined,
                 used: retrievalUsed,
                 intent: effectiveNormalizedGeneration?.search?.intent,
                 contextSize: effectiveNormalizedGeneration?.search?.contextSize,

--- a/packages/backend/src/services/contextIntegrations/webSearch/index.ts
+++ b/packages/backend/src/services/contextIntegrations/webSearch/index.ts
@@ -1,0 +1,13 @@
+/**
+ * @description: Public exports for web search context integration components.
+ * @footnote-scope: interface
+ * @footnote-module: WebSearchContextIntegrationIndex
+ * @footnote-risk: low - Export-map changes are isolated to backend integration wiring.
+ * @footnote-ethics: low - Export paths do not alter governance or user-facing decisions.
+ */
+export { createWebSearchContextStepExecutor } from './webSearchContextStepExecutor.js';
+export {
+    resolveWebSearchProviderSelectionPlan,
+    type WebSearchProviderPolicy,
+    type WebSearchProviderSelectionPlan,
+} from './webSearchProviderPolicy.js';

--- a/packages/backend/src/services/contextIntegrations/webSearch/webSearchContextStepExecutor.ts
+++ b/packages/backend/src/services/contextIntegrations/webSearch/webSearchContextStepExecutor.ts
@@ -98,7 +98,7 @@ export const createWebSearchContextStepExecutor =
                 enabledProviders: ['openai'],
                 providerOrder: ['openai'],
             },
-            // Row-4 scaffolding: only OpenAI-backed search is executable today.
+            // Current scaffolding: only OpenAI-backed search is executable today.
             // Brave/SearXNG will be added as dedicated providers in follow-up work.
             availableProviders: ['openai'],
         });

--- a/packages/backend/src/services/contextIntegrations/webSearch/webSearchContextStepExecutor.ts
+++ b/packages/backend/src/services/contextIntegrations/webSearch/webSearchContextStepExecutor.ts
@@ -58,6 +58,30 @@ const toGenerationSearchRequest = (
 };
 
 export const createWebSearchContextStepExecutor =
+    /**
+     * Creates the web-search Context Step executor used by workflow orchestration.
+     *
+     * The executor validates request shape, resolves provider-selection policy,
+     * and emits a provider-neutral search instruction as a system context message.
+     *
+     * @param input.providerPolicy - Optional provider policy from runtime config
+     * (`RuntimeConfig['webSearchProviders']`). When omitted, defaults to an
+     * `auto` policy with OpenAI enabled and ordered first.
+     * @returns ContextStepExecutor
+     *
+     * Fail-open behavior:
+     * - Returns `skipped/tool_not_requested` when the request is not requested.
+     * - Returns `skipped/tool_unavailable` when the request is ineligible.
+     * - Returns `failed/unspecified_tool_outcome` when input is malformed.
+     * - Returns `skipped/tool_unavailable` when no providers are selectable.
+     *
+     * Authority/provenance:
+     * - Execution policy authority is backend-owned via provider policy.
+     * - Provider protocol execution remains outside this executor boundary.
+     *
+     * Side effects/logging:
+     * - No network calls and no logging side effects.
+     */
     (input?: {
         providerPolicy?: RuntimeConfig['webSearchProviders'];
     }): ContextStepExecutor =>
@@ -76,8 +100,7 @@ export const createWebSearchContextStepExecutor =
                 executionContext: {
                     toolName: request.integrationName,
                     status: 'skipped',
-                    reasonCode:
-                        request.reasonCode ?? 'unspecified_tool_outcome',
+                    reasonCode: request.reasonCode ?? 'tool_unavailable',
                 },
             };
         }

--- a/packages/backend/src/services/contextIntegrations/webSearch/webSearchContextStepExecutor.ts
+++ b/packages/backend/src/services/contextIntegrations/webSearch/webSearchContextStepExecutor.ts
@@ -1,0 +1,122 @@
+/**
+ * @description: Web search context-step executor that emits provider-neutral search guidance for generation.
+ * @footnote-scope: core
+ * @footnote-module: WebSearchContextStepExecutor
+ * @footnote-risk: low - Failures only affect optional search guidance and keep generation fail-open.
+ * @footnote-ethics: medium - Clear search guidance improves transparency around retrieval behavior.
+ */
+import type { GenerationSearchRequest } from '@footnote/agent-runtime';
+import type {
+    ContextStepExecutor,
+    ContextStepResult,
+} from '../../workflowEngine.js';
+import { buildWebSearchInstruction } from '../../chatGenerationHints.js';
+import type { RuntimeConfig } from '../../../config/types.js';
+import { resolveWebSearchProviderSelectionPlan } from './webSearchProviderPolicy.js';
+
+const toGenerationSearchRequest = (
+    input: unknown
+): GenerationSearchRequest | undefined => {
+    if (input === null || typeof input !== 'object') {
+        return undefined;
+    }
+    const candidate = input as Record<string, unknown>;
+    if (typeof candidate.query !== 'string') {
+        return undefined;
+    }
+    const query = candidate.query.trim();
+    if (query.length === 0) {
+        return undefined;
+    }
+
+    return {
+        query,
+        contextSize:
+            candidate.contextSize === 'low' ||
+            candidate.contextSize === 'medium' ||
+            candidate.contextSize === 'high'
+                ? candidate.contextSize
+                : 'medium',
+        intent:
+            candidate.intent === 'repo_explainer' ||
+            candidate.intent === 'current_facts'
+                ? candidate.intent
+                : 'current_facts',
+        ...(Array.isArray(candidate.repoHints) && {
+            repoHints: candidate.repoHints.filter(
+                (hint): hint is string =>
+                    typeof hint === 'string' && hint.trim().length > 0
+            ),
+        }),
+        ...(Array.isArray(candidate.topicHints) && {
+            topicHints: candidate.topicHints.filter(
+                (hint): hint is string =>
+                    typeof hint === 'string' && hint.trim().length > 0
+            ),
+        }),
+    };
+};
+
+export const createWebSearchContextStepExecutor =
+    (input?: {
+        providerPolicy?: RuntimeConfig['webSearchProviders'];
+    }): ContextStepExecutor =>
+    async ({ request }): Promise<ContextStepResult> => {
+        if (!request.requested) {
+            return {
+                executionContext: {
+                    toolName: request.integrationName,
+                    status: 'skipped',
+                    reasonCode: request.reasonCode ?? 'tool_not_requested',
+                },
+            };
+        }
+        if (!request.eligible) {
+            return {
+                executionContext: {
+                    toolName: request.integrationName,
+                    status: 'skipped',
+                    reasonCode:
+                        request.reasonCode ?? 'unspecified_tool_outcome',
+                },
+            };
+        }
+
+        const searchRequest = toGenerationSearchRequest(request.input);
+        if (!searchRequest) {
+            return {
+                executionContext: {
+                    toolName: request.integrationName,
+                    status: 'failed',
+                    reasonCode: 'unspecified_tool_outcome',
+                },
+            };
+        }
+        const selectionPlan = resolveWebSearchProviderSelectionPlan({
+            policy: input?.providerPolicy ?? {
+                mode: 'auto',
+                enabledProviders: ['openai'],
+                providerOrder: ['openai'],
+            },
+            // Row-4 scaffolding: only OpenAI-backed search is executable today.
+            // Brave/SearXNG will be added as dedicated providers in follow-up work.
+            availableProviders: ['openai'],
+        });
+        if (selectionPlan.candidates.length === 0) {
+            return {
+                executionContext: {
+                    toolName: request.integrationName,
+                    status: 'skipped',
+                    reasonCode: 'tool_unavailable',
+                },
+            };
+        }
+
+        return {
+            executionContext: {
+                toolName: request.integrationName,
+                status: 'executed',
+            },
+            contextMessages: [buildWebSearchInstruction(searchRequest)],
+        };
+    };

--- a/packages/backend/src/services/contextIntegrations/webSearch/webSearchProviderPolicy.ts
+++ b/packages/backend/src/services/contextIntegrations/webSearch/webSearchProviderPolicy.ts
@@ -1,0 +1,56 @@
+/**
+ * @description: Provider-agnostic policy helpers for web search context integration selection and fallback planning.
+ * @footnote-scope: utility
+ * @footnote-module: WebSearchProviderPolicy
+ * @footnote-risk: medium - Incorrect provider ranking can degrade retrieval behavior or availability.
+ * @footnote-ethics: medium - Provider policy shapes evidence quality and user-visible grounding behavior.
+ */
+import type {
+    WebSearchProviderId,
+    WebSearchProviderMode,
+} from '../../../config/types.js';
+
+export type WebSearchProviderPolicy = {
+    mode: WebSearchProviderMode;
+    enabledProviders: WebSearchProviderId[];
+    providerOrder: WebSearchProviderId[];
+};
+
+export type WebSearchProviderSelectionPlan = {
+    candidates: WebSearchProviderId[];
+    mode: WebSearchProviderMode;
+};
+
+const uniqueProviders = (
+    providers: readonly WebSearchProviderId[]
+): WebSearchProviderId[] => [...new Set(providers)];
+
+export const resolveWebSearchProviderSelectionPlan = (input: {
+    policy: WebSearchProviderPolicy;
+    availableProviders: readonly WebSearchProviderId[];
+}): WebSearchProviderSelectionPlan => {
+    const enabled = new Set(uniqueProviders(input.policy.enabledProviders));
+    const available = new Set(uniqueProviders(input.availableProviders));
+
+    const orderedCandidates = uniqueProviders(
+        input.policy.providerOrder.filter(
+            (providerId) => enabled.has(providerId) && available.has(providerId)
+        )
+    );
+    if (orderedCandidates.length > 0) {
+        return {
+            candidates: orderedCandidates,
+            mode: input.policy.mode,
+        };
+    }
+
+    const fallbackCandidates = uniqueProviders(
+        input.policy.enabledProviders.filter((providerId) =>
+            available.has(providerId)
+        )
+    );
+    return {
+        candidates: fallbackCandidates,
+        mode: input.policy.mode,
+    };
+};

--- a/packages/backend/src/services/contextIntegrations/webSearch/webSearchProviderPolicy.ts
+++ b/packages/backend/src/services/contextIntegrations/webSearch/webSearchProviderPolicy.ts
@@ -10,12 +10,31 @@ import type {
     WebSearchProviderMode,
 } from '../../../config/types.js';
 
+/**
+ * Policy inputs for provider selection planning in web search Context Integration.
+ *
+ * - `mode`: selection posture (`auto`, `strict`, `preferred_order`)
+ * - `enabledProviders`: providers allowed by backend policy/config
+ * - `providerOrder`: explicit preference order for ordered selection
+ *
+ * Invariants:
+ * - Providers should be listed using `WebSearchProviderId`.
+ * - Empty lists are allowed and resolve fail-open to empty candidates.
+ */
 export type WebSearchProviderPolicy = {
     mode: WebSearchProviderMode;
     enabledProviders: WebSearchProviderId[];
     providerOrder: WebSearchProviderId[];
 };
 
+/**
+ * Planned provider candidates for one execution attempt.
+ *
+ * - `candidates`: ordered provider ids to try
+ * - `mode`: mode used to derive this plan
+ *
+ * Empty candidates indicate no eligible+available provider could be selected.
+ */
 export type WebSearchProviderSelectionPlan = {
     candidates: WebSearchProviderId[];
     mode: WebSearchProviderMode;
@@ -25,6 +44,25 @@ const uniqueProviders = (
     providers: readonly WebSearchProviderId[]
 ): WebSearchProviderId[] => [...new Set(providers)];
 
+/**
+ * Resolves provider candidates for web search execution.
+ *
+ * Algorithm:
+ * 1) Ordered branch: pick providers in `providerOrder` that are both enabled
+ *    and available.
+ * 2) If ordered branch returns candidates, use them for all modes.
+ * 3) `strict` mode: if ordered branch is empty, return empty candidates.
+ * 4) Non-strict fallback (`auto`/`preferred_order`): use enabled providers
+ *    that are available, preserving enabledProviders order.
+ *
+ * Fail-open semantics:
+ * - Never throws.
+ * - Returns empty candidates when policy/availability cannot yield a runnable
+ *   provider; caller decides skip/failure behavior.
+ *
+ * Authority:
+ * - Backend policy/config is authoritative for enabled/order constraints.
+ */
 export const resolveWebSearchProviderSelectionPlan = (input: {
     policy: WebSearchProviderPolicy;
     availableProviders: readonly WebSearchProviderId[];
@@ -40,6 +78,12 @@ export const resolveWebSearchProviderSelectionPlan = (input: {
     if (orderedCandidates.length > 0) {
         return {
             candidates: orderedCandidates,
+            mode: input.policy.mode,
+        };
+    }
+    if (input.policy.mode === 'strict') {
+        return {
+            candidates: [],
             mode: input.policy.mode,
         };
     }

--- a/packages/backend/src/services/openaiService/request.ts
+++ b/packages/backend/src/services/openaiService/request.ts
@@ -10,7 +10,6 @@
 import type { RuntimeMessage } from '@footnote/agent-runtime';
 import { runtimeConfig } from '../../config.js';
 import { logger } from '../../utils/logger.js';
-import { buildWebSearchInstruction } from '../chatGenerationHints.js';
 import {
     extractCitationsFromOutputItems,
     extractMarkdownLinkCitations,
@@ -184,17 +183,6 @@ class SimpleOpenAIService implements OpenAIService {
             ...validMessages.map((message) =>
                 buildInputMessage(message.role, message.content)
             ),
-            ...(hasSearchRequest && options.search
-                ? [
-                      buildInputMessage(
-                          'system',
-                          buildWebSearchInstruction({
-                              ...options.search,
-                              repoHints: options.search.repoHints ?? [],
-                          })
-                      ),
-                  ]
-                : []),
         ];
 
         const requestBody = JSON.stringify({

--- a/packages/backend/src/services/plannerWorkflowSeams.ts
+++ b/packages/backend/src/services/plannerWorkflowSeams.ts
@@ -113,7 +113,6 @@ export type PlannerApplicationResult = {
     capabilityReasonCode?: string;
     toolRequestContext: ToolInvocationRequest;
     toolExecutionContext?: ToolExecutionContext;
-    contextStepRequest?: ContextStepRequest;
     contextStepRequests?: ContextStepRequest[];
     plannerApplyOutcome: PlannerExecutionApplyOutcome;
     plannerMattered: boolean;
@@ -183,8 +182,6 @@ export type PlanContinuation = {
           generationRequest: GenerationRequest;
           plannerTemperament?: PartialResponseTemperament;
           conversationSnapshot: string;
-          // Backward-compatible single integration field for existing callers.
-          contextStepRequest?: ContextStepRequest;
           // Preferred multi-integration field consumed by parallel context-step execution.
           contextStepRequests?: ContextStepRequest[];
       }

--- a/packages/backend/src/services/workflowEngine.ts
+++ b/packages/backend/src/services/workflowEngine.ts
@@ -172,12 +172,8 @@ export type RunBoundedReviewWorkflowInput = {
     plannerStepExecutor?: PlannerStepExecutor;
     // Caller-owned policy application. Engine only consumes continuation output.
     planContinuationBuilder?: PlanContinuationBuilder;
-    // Backward-compatible single integration input used by current callers.
-    contextStepRequest?: ContextStepRequest;
     // Preferred multi-integration input. Engine executes eligible steps in parallel.
     contextStepRequests?: ContextStepRequest[];
-    // Backward-compatible default executor for single-integration callers.
-    contextStepExecutor?: ContextStepExecutor;
     // Preferred executor routing by integration name.
     contextStepExecutorRegistry?: Record<string, ContextStepExecutor>;
 };
@@ -189,7 +185,6 @@ export type RunBoundedReviewWorkflowResult =
           workflowLineage: WorkflowRecord;
           plannerStepResult?: PlannerStepResult;
           planContinuation?: PlanContinuation;
-          contextStepResult?: ContextStepResult;
           contextStepResults?: ContextStepResult[];
       }
     | {
@@ -198,7 +193,6 @@ export type RunBoundedReviewWorkflowResult =
           workflowLineage: WorkflowRecord;
           plannerStepResult?: PlannerStepResult;
           planContinuation?: PlanContinuation;
-          contextStepResult?: ContextStepResult;
           contextStepResults?: ContextStepResult[];
       }
     | {
@@ -206,7 +200,6 @@ export type RunBoundedReviewWorkflowResult =
           workflowLineage: WorkflowRecord;
           plannerStepResult?: PlannerStepResult;
           planContinuation?: PlanContinuation;
-          contextStepResult?: ContextStepResult;
           contextStepResults?: ContextStepResult[];
       };
 
@@ -735,9 +728,7 @@ export const runBoundedReviewWorkflow = async ({
     plannerStepRequest,
     plannerStepExecutor,
     planContinuationBuilder,
-    contextStepRequest,
     contextStepRequests,
-    contextStepExecutor,
     contextStepExecutorRegistry,
 }: RunBoundedReviewWorkflowInput): Promise<RunBoundedReviewWorkflowResult> => {
     // NOTE: Concrete tool execution is still orchestrator/registry-owned.
@@ -789,12 +780,10 @@ export const runBoundedReviewWorkflow = async ({
     let latestReviewReason: string | undefined;
     let shouldStop = false;
     let exhaustedLimitKey: WorkflowLimitKey | undefined;
-    let executedContextStepResult: ContextStepResult | undefined;
     let executedContextStepResults: ContextStepResult[] = [];
     let messagesWithContext = messagesWithHints;
     let effectiveGenerationRequest = generationRequest;
     let effectiveMessagesWithHints = messagesWithHints;
-    let effectiveContextStepRequest = contextStepRequest;
     let effectiveContextStepRequests = contextStepRequests;
     let workflowTerminalAction: PlanTerminalAction | undefined;
     let planContinuation: PlanContinuation | undefined;
@@ -1036,9 +1025,6 @@ export const runBoundedReviewWorkflow = async ({
             } else {
                 effectiveGenerationRequest = planContinuation.generationRequest;
                 effectiveMessagesWithHints = planContinuation.messagesWithHints;
-                effectiveContextStepRequest =
-                    planContinuation.contextStepRequest ??
-                    effectiveContextStepRequest;
                 effectiveContextStepRequests =
                     planContinuation.contextStepRequests ??
                     effectiveContextStepRequests;
@@ -1128,25 +1114,16 @@ export const runBoundedReviewWorkflow = async ({
 
     /**
      * Resolve executor authority per context integration.
-     * Registry mapping is authoritative. Fallback executor preserves existing
-     * single-step call sites while migration to registry is in progress.
+     * Registry mapping is authoritative.
      */
     const selectContextStepExecutor = (
         request: ContextStepRequest
     ): ContextStepExecutor | undefined => {
-        const registryExecutor =
-            contextStepExecutorRegistry?.[request.integrationName];
-        if (registryExecutor !== undefined) {
-            return registryExecutor;
-        }
-        return contextStepExecutor;
+        return contextStepExecutorRegistry?.[request.integrationName];
     };
-    const requestedContextSteps = (
-        effectiveContextStepRequests ??
-        (effectiveContextStepRequest !== undefined
-            ? [effectiveContextStepRequest]
-            : [])
-    ).filter((request) => request.requested === true && request.eligible);
+    const requestedContextSteps = (effectiveContextStepRequests ?? []).filter(
+        (request) => request.requested === true && request.eligible
+    );
     const executableContextSteps = requestedContextSteps.filter(
         (request) => selectContextStepExecutor(request) !== undefined
     );
@@ -1347,7 +1324,6 @@ export const runBoundedReviewWorkflow = async ({
                     shouldStop = true;
                 }
             }
-            executedContextStepResult = executedContextStepResults.at(0);
         }
     }
 
@@ -1707,9 +1683,6 @@ export const runBoundedReviewWorkflow = async ({
             ...(planContinuation !== undefined && {
                 planContinuation,
             }),
-            ...(executedContextStepResult !== undefined && {
-                contextStepResult: executedContextStepResult,
-            }),
             ...(executedContextStepResults.length > 0 && {
                 contextStepResults: executedContextStepResults,
             }),
@@ -1726,9 +1699,6 @@ export const runBoundedReviewWorkflow = async ({
             ...(planContinuation !== undefined && {
                 planContinuation,
             }),
-            ...(executedContextStepResult !== undefined && {
-                contextStepResult: executedContextStepResult,
-            }),
             ...(executedContextStepResults.length > 0 && {
                 contextStepResults: executedContextStepResults,
             }),
@@ -1744,9 +1714,6 @@ export const runBoundedReviewWorkflow = async ({
         }),
         ...(planContinuation !== undefined && {
             planContinuation,
-        }),
-        ...(executedContextStepResult !== undefined && {
-            contextStepResult: executedContextStepResult,
         }),
         ...(executedContextStepResults.length > 0 && {
             contextStepResults: executedContextStepResults,

--- a/packages/backend/src/services/workflowEngine.ts
+++ b/packages/backend/src/services/workflowEngine.ts
@@ -1124,6 +1124,20 @@ export const runBoundedReviewWorkflow = async ({
     const requestedContextSteps = (effectiveContextStepRequests ?? []).filter(
         (request) => request.requested === true && request.eligible
     );
+    const unregisteredContextSteps = requestedContextSteps.filter(
+        (request) => selectContextStepExecutor(request) === undefined
+    );
+    for (const request of unregisteredContextSteps) {
+        logger.warn(
+            'Context step requested without registered executor; skipping integration.',
+            {
+                workflowId,
+                workflowName: workflowConfig.workflowName,
+                integrationName: request.integrationName,
+                reasonCode: request.reasonCode ?? 'tool_unavailable',
+            }
+        );
+    }
     const executableContextSteps = requestedContextSteps.filter(
         (request) => selectContextStepExecutor(request) !== undefined
     );

--- a/packages/backend/test/plannerResultApplier.test.ts
+++ b/packages/backend/test/plannerResultApplier.test.ts
@@ -165,10 +165,19 @@ test('PlannerResultApplier enforces single-tool policy and derives weather conte
 
     assert.equal(output.toolRequestContext.toolName, 'weather_forecast');
     assert.equal(output.toolRequestContext.requested, true);
-    assert.equal(
-        output.contextStepRequest?.integrationName,
-        'weather_forecast'
-    );
+    assert.deepEqual(output.contextStepRequests, [
+        {
+            integrationName: 'weather_forecast',
+            requested: true,
+            eligible: true,
+            input: {
+                location: {
+                    type: 'place_query',
+                    query: 'Paris',
+                },
+            },
+        },
+    ]);
     assert.deepEqual(output.generationForExecution.search, {
         query: 'Paris weather',
         contextSize: 'low',
@@ -197,4 +206,68 @@ test('PlannerResultApplier resolves profile and keeps planner suggestions non-au
     assert.equal(typeof output.selectedResponseProfile.id, 'string');
     assert.equal(output.plan.profileId, output.selectedResponseProfile.id);
     assert.equal(output.plannerApplyOutcome, 'applied');
+});
+
+test('PlannerResultApplier derives web-search context-step request when web search is selected', () => {
+    const applier = createApplier();
+    const output = applier({
+        normalizedRequest: createChatRequest({
+            latestUserInput: 'What changed in TypeScript 5.7?',
+            conversation: [
+                {
+                    role: 'user',
+                    content: 'What changed in TypeScript 5.7?',
+                },
+            ],
+        }),
+        plannerStepResult: createPlannerStepResult({
+            plan: {
+                ...createPlannerStepResult().plan,
+                generation: {
+                    ...createPlannerStepResult().plan.generation,
+                    toolIntent: {
+                        toolName: 'web_search',
+                        requested: true,
+                        input: {
+                            query: 'TypeScript 5.7 release notes',
+                            contextSize: 'medium',
+                            intent: 'current_facts',
+                        },
+                    },
+                    search: {
+                        query: 'TypeScript 5.7 release notes',
+                        contextSize: 'medium',
+                        intent: 'current_facts',
+                    },
+                },
+            },
+            diagnostics: {
+                rawToolIntentPresent: true,
+                normalizedToolIntentPresent: true,
+                toolIntentRejected: false,
+                toolIntentRejectionReasons: [],
+                rawToolIntentName: 'web_search',
+                normalizedToolIntentName: 'web_search',
+            },
+        }),
+        clarificationContinuation: { kind: 'none' },
+        resolvedExecutionPolicy: resolveExecutionContract({
+            presetId: 'quality-grounded',
+        }).policyContract,
+    });
+
+    assert.equal(output.toolRequestContext.toolName, 'web_search');
+    assert.equal(output.toolRequestContext.requested, true);
+    assert.deepEqual(output.contextStepRequests, [
+        {
+            integrationName: 'web_search',
+            requested: true,
+            eligible: true,
+            input: {
+                query: 'TypeScript 5.7 release notes',
+                contextSize: 'medium',
+                intent: 'current_facts',
+            },
+        },
+    ]);
 });

--- a/packages/backend/test/toolExecutionParity.test.ts
+++ b/packages/backend/test/toolExecutionParity.test.ts
@@ -82,40 +82,44 @@ test('weather success flows through workflow context-step: tool step recorded in
             enableAssessment: true,
             enableRevision: true,
         },
-        contextStepRequest: {
-            integrationName: 'weather_forecast',
-            requested: true,
-            eligible: true,
-            input: {
-                location: {
-                    type: 'lat_lon',
-                    latitude: 39.7684,
-                    longitude: -86.1581,
+        contextStepRequests: [
+            {
+                integrationName: 'weather_forecast',
+                requested: true,
+                eligible: true,
+                input: {
+                    location: {
+                        type: 'lat_lon',
+                        latitude: 39.7684,
+                        longitude: -86.1581,
+                    },
                 },
             },
-        },
-        contextStepExecutor: async ({ request }) => {
-            const execution = await weatherForecastTool.fetchForecast(
-                request.input as {
-                    location: {
-                        type: 'lat_lon';
-                        latitude: number;
-                        longitude: number;
-                    };
-                }
-            );
-            return {
-                executionContext: {
-                    toolName: 'weather_forecast',
-                    status: 'executed',
-                    durationMs: 10,
-                },
-                contextMessages: [
-                    execution.status === 'ok' && execution.location?.name
-                        ? `Weather in ${execution.location.name}: clear skies`
-                        : 'Weather context: clear skies',
-                ],
-            };
+        ],
+        contextStepExecutorRegistry: {
+            weather_forecast: async ({ request }) => {
+                const execution = await weatherForecastTool.fetchForecast(
+                    request.input as {
+                        location: {
+                            type: 'lat_lon';
+                            latitude: number;
+                            longitude: number;
+                        };
+                    }
+                );
+                return {
+                    executionContext: {
+                        toolName: 'weather_forecast',
+                        status: 'executed',
+                        durationMs: 10,
+                    },
+                    contextMessages: [
+                        execution.status === 'ok' && execution.location?.name
+                            ? `Weather in ${execution.location.name}: clear skies`
+                            : 'Weather context: clear skies',
+                    ],
+                };
+            },
         },
         captureUsage: (generationResult) => ({
             model: generationResult.model ?? 'gpt-5-mini',
@@ -190,32 +194,36 @@ test('weather failure preserves fail-open: generation runs, tool step recorded a
             enableAssessment: true,
             enableRevision: true,
         },
-        contextStepRequest: {
-            integrationName: 'weather_forecast',
-            requested: true,
-            eligible: true,
-            input: { location: 'Indianapolis' },
-        },
-        contextStepExecutor: async () => {
-            try {
-                await weatherForecastTool.fetchForecast({
-                    location: 'Indianapolis',
-                } as never);
-                return {
-                    executionContext: {
-                        toolName: 'weather_forecast',
-                        status: 'executed',
-                    },
-                };
-            } catch {
-                return {
-                    executionContext: {
-                        toolName: 'weather_forecast',
-                        status: 'failed',
-                        reasonCode: 'tool_execution_error',
-                    },
-                };
-            }
+        contextStepRequests: [
+            {
+                integrationName: 'weather_forecast',
+                requested: true,
+                eligible: true,
+                input: { location: 'Indianapolis' },
+            },
+        ],
+        contextStepExecutorRegistry: {
+            weather_forecast: async () => {
+                try {
+                    await weatherForecastTool.fetchForecast({
+                        location: 'Indianapolis',
+                    } as never);
+                    return {
+                        executionContext: {
+                            toolName: 'weather_forecast',
+                            status: 'executed',
+                        },
+                    };
+                } catch {
+                    return {
+                        executionContext: {
+                            toolName: 'weather_forecast',
+                            status: 'failed',
+                            reasonCode: 'tool_execution_error',
+                        },
+                    };
+                }
+            },
         },
         captureUsage: (generationResult) => ({
             model: generationResult.model ?? 'gpt-5-mini',
@@ -293,29 +301,36 @@ test('weather clarification short-circuits: no generation, clarification respons
             enableAssessment: true,
             enableRevision: true,
         },
-        contextStepRequest: {
-            integrationName: 'weather_forecast',
-            requested: true,
-            eligible: true,
-            input: { location: 'New York' },
+        contextStepRequests: [
+            {
+                integrationName: 'weather_forecast',
+                requested: true,
+                eligible: true,
+                input: { location: 'New York' },
+            },
+        ],
+        contextStepExecutorRegistry: {
+            weather_forecast: async () => ({
+                executionContext: {
+                    toolName: 'weather_forecast',
+                    status: 'executed',
+                },
+                clarification: {
+                    reasonCode: 'ambiguous_location',
+                    question: 'Which New York did you mean?',
+                    options: [
+                        {
+                            id: 'nyc',
+                            label: 'New York City, New York, United States',
+                        },
+                        {
+                            id: 'albany',
+                            label: 'Albany, New York, United States',
+                        },
+                    ],
+                },
+            }),
         },
-        contextStepExecutor: async () => ({
-            executionContext: {
-                toolName: 'weather_forecast',
-                status: 'executed',
-            },
-            clarification: {
-                reasonCode: 'ambiguous_location',
-                question: 'Which New York did you mean?',
-                options: [
-                    {
-                        id: 'nyc',
-                        label: 'New York City, New York, United States',
-                    },
-                    { id: 'albany', label: 'Albany, New York, United States' },
-                ],
-            },
-        }),
         captureUsage: (generationResult) => ({
             model: generationResult.model ?? 'gpt-5-mini',
             promptTokens: generationResult.usage?.promptTokens ?? 0,
@@ -354,7 +369,7 @@ test('weather clarification short-circuits: no generation, clarification respons
         'Tool step should have clarification reason'
     );
     assert.equal(
-        result.contextStepResult?.clarification?.reasonCode,
+        result.contextStepResults?.[0]?.clarification?.reasonCode,
         'ambiguous_location',
         'Context result should have clarification'
     );

--- a/packages/backend/test/webSearchContextStepExecutor.test.ts
+++ b/packages/backend/test/webSearchContextStepExecutor.test.ts
@@ -1,0 +1,101 @@
+/**
+ * @description: Verifies web-search context-step executor behavior and fail-open handling.
+ * @footnote-scope: test
+ * @footnote-module: WebSearchContextStepExecutorTests
+ * @footnote-risk: low - Coverage is isolated to one optional context integration seam.
+ * @footnote-ethics: medium - Correct context-step status helps maintain transparent retrieval provenance.
+ */
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { createWebSearchContextStepExecutor } from '../src/services/contextIntegrations/webSearch/index.js';
+
+test('web-search context-step executor emits context message for valid request', async () => {
+    const executor = createWebSearchContextStepExecutor();
+    const result = await executor({
+        request: {
+            integrationName: 'web_search',
+            requested: true,
+            eligible: true,
+            input: {
+                query: 'Footnote architecture',
+                contextSize: 'medium',
+                intent: 'repo_explainer',
+                repoHints: ['architecture'],
+            },
+        },
+        workflowId: 'wf_test',
+        workflowName: 'message_reviewed',
+        attempt: 1,
+    });
+
+    assert.equal(result.executionContext.toolName, 'web_search');
+    assert.equal(result.executionContext.status, 'executed');
+    assert.equal((result.contextMessages?.length ?? 0) > 0, true);
+});
+
+test('web-search context-step executor skips when request is not requested', async () => {
+    const executor = createWebSearchContextStepExecutor();
+    const result = await executor({
+        request: {
+            integrationName: 'web_search',
+            requested: false,
+            eligible: false,
+            reasonCode: 'tool_not_requested',
+        },
+        workflowId: 'wf_test',
+        workflowName: 'message_reviewed',
+        attempt: 1,
+    });
+
+    assert.equal(result.executionContext.status, 'skipped');
+    assert.equal(result.executionContext.reasonCode, 'tool_not_requested');
+});
+
+test('web-search context-step executor fails open on invalid input', async () => {
+    const executor = createWebSearchContextStepExecutor();
+    const result = await executor({
+        request: {
+            integrationName: 'web_search',
+            requested: true,
+            eligible: true,
+            input: {
+                query: '   ',
+            },
+        },
+        workflowId: 'wf_test',
+        workflowName: 'message_reviewed',
+        attempt: 1,
+    });
+
+    assert.equal(result.executionContext.status, 'failed');
+    assert.equal(
+        result.executionContext.reasonCode,
+        'unspecified_tool_outcome'
+    );
+});
+
+test('web-search context-step executor skips when provider policy has no available candidates', async () => {
+    const executor = createWebSearchContextStepExecutor({
+        providerPolicy: {
+            mode: 'strict',
+            enabledProviders: ['brave'],
+            providerOrder: ['brave'],
+        },
+    });
+    const result = await executor({
+        request: {
+            integrationName: 'web_search',
+            requested: true,
+            eligible: true,
+            input: {
+                query: 'Footnote architecture',
+            },
+        },
+        workflowId: 'wf_test',
+        workflowName: 'message_reviewed',
+        attempt: 1,
+    });
+
+    assert.equal(result.executionContext.status, 'skipped');
+    assert.equal(result.executionContext.reasonCode, 'tool_unavailable');
+});

--- a/packages/backend/test/webSearchProviderPolicy.test.ts
+++ b/packages/backend/test/webSearchProviderPolicy.test.ts
@@ -36,3 +36,31 @@ test('web search provider selection returns empty candidates when no enabled pro
     assert.equal(plan.mode, 'strict');
     assert.deepEqual(plan.candidates, []);
 });
+
+test('web search provider selection uses enabled-order fallback when ordered branch has no overlap', () => {
+    const plan = resolveWebSearchProviderSelectionPlan({
+        policy: {
+            mode: 'preferred_order',
+            enabledProviders: ['searxng', 'openai', 'brave'],
+            providerOrder: [],
+        },
+        availableProviders: ['openai', 'searxng'],
+    });
+
+    assert.equal(plan.mode, 'preferred_order');
+    assert.deepEqual(plan.candidates, ['searxng', 'openai']);
+});
+
+test('web search provider selection preserves auto mode and ordered candidate behavior', () => {
+    const plan = resolveWebSearchProviderSelectionPlan({
+        policy: {
+            mode: 'auto',
+            enabledProviders: ['openai', 'searxng', 'brave'],
+            providerOrder: ['brave', 'openai', 'searxng'],
+        },
+        availableProviders: ['openai', 'searxng'],
+    });
+
+    assert.equal(plan.mode, 'auto');
+    assert.deepEqual(plan.candidates, ['openai', 'searxng']);
+});

--- a/packages/backend/test/webSearchProviderPolicy.test.ts
+++ b/packages/backend/test/webSearchProviderPolicy.test.ts
@@ -1,0 +1,38 @@
+/**
+ * @description: Verifies provider-policy candidate selection for web search context integration scaffolding.
+ * @footnote-scope: test
+ * @footnote-module: WebSearchProviderPolicyTests
+ * @footnote-risk: low - Tests cover deterministic ordering and availability filtering only.
+ * @footnote-ethics: low - Selection planning tests do not execute external providers or user-affecting policy.
+ */
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { resolveWebSearchProviderSelectionPlan } from '../src/services/contextIntegrations/webSearch/index.js';
+
+test('web search provider selection honors ordered enabled providers', () => {
+    const plan = resolveWebSearchProviderSelectionPlan({
+        policy: {
+            mode: 'preferred_order',
+            enabledProviders: ['openai', 'brave', 'searxng'],
+            providerOrder: ['brave', 'searxng', 'openai'],
+        },
+        availableProviders: ['openai', 'searxng'],
+    });
+
+    assert.equal(plan.mode, 'preferred_order');
+    assert.deepEqual(plan.candidates, ['searxng', 'openai']);
+});
+
+test('web search provider selection returns empty candidates when no enabled providers are available', () => {
+    const plan = resolveWebSearchProviderSelectionPlan({
+        policy: {
+            mode: 'strict',
+            enabledProviders: ['brave'],
+            providerOrder: ['brave'],
+        },
+        availableProviders: ['openai'],
+    });
+
+    assert.equal(plan.mode, 'strict');
+    assert.deepEqual(plan.candidates, []);
+});

--- a/packages/backend/test/workflowEngine.test.ts
+++ b/packages/backend/test/workflowEngine.test.ts
@@ -1312,20 +1312,24 @@ test('runBoundedReviewWorkflow executes injected context step and records contex
             enableAssessment: true,
             enableRevision: true,
         },
-        contextStepRequest: {
-            integrationName: 'weather_forecast',
-            requested: true,
-            eligible: true,
-            input: { location: 'Indianapolis' },
-        },
-        contextStepExecutor: async () => ({
-            executionContext: {
-                toolName: 'weather_forecast',
-                status: 'executed',
-                durationMs: 4,
+        contextStepRequests: [
+            {
+                integrationName: 'weather_forecast',
+                requested: true,
+                eligible: true,
+                input: { location: 'Indianapolis' },
             },
-            contextMessages: ['weather_context: clear skies'],
-        }),
+        ],
+        contextStepExecutorRegistry: {
+            weather_forecast: async () => ({
+                executionContext: {
+                    toolName: 'weather_forecast',
+                    status: 'executed',
+                    durationMs: 4,
+                },
+                contextMessages: ['weather_context: clear skies'],
+            }),
+        },
         captureUsage: (generationResult) => ({
             model: generationResult.model ?? 'gpt-5-mini',
             promptTokens: generationResult.usage?.promptTokens ?? 0,
@@ -1500,20 +1504,24 @@ test('runBoundedReviewWorkflow records failed injected context step with reason 
             enableAssessment: true,
             enableRevision: true,
         },
-        contextStepRequest: {
-            integrationName: 'weather_forecast',
-            requested: true,
-            eligible: true,
-            input: { location: 'Indianapolis' },
-        },
-        contextStepExecutor: async () => ({
-            executionContext: {
-                toolName: 'weather_forecast',
-                status: 'failed',
-                reasonCode: 'tool_timeout',
-                durationMs: 10,
+        contextStepRequests: [
+            {
+                integrationName: 'weather_forecast',
+                requested: true,
+                eligible: true,
+                input: { location: 'Indianapolis' },
             },
-        }),
+        ],
+        contextStepExecutorRegistry: {
+            weather_forecast: async () => ({
+                executionContext: {
+                    toolName: 'weather_forecast',
+                    status: 'failed',
+                    reasonCode: 'tool_timeout',
+                    durationMs: 10,
+                },
+            }),
+        },
         captureUsage: (generationResult) => ({
             model: generationResult.model ?? 'gpt-5-mini',
             promptTokens: generationResult.usage?.promptTokens ?? 0,
@@ -1577,26 +1585,30 @@ test('runBoundedReviewWorkflow stops before generation when injected context ste
             enableAssessment: true,
             enableRevision: true,
         },
-        contextStepRequest: {
-            integrationName: 'weather_forecast',
-            requested: true,
-            eligible: true,
-            input: { location: 'Springfield' },
+        contextStepRequests: [
+            {
+                integrationName: 'weather_forecast',
+                requested: true,
+                eligible: true,
+                input: { location: 'Springfield' },
+            },
+        ],
+        contextStepExecutorRegistry: {
+            weather_forecast: async () => ({
+                executionContext: {
+                    toolName: 'weather_forecast',
+                    status: 'executed',
+                },
+                clarification: {
+                    reasonCode: 'ambiguous_location',
+                    question: 'Which Springfield did you mean?',
+                    options: [
+                        { id: '1', label: 'Springfield, Illinois' },
+                        { id: '2', label: 'Springfield, Missouri' },
+                    ],
+                },
+            }),
         },
-        contextStepExecutor: async () => ({
-            executionContext: {
-                toolName: 'weather_forecast',
-                status: 'executed',
-            },
-            clarification: {
-                reasonCode: 'ambiguous_location',
-                question: 'Which Springfield did you mean?',
-                options: [
-                    { id: '1', label: 'Springfield, Illinois' },
-                    { id: '2', label: 'Springfield, Missouri' },
-                ],
-            },
-        }),
         captureUsage: () => ({
             model: 'gpt-5-mini',
             promptTokens: 0,

--- a/packages/backend/test/workflowEngine.test.ts
+++ b/packages/backend/test/workflowEngine.test.ts
@@ -1375,6 +1375,8 @@ test('runBoundedReviewWorkflow executes eligible context steps in parallel and m
     };
     let weatherStartedAt = 0;
     let webSearchStartedAt = 0;
+    let weatherFinishedAt = 0;
+    let webSearchFinishedAt = 0;
 
     const result = await runBoundedReviewWorkflow({
         generationRuntime,
@@ -1413,6 +1415,7 @@ test('runBoundedReviewWorkflow executes eligible context steps in parallel and m
             weather_forecast: async () => {
                 weatherStartedAt = Date.now();
                 await new Promise((resolve) => setTimeout(resolve, 40));
+                weatherFinishedAt = Date.now();
                 return {
                     executionContext: {
                         toolName: 'weather_forecast',
@@ -1424,6 +1427,7 @@ test('runBoundedReviewWorkflow executes eligible context steps in parallel and m
             web_search: async () => {
                 webSearchStartedAt = Date.now();
                 await new Promise((resolve) => setTimeout(resolve, 40));
+                webSearchFinishedAt = Date.now();
                 return {
                     executionContext: {
                         toolName: 'web_search',
@@ -1447,7 +1451,10 @@ test('runBoundedReviewWorkflow executes eligible context steps in parallel and m
     });
 
     assert.equal(result.outcome, 'generated');
-    assert.ok(Math.abs(weatherStartedAt - webSearchStartedAt) < 35);
+    const parallelElapsedMs =
+        Math.max(weatherFinishedAt, webSearchFinishedAt) -
+        Math.min(weatherStartedAt, webSearchStartedAt);
+    assert.ok(parallelElapsedMs < 70);
     assert.equal(result.contextStepResults?.length, 2);
     const firstMessageBatch = observedMessages[0] ?? [];
     const weatherContextMessageIndex = firstMessageBatch.findIndex(


### PR DESCRIPTION
## Summary
- migrate web_search into the workflow Context Step path
- complete direct cutover to contextStepRequests + contextStepExecutorRegistry (remove single-path compatibility plumbing)
- keep provider/runtime protocol semantics at provider boundaries
- add provider-policy scaffolding (mode, enabledProviders, providerOrder) with current OpenAI-only runtime availability
- add/update tests for web-search Context Step executor, provider policy, and planner/workflow parity
- fold follow-up provider expansion plan into status docs

## Validation
- pnpm lint:fix
- pnpm lint

## Scope
- Implements Issue #336 branch scope and PR-prep compatibility work for parallel context integrations.
- Does not implement #334 or #337 feature behavior directly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Web search is now available as an integrated context step within workflows, with support for multiple provider configurations.
  * Added web search provider policy settings enabling mode selection (auto, strict, preferred order) and provider ordering control.
  * Provider selection framework scaffolded for future multi-provider execution.

* **Documentation**
  * Updated context integration architecture and rollout status documentation to reflect web search implementation and multi-provider planning.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->