### PR TITLE
feat(backend): file_scan context-step for attachment grounding

### DIFF
--- a/docs/architecture/context-integrations/README.md
+++ b/docs/architecture/context-integrations/README.md
@@ -106,8 +106,8 @@ under one path.
 
 ### Workflow context-step execution
 
-`weather_forecast` uses the workflow context-step execution path for
-bounded-review modes (`balanced` and `grounded`). In this pattern:
+`weather_forecast` and `file_scan` use the workflow context-step execution path
+for bounded-review modes (`balanced` and `grounded`). In this pattern:
 
 - Executes through `workflowEngine` with an injected `ContextStepExecutor`
 - Executes before the `generate` step in bounded-review workflows
@@ -137,3 +137,4 @@ instead of workflow context-step execution.
 
 - [TrustGraph](./trustgraph.md)
 - [Weather Forecast](./weather-forecast.md)
+- [File Scanning](./file-scanning.md)

--- a/docs/architecture/context-integrations/file-scanning.md
+++ b/docs/architecture/context-integrations/file-scanning.md
@@ -1,0 +1,41 @@
+# File Scanning Context Integration
+
+This document describes the backend-owned `file_scan` context integration.
+
+`file_scan` runs in workflow context-step execution and provides attachment
+grounding signals before generation. It is advisory and fail-open.
+
+## Scope
+
+`file_scan` currently handles:
+
+- image attachments (via backend image-description task service)
+- non-image attachments (as typed attachment context metadata)
+
+It does not grant terminal authority or policy authority.
+
+## Execution model
+
+`file_scan` is emitted through planner application when chat attachments are
+present. The workflow engine executes it through the context-step executor
+registry.
+
+### Behavior
+
+- Requested + eligible with attachments: executes and returns context messages
+  and citation-style sources.
+- Requested + eligible with no attachments: skipped with `tool_not_used`.
+- Not requested or not eligible: skipped with `tool_not_requested` (or incoming
+  reason code).
+
+## Fail-open semantics
+
+If image-description execution fails for an attachment, the integration logs a
+warning, emits a degraded attachment message, and continues execution.
+
+Generation is not blocked by file scanning failures.
+
+## Provenance and sources
+
+`file_scan` outputs `sources` entries in context-step results so downstream
+metadata can include attachment influence in citations/provenance surfaces.

--- a/docs/status/context-integration-architecture.md
+++ b/docs/status/context-integration-architecture.md
@@ -41,7 +41,7 @@ Before integrations can run in parallel with assess-driven cycling:
 | `trustgraph`           | evidence ingestion seam | Not migrated to context-step |
 | `web_search`           | tool-registry path      | Not migrated to context-step |
 | `image_scan`           | Discord bot layer       | Not migrated to context-step |
-| `file_scan`            | not implemented         | Not implemented              |
+| `file_scan`            | context-step            | Implemented                  |
 | `reverse_image_search` | not implemented         | Not implemented              |
 
 ## Implementation Sequence
@@ -74,8 +74,10 @@ Before integrations can run in parallel with assess-driven cycling:
 
 **Issue #334** - File attachment scanning
 
-- Implement as new context integration
-- Support PDF, documents in addition to images
+- Implemented as new context integration (`file_scan`)
+- Runs through workflow context-step execution with fail-open semantics
+- Scans image attachments via backend image-description task service
+- Surfaces non-image files as attachment context metadata
 
 **Issue #335** - Reverse image search
 

--- a/docs/status/context-integration-architecture.md
+++ b/docs/status/context-integration-architecture.md
@@ -38,10 +38,9 @@ Before integrations can run in parallel with assess-driven cycling:
 | Integration            | Pattern                 | Status                       |
 | ---------------------- | ----------------------- | ---------------------------- |
 | `weather_forecast`     | context-step            | Implemented                  |
-| `trustgraph`           | evidence ingestion seam | Not migrated to context-step |
-| `web_search`           | tool-registry path      | Not migrated to context-step |
-| `image_scan`           | Discord bot layer       | Not migrated to context-step |
+| `web_search`           | context-step            | Implemented                  |
 | `file_scan`            | context-step            | Implemented                  |
+| `trustgraph`           | evidence ingestion seam | Not migrated to context-step |
 | `reverse_image_search` | not implemented         | Not implemented              |
 
 ## Implementation Sequence

--- a/docs/status/workflow-engine-rollout-status.md
+++ b/docs/status/workflow-engine-rollout-status.md
@@ -44,4 +44,5 @@ This file tracks the remaining rollout work. The canonical architecture is in
 - [Workflow Architecture](../architecture/workflow.md)
 - [Context Integrations](../architecture/context-integrations/README.md)
 - [Weather Forecast Integration](../architecture/context-integrations/weather-forecast.md)
+- [File Scanning Integration](../architecture/context-integrations/file-scanning.md)
 - [Web Search Context Integration Proposal](../proposals/web-search-context-integration.md)

--- a/docs/status/workflow-engine-rollout-status.md
+++ b/docs/status/workflow-engine-rollout-status.md
@@ -31,9 +31,8 @@ This file tracks the remaining rollout work. The canonical architecture is in
 
 ## Pending Work
 
-- **Tool/context-step expansion**: Only `weather_forecast` uses the workflow
-  context-step path. The infrastructure exists for additional tools, but none
-  are implemented yet.
+- **Tool/context-step expansion**: `weather_forecast` and `file_scan` now use
+  the workflow context-step path. Additional integrations are still pending.
 
 - **web_search**: Not migrated to context-step execution. It still uses the
   current search/runtime path. The proposal in

--- a/packages/backend/src/handlers/chat.ts
+++ b/packages/backend/src/handlers/chat.ts
@@ -19,6 +19,7 @@ import { runtimeConfig } from '../config.js';
 import { createChatOrchestrator } from '../services/chatOrchestrator.js';
 import type { IncidentAlertRouter } from '../services/incidentAlerts.js';
 import type { WeatherForecastTool } from '../services/contextIntegrations/weather/index.js';
+import type { InternalImageDescriptionTaskService } from '../services/internalText.js';
 import { logger } from '../utils/logger.js';
 import {
     type ChatAuthContext,
@@ -44,6 +45,7 @@ type ChatHandlerDeps = {
     generationRuntime: GenerationRuntime | null;
     alertRouter?: IncidentAlertRouter;
     weatherForecastTool?: WeatherForecastTool;
+    internalImageDescriptionTaskService?: InternalImageDescriptionTaskService | null;
     ipRateLimiter: SimpleRateLimiter | null;
     sessionRateLimiter: SimpleRateLimiter | null;
     serviceRateLimiter: SimpleRateLimiter | null;
@@ -138,6 +140,7 @@ const createChatHandler = ({
     generationRuntime,
     alertRouter,
     weatherForecastTool,
+    internalImageDescriptionTaskService,
     ipRateLimiter,
     sessionRateLimiter,
     serviceRateLimiter,
@@ -151,6 +154,8 @@ const createChatHandler = ({
         ? createChatOrchestrator({
               generationRuntime,
               weatherForecastTool,
+              internalImageDescriptionTaskService:
+                  internalImageDescriptionTaskService ?? undefined,
               alertRouter,
               storeTrace,
               buildResponseMetadata,

--- a/packages/backend/src/server.ts
+++ b/packages/backend/src/server.ts
@@ -565,6 +565,7 @@ const handleChatRequest = createChatHandler({
     generationRuntime,
     alertRouter: incidentAlertRouter,
     weatherForecastTool: weatherForecastTool ?? undefined,
+    internalImageDescriptionTaskService,
     ipRateLimiter,
     sessionRateLimiter,
     serviceRateLimiter,

--- a/packages/backend/src/services/chatOrchestrator.ts
+++ b/packages/backend/src/services/chatOrchestrator.ts
@@ -411,8 +411,6 @@ export const createChatOrchestrator = ({
                     internalImageDescriptionTaskService,
                 logger: chatOrchestratorLogger,
             });
-        // Keep this registry additive so parallel Context Integration branches
-        // can merge by appending entries without restructuring call sites.
         const contextStepExecutorRegistry = {
             weather_forecast: weatherContextStepExecutor,
             file_scan: fileScanningContextStepExecutor,

--- a/packages/backend/src/services/chatOrchestrator.ts
+++ b/packages/backend/src/services/chatOrchestrator.ts
@@ -411,6 +411,12 @@ export const createChatOrchestrator = ({
                     internalImageDescriptionTaskService,
                 logger: chatOrchestratorLogger,
             });
+        // Keep this registry additive so parallel Context Integration branches
+        // can merge by appending entries without restructuring call sites.
+        const contextStepExecutorRegistry = {
+            weather_forecast: weatherContextStepExecutor,
+            file_scan: fileScanningContextStepExecutor,
+        };
         const buildPlannerSummary = (input: {
             plannerStepResult: PlannerStepResult;
             plannerApplication: ReturnType<typeof plannerResultApplier>;
@@ -649,10 +655,7 @@ export const createChatOrchestrator = ({
             plannerStepRequest,
             plannerStepExecutor,
             planContinuationBuilder,
-            contextStepExecutorRegistry: {
-                weather_forecast: weatherContextStepExecutor,
-                file_scan: fileScanningContextStepExecutor,
-            },
+            contextStepExecutorRegistry,
             latestUserInput: normalizedRequest.latestUserInput,
             ExecutionContract: resolvedExecutionContract,
             ...(executionContractScopeTuple !== undefined && {

--- a/packages/backend/src/services/chatOrchestrator.ts
+++ b/packages/backend/src/services/chatOrchestrator.ts
@@ -37,8 +37,10 @@ import { resolveExecutionContract } from './executionContractResolver.js';
 import { resolveWorkflowModeDecision } from './workflowProfileRegistry.js';
 import { buildSteerabilityControls } from './steerabilityControls.js';
 import type { WeatherForecastTool } from './contextIntegrations/weather/index.js';
+import type { InternalImageDescriptionTaskService } from './internalText.js';
 import { resolveWeatherClarificationContinuation } from './tools/weatherClarificationContinuation.js';
 import { createWeatherForecastContextStepExecutor } from './contextIntegrations/weather/index.js';
+import { createFileScanningContextStepExecutor } from './contextIntegrations/fileScanning/index.js';
 import { createPlannerResultApplier } from './chatOrchestrator/plannerResultApplier.js';
 import { runtimeConfig } from '../config.js';
 import { logger } from '../utils/logger.js';
@@ -67,6 +69,7 @@ import type {
 
 type CreateChatOrchestratorOptions = CreateChatServiceOptions & {
     weatherForecastTool?: WeatherForecastTool;
+    internalImageDescriptionTaskService?: InternalImageDescriptionTaskService;
     alertRouter?: IncidentAlertRouter;
 };
 
@@ -89,6 +92,7 @@ export const createChatOrchestrator = ({
     recordUsage,
     executionContractTrustGraph,
     weatherForecastTool,
+    internalImageDescriptionTaskService,
     alertRouter,
 }: CreateChatOrchestratorOptions) => {
     const chatOrchestratorLogger =
@@ -401,6 +405,12 @@ export const createChatOrchestrator = ({
                     chatOrchestratorLogger.warn(message, meta);
                 },
             });
+        const fileScanningContextStepExecutor =
+            createFileScanningContextStepExecutor({
+                imageDescriptionTaskService:
+                    internalImageDescriptionTaskService,
+                logger: chatOrchestratorLogger,
+            });
         const buildPlannerSummary = (input: {
             plannerStepResult: PlannerStepResult;
             plannerApplication: ReturnType<typeof plannerResultApplier>;
@@ -639,7 +649,10 @@ export const createChatOrchestrator = ({
             plannerStepRequest,
             plannerStepExecutor,
             planContinuationBuilder,
-            contextStepExecutor: weatherContextStepExecutor,
+            contextStepExecutorRegistry: {
+                weather_forecast: weatherContextStepExecutor,
+                file_scan: fileScanningContextStepExecutor,
+            },
             latestUserInput: normalizedRequest.latestUserInput,
             ExecutionContract: resolvedExecutionContract,
             ...(executionContractScopeTuple !== undefined && {

--- a/packages/backend/src/services/chatOrchestrator/plannerResultApplier.ts
+++ b/packages/backend/src/services/chatOrchestrator/plannerResultApplier.ts
@@ -131,10 +131,11 @@ export const createPlannerResultApplier = (
         });
 
         const contextStepRequest =
-            toolSelection.toolRequest.toolName === 'weather_forecast' &&
+            (toolSelection.toolRequest.toolName === 'weather_forecast' ||
+                toolSelection.toolRequest.toolName === 'web_search') &&
             toolSelection.toolRequest.requested
                 ? {
-                      integrationName: 'weather_forecast',
+                      integrationName: toolSelection.toolRequest.toolName,
                       requested: toolSelection.toolRequest.requested,
                       eligible: toolSelection.toolRequest.eligible,
                       ...(toolSelection.toolRequest.reasonCode !==

--- a/packages/backend/src/services/chatOrchestrator/plannerResultApplier.ts
+++ b/packages/backend/src/services/chatOrchestrator/plannerResultApplier.ts
@@ -14,6 +14,7 @@ import { coercePlanForSurface } from '../chatSurfacePolicy.js';
 import { applySingleToolPolicy } from '../tools/toolPolicy.js';
 import { resolveToolSelection } from '../tools/toolRegistry.js';
 import type { WeatherForecastTool } from '../contextIntegrations/weather/index.js';
+import { FILE_SCAN_INTEGRATION_NAME } from '../contextIntegrations/fileScanning/index.js';
 import { resolveExecutionProfile } from './profileResolution.js';
 import type {
     PlannerApplicationInput,
@@ -154,7 +155,7 @@ export const createPlannerResultApplier = (
             plannerInput.normalizedRequest.attachments !== undefined &&
             plannerInput.normalizedRequest.attachments.length > 0
                 ? {
-                      integrationName: 'file_scan',
+                      integrationName: FILE_SCAN_INTEGRATION_NAME,
                       requested: true,
                       eligible: true,
                       input: {

--- a/packages/backend/src/services/chatOrchestrator/plannerResultApplier.ts
+++ b/packages/backend/src/services/chatOrchestrator/plannerResultApplier.ts
@@ -149,6 +149,27 @@ export const createPlannerResultApplier = (
                       }),
                   }
                 : undefined;
+        const fileScanContextStepRequest =
+            plannerInput.normalizedRequest.attachments !== undefined &&
+            plannerInput.normalizedRequest.attachments.length > 0
+                ? {
+                      integrationName: 'file_scan',
+                      requested: true,
+                      eligible: true,
+                      input: {
+                          attachments: plannerInput.normalizedRequest
+                              .attachments as Record<string, unknown>[],
+                          latestUserInput:
+                              plannerInput.normalizedRequest.latestUserInput,
+                      },
+                  }
+                : undefined;
+        const contextStepRequests = [
+            ...(contextStepRequest !== undefined ? [contextStepRequest] : []),
+            ...(fileScanContextStepRequest !== undefined
+                ? [fileScanContextStepRequest]
+                : []),
+        ];
         const plannerApplyOutcome =
             plannerInput.plannerStepResult.execution.status !== 'executed'
                 ? 'not_applied'
@@ -187,6 +208,7 @@ export const createPlannerResultApplier = (
             toolRequestContext: toolSelection.toolRequest,
             toolExecutionContext: toolSelection.toolExecution,
             contextStepRequest,
+            ...(contextStepRequests.length > 0 && { contextStepRequests }),
             plannerApplyOutcome,
             plannerMattered,
             plannerMatteredControlIds,

--- a/packages/backend/src/services/contextIntegrations/fileScanning/fileScanningContextStepExecutor.ts
+++ b/packages/backend/src/services/contextIntegrations/fileScanning/fileScanningContextStepExecutor.ts
@@ -1,0 +1,170 @@
+/**
+ * @description: File scanning context-step executor for attachment grounding.
+ * Scans image attachments with the backend image-description task and reports
+ * non-image files as structured advisory context.
+ * @footnote-scope: core
+ * @footnote-module: FileScanningContextStepExecutor
+ * @footnote-risk: medium - Incorrect attachment handling can reduce grounding quality for attachment-driven prompts.
+ * @footnote-ethics: medium - Attachment summaries can influence assistant claims, so this path stays fail-open and explicit about uncertainty.
+ */
+import type { Citation } from '@footnote/contracts/ethics-core';
+import type { PostChatRequest } from '@footnote/contracts/web';
+import type { InternalImageDescriptionTaskService } from '../../internalText.js';
+import type {
+    ContextStepExecutor,
+    ContextStepExecutorInput,
+    ContextStepResult,
+} from '../../workflowEngine.js';
+
+type FileScanningExecutorLogger = {
+    warn: (message: string, meta?: Record<string, unknown>) => void;
+};
+
+type CreateFileScanningContextStepExecutorOptions = {
+    imageDescriptionTaskService?: InternalImageDescriptionTaskService | null;
+    logger: FileScanningExecutorLogger;
+};
+
+type ChatAttachment = NonNullable<PostChatRequest['attachments']>[number];
+
+const buildAttachmentSource = (
+    attachment: ChatAttachment,
+    title: string,
+    snippet?: string
+): Citation => ({
+    title,
+    url: attachment.url,
+    ...(snippet !== undefined && { snippet }),
+});
+
+export const createFileScanningContextStepExecutor = ({
+    imageDescriptionTaskService,
+    logger,
+}: CreateFileScanningContextStepExecutorOptions): ContextStepExecutor => {
+    const execute: ContextStepExecutor = async (
+        input: ContextStepExecutorInput
+    ): Promise<ContextStepResult> => {
+        const requestedAttachments = input.request.input?.attachments;
+        const attachmentList = Array.isArray(requestedAttachments)
+            ? (requestedAttachments as ChatAttachment[])
+            : [];
+        const userContext =
+            typeof input.request.input?.latestUserInput === 'string'
+                ? input.request.input.latestUserInput.trim()
+                : '';
+
+        if (!input.request.requested || !input.request.eligible) {
+            return {
+                executionContext: {
+                    toolName: 'file_scan',
+                    status: 'skipped',
+                    reasonCode:
+                        input.request.reasonCode ?? 'tool_not_requested',
+                },
+            };
+        }
+
+        if (attachmentList.length === 0) {
+            return {
+                executionContext: {
+                    toolName: 'file_scan',
+                    status: 'skipped',
+                    reasonCode: 'tool_not_used',
+                },
+            };
+        }
+
+        const contextMessages: string[] = [];
+        const sources: Citation[] = [];
+
+        for (const [index, attachment] of attachmentList.entries()) {
+            const contentType = attachment.contentType?.toLowerCase() ?? '';
+            const isImage =
+                attachment.kind === 'image' || contentType.startsWith('image/');
+            if (isImage) {
+                if (!imageDescriptionTaskService) {
+                    contextMessages.push(
+                        `[Attachment ${index + 1}] image present but image scanning is unavailable in this runtime.`
+                    );
+                    sources.push(
+                        buildAttachmentSource(
+                            attachment,
+                            `Attachment ${index + 1} (image)`,
+                            'Image scanning unavailable at runtime.'
+                        )
+                    );
+                    continue;
+                }
+
+                try {
+                    const response =
+                        await imageDescriptionTaskService.runImageDescriptionTask(
+                            {
+                                task: 'image_description',
+                                imageUrl: attachment.url,
+                                ...(userContext.length > 0 && {
+                                    context: userContext,
+                                }),
+                            }
+                        );
+                    contextMessages.push(
+                        `[Attachment ${index + 1}] ${response.result.description}`
+                    );
+                    sources.push(
+                        buildAttachmentSource(
+                            attachment,
+                            `Attachment ${index + 1} (image)`,
+                            'Backend image-description context integration.'
+                        )
+                    );
+                } catch (error) {
+                    logger.warn(
+                        'file_scan: image-description task failed; continuing without image grounding.',
+                        {
+                            attachmentIndex: index + 1,
+                            error:
+                                error instanceof Error
+                                    ? error.message
+                                    : String(error),
+                        }
+                    );
+                    contextMessages.push(
+                        `[Attachment ${index + 1}] image scan failed; continue without image-grounded details.`
+                    );
+                    sources.push(
+                        buildAttachmentSource(
+                            attachment,
+                            `Attachment ${index + 1} (image)`,
+                            'Image scan failed in fail-open mode.'
+                        )
+                    );
+                }
+                continue;
+            }
+
+            const normalizedType =
+                contentType.length > 0 ? contentType : 'unknown';
+            contextMessages.push(
+                `[Attachment ${index + 1}] non-image file attached (${normalizedType}).`
+            );
+            sources.push(
+                buildAttachmentSource(
+                    attachment,
+                    `Attachment ${index + 1} (file)`,
+                    `Detected file attachment (${normalizedType}).`
+                )
+            );
+        }
+
+        return {
+            executionContext: {
+                toolName: 'file_scan',
+                status: 'executed',
+            },
+            ...(contextMessages.length > 0 && { contextMessages }),
+            ...(sources.length > 0 && { sources }),
+        };
+    };
+
+    return execute;
+};

--- a/packages/backend/src/services/contextIntegrations/fileScanning/index.ts
+++ b/packages/backend/src/services/contextIntegrations/fileScanning/index.ts
@@ -6,3 +6,5 @@
  * @footnote-ethics: low - Re-exports only.
  */
 export { createFileScanningContextStepExecutor } from './fileScanningContextStepExecutor.js';
+
+export const FILE_SCAN_INTEGRATION_NAME = 'file_scan' as const;

--- a/packages/backend/src/services/contextIntegrations/fileScanning/index.ts
+++ b/packages/backend/src/services/contextIntegrations/fileScanning/index.ts
@@ -1,0 +1,8 @@
+/**
+ * @description: File scanning context integration entry point.
+ * @footnote-scope: core
+ * @footnote-module: FileScanningContextIntegration
+ * @footnote-risk: low - Re-exports only.
+ * @footnote-ethics: low - Re-exports only.
+ */
+export { createFileScanningContextStepExecutor } from './fileScanningContextStepExecutor.js';

--- a/packages/contracts/src/web/schemas.ts
+++ b/packages/contracts/src/web/schemas.ts
@@ -79,7 +79,7 @@ const ChatConversationMessageSchema = z
     .strict();
 const ChatAttachmentSchema = z
     .object({
-        kind: z.literal('image'),
+        kind: z.enum(['image', 'file']),
         url: z.string().url(),
         contentType: z.string().min(1).optional(),
     })

--- a/packages/contracts/src/web/types.ts
+++ b/packages/contracts/src/web/types.ts
@@ -278,7 +278,7 @@ export type ChatConversationMessage = {
  * to one surface's event model.
  */
 export type ChatAttachment = {
-    kind: 'image';
+    kind: 'image' | 'file';
     url: string;
     contentType?: string;
 };

--- a/packages/discord-bot/src/utils/MessageProcessor.ts
+++ b/packages/discord-bot/src/utils/MessageProcessor.ts
@@ -318,10 +318,8 @@ const isChatImageAction = (
     );
 };
 
-const hasImageAttachments = (message: Message): boolean =>
-    message.attachments.some((attachment) =>
-        attachment.contentType?.startsWith('image/')
-    );
+const hasAnyAttachments = (message: Message): boolean =>
+    message.attachments.size > 0;
 
 const hasImageEmbeds = (message: Message): boolean =>
     message.embeds.some(
@@ -468,7 +466,7 @@ export class MessageProcessor {
 
         if (
             !message.content.trim() &&
-            !hasImageAttachments(message) &&
+            !hasAnyAttachments(message) &&
             !hasImageEmbeds(message)
         ) {
             return;
@@ -558,78 +556,6 @@ export class MessageProcessor {
             message,
             RESPONSE_CONTEXT_SIZE
         );
-        const imageAttachments = message.attachments.filter((attachment) =>
-            attachment.contentType?.startsWith('image/')
-        );
-
-        if (imageAttachments.size > 0) {
-            logger.debug(
-                `Processing image attachment(s) for chat request on message ${message.id}.`,
-                {
-                    attachmentCount: imageAttachments.size,
-                    contentLength: message.content.length,
-                }
-            );
-            const trimmedAttachmentContext = message.content.trim();
-
-            const imageDescriptions = await Promise.all(
-                imageAttachments.map(async (attachment) => {
-                    try {
-                        const response =
-                            await botApi.runImageDescriptionTaskViaApi({
-                                task: 'image_description',
-                                imageUrl: attachment.url,
-                                ...(trimmedAttachmentContext.length > 0
-                                    ? {
-                                          context: trimmedAttachmentContext,
-                                      }
-                                    : {}),
-                                channelContext: {
-                                    channelId: message.channelId,
-                                    guildId: message.guildId ?? undefined,
-                                },
-                            });
-
-                        return (
-                            response.result.description ??
-                            `Error generating image description for message ${message.id} attachment ${attachment.id}`
-                        );
-                    } catch (error) {
-                        logger.error(
-                            `Error generating image description for chat attachment on message ${message.id}: ${
-                                error instanceof Error
-                                    ? error.message
-                                    : String(error)
-                            }`,
-                            {
-                                attachmentId: attachment.id,
-                                attachmentCount: imageAttachments.size,
-                            }
-                        );
-                        return `Error generating image description for message ${message.id} attachment ${attachment.id}`;
-                    }
-                })
-            );
-
-            conversation.push({
-                role: 'system',
-                content: [
-                    '// ==========',
-                    '// BEGIN Image Descriptions',
-                    '// The user uploaded images; use these auto-generated descriptions for grounding.',
-                    '// ==========',
-                    imageDescriptions
-                        .map(
-                            (description, index) =>
-                                `[Image ${index + 1}]: ${description}`
-                        )
-                        .join('\n'),
-                    '// ==========',
-                    '// END Image Descriptions',
-                    '// ==========',
-                ].join('\n'),
-            });
-        }
 
         let recoveredImageContext: RecoveredImageContext | null = null;
         try {
@@ -680,8 +606,10 @@ export class MessageProcessor {
                 },
                 latestUserInput: message.content.trim(),
                 conversation,
-                attachments: imageAttachments.map((attachment) => ({
-                    kind: 'image' as const,
+                attachments: message.attachments.map((attachment) => ({
+                    kind: attachment.contentType?.startsWith('image/')
+                        ? ('image' as const)
+                        : ('file' as const),
                     url: attachment.url,
                     contentType: attachment.contentType ?? undefined,
                 })),
@@ -776,8 +704,8 @@ export class MessageProcessor {
         const currentMessageContent =
             message.content.trim() ||
             buildEmbedSummary(message) ||
-            (hasImageAttachments(message)
-                ? '[User uploaded one or more images.]'
+            (hasAnyAttachments(message)
+                ? '[User uploaded one or more attachments.]'
                 : 'User sent a non-text message.');
         historyConversation.push({
             role: 'user',

--- a/packages/discord-bot/test/messageProcessor.chat.test.ts
+++ b/packages/discord-bot/test/messageProcessor.chat.test.ts
@@ -113,10 +113,8 @@ const createChatBuildMessage = () =>
         channelId: 'channel-1',
         guildId: 'guild-1',
         attachments: {
-            filter: () => ({
-                size: 0,
-                map: () => [],
-            }),
+            size: 0,
+            map: () => [],
         },
         mentions: {
             users: {
@@ -858,8 +856,8 @@ test('processMessage replies with a red code-block error when backend chat reque
         author: { id: 'user-1', username: 'Jordan' },
         channel: { id: 'channel-1' },
         attachments: {
-            some: () => false,
-            filter: () => ({ size: 0 }),
+            size: 0,
+            map: () => [],
         },
         embeds: [],
         channelId: 'channel-1',
@@ -932,216 +930,67 @@ test('buildChatRequestFromMessage includes botPersonaId and leaves overlay compo
     }
 });
 
-test('buildChatRequestFromMessage uses backend image-description tasks for attachment grounding', async () => {
+test('buildChatRequestFromMessage forwards attachments for backend context integration', async () => {
     const processor = createProcessor();
     const processorAccess = processor as unknown as ProcessorPrivateAccess;
-    const originalRunImageDescriptionTaskViaApi =
-        botApi.runImageDescriptionTaskViaApi;
-    const capturedRequests: Array<{
-        task: string;
-        imageUrl: string;
-        context?: string;
-        channelContext?: { channelId?: string; guildId?: string };
-    }> = [];
 
     processorAccess.buildRawConversationHistory = async () => [
-        { role: 'user', content: 'Jordan uploaded a screenshot.' },
+        { role: 'user', content: 'Jordan uploaded files.' },
     ];
-
-    (
-        botApi as {
-            runImageDescriptionTaskViaApi: typeof botApi.runImageDescriptionTaskViaApi;
-        }
-    ).runImageDescriptionTaskViaApi = (async (request) => {
-        capturedRequests.push(request);
-        return {
-            task: 'image_description',
-            result: {
-                description: '{"summary":"Screenshot of a policy update"}',
-                model: 'gpt-4o-mini',
-                usage: {
-                    inputTokens: 10,
-                    outputTokens: 5,
-                    totalTokens: 15,
-                },
-                costs: {
-                    input: 0.0000015,
-                    output: 0.000003,
-                    total: 0.0000045,
+    const built = await processorAccess.buildChatRequestFromMessage(
+        {
+            id: 'message-attach-1',
+            content: 'Summarize these attachments.',
+            author: { id: 'user-1', username: 'Jordan' },
+            channelId: 'channel-1',
+            guildId: 'guild-1',
+            attachments: {
+                size: 2,
+                map: (callback: (attachment: unknown) => unknown) => [
+                    callback({
+                        id: 'attachment-image',
+                        url: 'https://example.com/screenshot.png',
+                        contentType: 'image/png',
+                    }),
+                    callback({
+                        id: 'attachment-file',
+                        url: 'https://example.com/spec.pdf',
+                        contentType: 'application/pdf',
+                    }),
+                ],
+            },
+            mentions: {
+                users: {
+                    has: () => false,
                 },
             },
-        };
-    }) as typeof botApi.runImageDescriptionTaskViaApi;
-
-    try {
-        const built = await processorAccess.buildChatRequestFromMessage(
-            {
-                id: 'message-attach-1',
-                content: 'What changed in this image?',
-                author: { id: 'user-1', username: 'Jordan' },
-                channelId: 'channel-1',
-                guildId: 'guild-1',
-                attachments: {
-                    filter: () => ({
-                        size: 1,
-                        map: (callback: (attachment: unknown) => unknown) => [
-                            callback({
-                                id: 'attachment-1',
-                                url: 'https://example.com/screenshot.png',
-                                contentType: 'image/png',
-                            }),
-                        ],
-                    }),
-                },
-                mentions: {
-                    users: {
-                        has: () => false,
-                    },
-                },
-                client: {
-                    user: {
-                        id: 'bot-1',
-                    },
-                },
-                channel: {},
-                embeds: [],
-            } as never,
-            ''
-        );
-
-        if (!built) {
-            throw new Error('Expected chat request to be built');
-        }
-
-        assert.equal(capturedRequests.length, 1);
-        assert.equal(capturedRequests[0]?.task, 'image_description');
-        assert.equal(
-            capturedRequests[0]?.imageUrl,
-            'https://example.com/screenshot.png'
-        );
-        assert.equal(
-            capturedRequests[0]?.context,
-            'What changed in this image?'
-        );
-        assert.equal(
-            capturedRequests[0]?.channelContext?.channelId,
-            'channel-1'
-        );
-        const joinedConversation = built.request.conversation
-            .map((entry) => entry.content)
-            .join('\n');
-        assert.match(joinedConversation, /BEGIN Image Descriptions/);
-        assert.match(joinedConversation, /Screenshot of a policy update/);
-    } finally {
-        (
-            botApi as {
-                runImageDescriptionTaskViaApi: typeof botApi.runImageDescriptionTaskViaApi;
-            }
-        ).runImageDescriptionTaskViaApi = originalRunImageDescriptionTaskViaApi;
-    }
-});
-
-test('buildChatRequestFromMessage omits empty image-description context for image-only messages', async () => {
-    const processor = createProcessor();
-    const processorAccess = processor as unknown as ProcessorPrivateAccess;
-    const originalRunImageDescriptionTaskViaApi =
-        botApi.runImageDescriptionTaskViaApi;
-    const capturedRequests: Array<{
-        task: string;
-        imageUrl: string;
-        context?: string;
-        channelContext?: { channelId?: string; guildId?: string };
-    }> = [];
-
-    processorAccess.buildRawConversationHistory = async () => [
-        { role: 'user', content: 'Jordan uploaded an image.' },
-    ];
-
-    (
-        botApi as {
-            runImageDescriptionTaskViaApi: typeof botApi.runImageDescriptionTaskViaApi;
-        }
-    ).runImageDescriptionTaskViaApi = (async (request) => {
-        capturedRequests.push(request);
-        return {
-            task: 'image_description',
-            result: {
-                description: '{"summary":"Standalone screenshot description"}',
-                model: 'gpt-4o-mini',
-                usage: {
-                    inputTokens: 10,
-                    outputTokens: 5,
-                    totalTokens: 15,
-                },
-                costs: {
-                    input: 0.0000015,
-                    output: 0.000003,
-                    total: 0.0000045,
+            client: {
+                user: {
+                    id: 'bot-1',
                 },
             },
-        };
-    }) as typeof botApi.runImageDescriptionTaskViaApi;
+            channel: {},
+            embeds: [],
+        } as never,
+        ''
+    );
 
-    try {
-        const built = await processorAccess.buildChatRequestFromMessage(
-            {
-                id: 'message-attach-2',
-                content: '   ',
-                author: { id: 'user-1', username: 'Jordan' },
-                channelId: 'channel-1',
-                guildId: 'guild-1',
-                attachments: {
-                    filter: () => ({
-                        size: 1,
-                        map: (callback: (attachment: unknown) => unknown) => [
-                            callback({
-                                id: 'attachment-1',
-                                url: 'https://example.com/screenshot.png',
-                                contentType: 'image/png',
-                            }),
-                        ],
-                    }),
-                },
-                mentions: {
-                    users: {
-                        has: () => false,
-                    },
-                },
-                client: {
-                    user: {
-                        id: 'bot-1',
-                    },
-                },
-                channel: {},
-                embeds: [],
-            } as never,
-            ''
-        );
-
-        if (!built) {
-            throw new Error('Expected chat request to be built');
-        }
-
-        assert.equal(capturedRequests.length, 1);
-        assert.equal(
-            Object.prototype.hasOwnProperty.call(
-                capturedRequests[0] ?? {},
-                'context'
-            ),
-            false
-        );
-        const joinedConversation = built.request.conversation
-            .map((entry) => entry.content)
-            .join('\n');
-        assert.match(joinedConversation, /BEGIN Image Descriptions/);
-        assert.match(joinedConversation, /Standalone screenshot description/);
-    } finally {
-        (
-            botApi as {
-                runImageDescriptionTaskViaApi: typeof botApi.runImageDescriptionTaskViaApi;
-            }
-        ).runImageDescriptionTaskViaApi = originalRunImageDescriptionTaskViaApi;
+    if (!built) {
+        throw new Error('Expected chat request to be built');
     }
+
+    assert.deepEqual(built.request.attachments, [
+        {
+            kind: 'image',
+            url: 'https://example.com/screenshot.png',
+            contentType: 'image/png',
+        },
+        {
+            kind: 'file',
+            url: 'https://example.com/spec.pdf',
+            contentType: 'application/pdf',
+        },
+    ]);
 });
 
 test('buildChatRequestFromMessage sends raw conversation without bot-side identity guard', async () => {


### PR DESCRIPTION
## Summary
- Add file_scan Context Step integration that scans image attachments via backend image-description task service
- Wire file_scan into context-step executor registry alongside weather_forecast
- Update planner to emit contextStepRequests when attachments exist
- Move attachment-grounding responsibility from Discord adapter to backend
- Expand shared chat attachment contract to support kind: 'file' in addition to kind: 'image'

## Changes
- New fileScanningContextStepExecutor.ts for fail-open attachment scanning
- Updated chatOrchestrator.ts to register file_scan in context-step registry
- Updated planner to emit contextStepRequests for attachments
- Removed Discord-side pre-injection of image description text

## Validation
- pnpm lint passed
- Build passes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for file attachments in chat alongside image attachments.
  * Implemented file scanning functionality to process attachments.

* **Documentation**
  * Clarified context integration architecture and workflow execution patterns.
  * Added file scanning documentation and implementation status.
  * Updated integration rollout progress.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->