### PR TITLE
refactor(context-integrations): finalize TrustGraph context step cutover

### DIFF
--- a/.devin/wiki.json
+++ b/.devin/wiki.json
@@ -156,7 +156,7 @@
                     "author": "Maintainer"
                 },
                 {
-                    "content": "Also define: workflow behavior presets (balanced/grounded), shared reviewed workflow shape (generate -> assess -> revise), workflow plan step (workflow-owned planner timing/lineage), applied plan state (`AppliedPlanState`), plan continuation (`PlanContinuation`), context step (injected pre-generation context), planner advisory boundary (planner suggests, backend policy decides), planner result applier (policy-application seam), terminal_action (workflow terminal outcome for ignore/react/image).",
+                    "content": "Also define: workflow behavior presets (balanced/grounded), shared reviewed workflow shape (generate -> assess -> revise), workflow plan step (workflow-owned planner timing/lineage), applied plan state (`AppliedPlanState`), plan continuation (`PlanContinuation`), context step (integration context injection before generation), planner advisory boundary (planner suggests, backend policy decides), planner result applier (policy-application seam), terminal_action (workflow terminal outcome for ignore/react/image).",
                     "author": "Maintainer"
                 }
             ]
@@ -269,7 +269,7 @@
                 },
                 {
                     "author": "Maintainer",
-                    "content": "weather_forecast is the first concrete context-step integration, executing before the generate step in reviewed workflows."
+                    "content": "Context-step integrations include weather_forecast, web_search, file_scan, and trustgraph."
                 }
             ]
         },
@@ -280,12 +280,14 @@
             "entrypoints": [
                 "docs/architecture/context-integrations/README.md",
                 "docs/architecture/context-integrations/weather-forecast.md",
+                "docs/architecture/context-integrations/trustgraph.md",
                 "docs/proposals/web-search-context-integration.md",
-                "packages/backend/src/services/contextIntegrations/toolRegistryContextStepAdapter.ts",
-                "packages/backend/src/services/openMeteoForecastTool.ts",
-                "packages/backend/src/services/tools/weatherForecastToolAdapter.ts",
-                "packages/backend/test/toolRegistryContextStepAdapter.test.ts",
-                "packages/backend/test/openMeteoForecastTool.test.ts"
+                "packages/backend/src/services/contextIntegrations/weather",
+                "packages/backend/src/services/contextIntegrations/webSearch",
+                "packages/backend/src/services/contextIntegrations/fileScanning",
+                "packages/backend/src/services/contextIntegrations/trustgraph",
+                "packages/backend/test/webSearchContextStepExecutor.test.ts",
+                "packages/backend/test/toolExecutionParity.test.ts"
             ],
             "page_notes": [
                 {
@@ -293,15 +295,15 @@
                     "author": "Maintainer"
                 },
                 {
-                    "content": "weather_forecast is implemented as a workflow context-step integration. It executes before the generate step and can inject context into the generation prompt.",
+                    "content": "weather_forecast is implemented as a workflow context-step integration and can inject context into the generation prompt.",
                     "author": "Maintainer"
                 },
                 {
-                    "content": "web_search is proposal/future work, not implemented as context-step execution yet. See the proposal for intended provider-neutral direction.",
+                    "content": "web_search is implemented as a workflow context-step integration. Keep provider protocol/tool semantics at runtime boundaries only.",
                     "author": "Maintainer"
                 },
                 {
-                    "content": "TrustGraph uses a separate evidence-ingestion seam, not the workflow context-step path. See context-integrations/trustgraph.md.",
+                    "content": "TrustGraph executes as a workflow context-step integration while keeping predicate/provenance mapping as a separate governance pass.",
                     "author": "Maintainer"
                 },
                 {
@@ -509,7 +511,7 @@
                 },
                 {
                     "author": "Maintainer",
-                    "content": "weather_forecast uses the workflow context-step path to inject context before generation in reviewed workflow runs."
+                    "content": "Chat flow uses contextStepRequests for workflow context-step execution (weather_forecast, web_search, file_scan, trustgraph where applicable)."
                 }
             ]
         },

--- a/docs/architecture/context-integrations/README.md
+++ b/docs/architecture/context-integrations/README.md
@@ -106,8 +106,9 @@ under one path.
 
 ### Workflow context-step execution
 
-`weather_forecast` and `file_scan` use the workflow context-step execution path
-for bounded-review modes (`balanced` and `grounded`). In this pattern:
+`weather_forecast`, `file_scan`, `web_search`, and `trustgraph` use the
+workflow context-step execution path for bounded-review modes (`balanced` and
+`grounded`). In this pattern:
 
 - Executes through `workflowEngine` with an injected `ContextStepExecutor`
 - Executes before the `generate` step in bounded-review workflows
@@ -118,20 +119,21 @@ for bounded-review modes (`balanced` and `grounded`). In this pattern:
 The adapter `toolRegistryContextStepAdapter.ts` implements this pattern while
 keeping the workflow engine provider-neutral.
 
-### Evidence ingestion seam
+### TrustGraph governance pass
 
-`TrustGraph` uses a separate evidence-ingestion seam. It is not implemented as
-a workflow context-step executor. In this pattern:
+`TrustGraph` executes as a workflow context step, while keeping
+its predicate-view and provenance mapping as a separate governance pass. In this
+pattern:
 
-- Flows through `chatService` evidence ingestion, not workflowEngine
-- Handles scope validation and ownership separately from workflow execution
-- Records provenance separately from workflow step records
+- Executes through `workflowEngine` as `trustgraph` context integration
+- Preserves scope validation and ownership validation inside TrustGraph ingestion
+- Surfaces bounded TrustGraph metadata/provenance after generation
 - Is documented in [trustgraph.md](./trustgraph.md)
 
 ### Tool-registry path
 
-`web_search` and other tools still use the traditional tool-registry path
-instead of workflow context-step execution.
+Provider/runtime protocol boundaries still use tool-oriented protocol semantics
+where required. Footnote orchestration remains Context Step-owned.
 
 ## Current docs
 

--- a/docs/architecture/context-integrations/trustgraph.md
+++ b/docs/architecture/context-integrations/trustgraph.md
@@ -91,8 +91,10 @@ In the current implementation:
 - `server.ts` resolves runtime options
 - the chat handler passes those options into orchestration
 - the orchestrator decides whether retrieval is even attempted
-- `chatService` calls evidence ingestion only when runtime options and a valid
-  TrustGraph context both exist
+- `chatService` injects a `trustgraph` context step when runtime options and a
+  valid TrustGraph context both exist
+- `workflowEngine` executes that context step before generation
+- `chatService` reuses context-step TrustGraph results for metadata/provenance
 
 The kill switch lives at the runtime wiring boundary. If it is on, no external
 retrieval is attempted and local behavior continues normally.
@@ -126,6 +128,9 @@ If TrustGraph influences a run, that influence should be visible afterward.
 | provenance join | what outside evidence was consumed, dropped, denied, or ignored   |
 | reason codes    | why retrieval succeeded, failed, timed out, or was denied         |
 | structured logs | machine-readable runtime detail for operators and debugging       |
+
+TrustGraph citation links are emitted only for URL-like source refs, and are
+normalized to HTTPS in the response citation surface.
 
 The current provenance join records fields such as:
 

--- a/docs/status/context-integration-architecture.md
+++ b/docs/status/context-integration-architecture.md
@@ -35,13 +35,13 @@ Before integrations can run in parallel with assess-driven cycling:
 
 ## Integration Status
 
-| Integration            | Pattern                 | Status                       |
-| ---------------------- | ----------------------- | ---------------------------- |
-| `weather_forecast`     | context-step            | Implemented                  |
-| `web_search`           | context-step            | Implemented                  |
-| `file_scan`            | context-step            | Implemented                  |
-| `trustgraph`           | evidence ingestion seam | Not migrated to context-step |
-| `reverse_image_search` | not implemented         | Not implemented              |
+| Integration            | Pattern                        | Status          |
+| ---------------------- | ------------------------------ | --------------- |
+| `weather_forecast`     | context-step                   | Implemented     |
+| `web_search`           | context-step                   | Implemented     |
+| `file_scan`            | context-step                   | Implemented     |
+| `trustgraph`           | context-step + governance pass | Implemented     |
+| `reverse_image_search` | not implemented                | Not implemented |
 
 ## Implementation Sequence
 
@@ -58,8 +58,9 @@ Before integrations can run in parallel with assess-driven cycling:
 
 **Issue #337** - TrustGraph context-step migration
 
-- Refactor to run pre-generation through workflow context-step
-- Keep predicate view mapping as separate post-generation governance pass
+- Refactor to run through workflow context-step ✅
+- Keep predicate view mapping as separate governance pass ✅
+- Full cutover: remove legacy post-generation fallback path ✅
 
 **Issue #336** - Web search context-step migration
 
@@ -69,7 +70,7 @@ Before integrations can run in parallel with assess-driven cycling:
 
 **Issue #333** - Image scanning context-step migration
 
-- Move from Discord bot layer to workflow context-step
+- Scope folded into `file_scan` integration and completed via Issue #334 ✅
 
 **Issue #334** - File attachment scanning
 
@@ -86,6 +87,11 @@ Before integrations can run in parallel with assess-driven cycling:
 
 - Remove `toolRegistryContextStepAdapter` once weather migrates to direct implementation (Issue #340 pattern)
 - Consider removing post-generation evidence ingestion paths that are no longer needed
+- Standardize Context Step short-circuit response policy via integration policy
+  registry instead of integration-specific conditionals in shared chat flow
+- Standardize integration status mapping (`executed`/`skipped`/`failed` +
+  reason-code conventions) across Context Integrations for consistent telemetry
+  and trace interpretation
 
 ## Related Work
 

--- a/packages/backend/src/services/chatOrchestrator.ts
+++ b/packages/backend/src/services/chatOrchestrator.ts
@@ -608,17 +608,8 @@ export const createChatOrchestrator = ({
                 },
                 plannerTemperament: executionPlan.generation.temperament,
                 conversationSnapshot: postPlanAssembly.conversationSnapshot,
-                ...((plannerApplication.contextStepRequests !== undefined ||
-                    plannerApplication.contextStepRequest !== undefined) && {
-                    ...(plannerApplication.contextStepRequest !== undefined && {
-                        contextStepRequest:
-                            plannerApplication.contextStepRequest,
-                    }),
-                    contextStepRequests:
-                        plannerApplication.contextStepRequests ??
-                        (plannerApplication.contextStepRequest !== undefined
-                            ? [plannerApplication.contextStepRequest]
-                            : []),
+                ...(plannerApplication.contextStepRequests !== undefined && {
+                    contextStepRequests: plannerApplication.contextStepRequests,
                 }),
                 plannerSummary: buildPlannerSummary({
                     plannerStepResult: input.plannerStepResult,

--- a/packages/backend/src/services/chatOrchestrator/plannerResultApplier.ts
+++ b/packages/backend/src/services/chatOrchestrator/plannerResultApplier.ts
@@ -131,7 +131,7 @@ export const createPlannerResultApplier = (
             inheritedToolExecution: profileResolution.toolExecutionContext,
         });
 
-        const contextStepRequest =
+        const toolContextStepRequest =
             (toolSelection.toolRequest.toolName === 'weather_forecast' ||
                 toolSelection.toolRequest.toolName === 'web_search') &&
             toolSelection.toolRequest.requested
@@ -167,7 +167,9 @@ export const createPlannerResultApplier = (
                   }
                 : undefined;
         const contextStepRequests = [
-            ...(contextStepRequest !== undefined ? [contextStepRequest] : []),
+            ...(toolContextStepRequest !== undefined
+                ? [toolContextStepRequest]
+                : []),
             ...(fileScanContextStepRequest !== undefined
                 ? [fileScanContextStepRequest]
                 : []),
@@ -209,7 +211,6 @@ export const createPlannerResultApplier = (
             }),
             toolRequestContext: toolSelection.toolRequest,
             toolExecutionContext: toolSelection.toolExecution,
-            contextStepRequest,
             ...(contextStepRequests.length > 0 && { contextStepRequests }),
             plannerApplyOutcome,
             plannerMattered,

--- a/packages/backend/src/services/chatService.ts
+++ b/packages/backend/src/services/chatService.ts
@@ -83,6 +83,21 @@ const SURFACED_NO_GENERATION_MESSAGE =
     'I could not generate a response for this request.';
 
 /**
+ * Returns context-step results in canonical order for downstream consumers.
+ *
+ * Preferred source is the multi-result field from parallel execution; when only
+ * legacy single-result shape exists, normalize it to a one-item array.
+ */
+const getEffectiveContextStepResults = (
+    workflowContextStepResults?: ContextStepResult[],
+    workflowContextStepResult?: ContextStepResult
+): ContextStepResult[] =>
+    workflowContextStepResults ??
+    (workflowContextStepResult !== undefined
+        ? [workflowContextStepResult]
+        : []);
+
+/**
  * Builds the fail-open short-circuit response surface for context-step outcomes.
  *
  * The short-circuit branch can return early when a context step asks for user
@@ -125,11 +140,10 @@ const buildContextStepShortCircuit = ({
           telemetry: FinalToolExecutionTelemetry;
       }
     | undefined => {
-    const effectiveContextStepResults =
-        workflowContextStepResults ??
-        (workflowContextStepResult !== undefined
-            ? [workflowContextStepResult]
-            : []);
+    const effectiveContextStepResults = getEffectiveContextStepResults(
+        workflowContextStepResults,
+        workflowContextStepResult
+    );
     if (effectiveContextStepResults.length === 0) {
         return undefined;
     }
@@ -492,8 +506,12 @@ const TRUSTGRAPH_CONTEXT_STEP_NAME = 'trustgraph';
  * Merges caller-owned Context Step requests with backend-owned TrustGraph
  * request injection.
  *
- * We preserve first-write precedence by integration name to avoid duplicate
- * execution in the same workflow cycle.
+ * TrustGraph is backend-owned: when buildTrustGraphContextStepRequest produces
+ * a request, we remove any upstream `trustgraph` entries before appending the
+ * backend request so backend authority wins for that integration slot.
+ *
+ * For all other integrations, deduplication is first-write-wins by
+ * integrationName to avoid duplicate execution in the same workflow cycle.
  */
 const mergeContextStepRequests = (input: {
     contextStepRequests?: ContextStepRequest[];
@@ -1151,15 +1169,13 @@ export const createChatService = ({
             );
         }
 
-        let trustGraphResult: TrustGraphEvidenceIngestionResult | undefined =
-            pickTrustGraphResultFromContextSteps(workflowContextStepResults);
-        if (trustGraphResult === undefined) {
-            trustGraphResult = pickTrustGraphResultFromContextSteps(
-                workflowContextStepResult !== undefined
-                    ? [workflowContextStepResult]
-                    : undefined
-            );
-        }
+        const effectiveContextStepResults = getEffectiveContextStepResults(
+            workflowContextStepResults,
+            workflowContextStepResult
+        );
+        const trustGraphResult = pickTrustGraphResultFromContextSteps(
+            effectiveContextStepResults
+        );
         // Full TrustGraph cutover: advisory evidence ingestion now flows
         // exclusively through Context Step execution.
         if (trustGraphResult !== undefined) {

--- a/packages/backend/src/services/chatService.ts
+++ b/packages/backend/src/services/chatService.ts
@@ -14,6 +14,8 @@ import type {
 } from '@footnote/agent-runtime';
 import type {
     Citation,
+    ContextStepRequest,
+    ContextStepResult,
     PartialResponseTemperament,
     ResponseMetadata,
     SafetyTier,
@@ -49,11 +51,10 @@ import {
 import {
     runBoundedReviewWorkflow,
     type ContextStepExecutor,
-    type ContextStepRequest,
-    type ContextStepResult,
     type RunBoundedReviewWorkflowResult,
     type WorkflowPolicy,
 } from './workflowEngine.js';
+import { createTrustGraphContextStepExecutor } from './contextIntegrations/trustgraph/index.js';
 import {
     planTerminalActionToResponse,
     type PlanContinuationOutcome,
@@ -65,7 +66,6 @@ import type {
     PlannerStepRequest,
     PlannerStepResult,
 } from './plannerWorkflowSeams.js';
-import { runEvidenceIngestion } from './executionContractTrustGraph/trustGraphEvidenceIngestion.js';
 import type {
     ScopeTuple,
     TrustGraphEvidenceAdapter,
@@ -88,9 +88,8 @@ const SURFACED_NO_GENERATION_MESSAGE =
  * The short-circuit branch can return early when a context step asks for user
  * clarification or reports a known tool failure pattern.
  *
- * Compatibility rule: this branch prefers the full context-step result list
- * when available, and falls back to the legacy single-result field for older
- * callers.
+ * This branch consumes the full context-step result list when available and
+ * falls back to single-result shape when only that field is present.
  *
  * Citation rule: when generation continues, citations from all executed context
  * integrations are merged later into assistant metadata. This helper does not
@@ -487,6 +486,94 @@ const logTrustGraphRuntimeOutcome = (
     logger.info(logPayload);
 };
 
+const TRUSTGRAPH_CONTEXT_STEP_NAME = 'trustgraph';
+
+/**
+ * Merges caller-owned Context Step requests with backend-owned TrustGraph
+ * request injection.
+ *
+ * We preserve first-write precedence by integration name to avoid duplicate
+ * execution in the same workflow cycle.
+ */
+const mergeContextStepRequests = (input: {
+    contextStepRequests?: ContextStepRequest[];
+    trustGraphContextStepRequest?: ContextStepRequest;
+}): ContextStepRequest[] => {
+    const merged = [...(input.contextStepRequests ?? [])];
+    if (input.trustGraphContextStepRequest !== undefined) {
+        // Backend-authored TrustGraph scope must remain authoritative.
+        // Remove any upstream trustgraph request before appending ours.
+        for (let i = merged.length - 1; i >= 0; i -= 1) {
+            if (merged[i]?.integrationName === TRUSTGRAPH_CONTEXT_STEP_NAME) {
+                merged.splice(i, 1);
+            }
+        }
+        merged.push(input.trustGraphContextStepRequest);
+    }
+    const seen = new Set<string>();
+    const deduped: ContextStepRequest[] = [];
+    for (const request of merged) {
+        if (seen.has(request.integrationName)) {
+            continue;
+        }
+        seen.add(request.integrationName);
+        deduped.push(request);
+    }
+    return deduped;
+};
+
+/**
+ * Builds the backend-owned TrustGraph Context Step request from normalized
+ * execution-contract context.
+ */
+const buildTrustGraphContextStepRequest = (
+    executionContractTrustGraphContext:
+        | ExecutionContractTrustGraphContext
+        | undefined
+): ContextStepRequest | undefined => {
+    if (executionContractTrustGraphContext === undefined) {
+        return undefined;
+    }
+    return {
+        integrationName: TRUSTGRAPH_CONTEXT_STEP_NAME,
+        requested: true,
+        eligible: true,
+        input: {
+            queryIntent: executionContractTrustGraphContext.queryIntent,
+            scopeTuple: executionContractTrustGraphContext.scopeTuple,
+        },
+    };
+};
+
+/**
+ * Reads TrustGraph ingestion output captured by Context Step execution.
+ *
+ * `integrationContext` is intentionally generic at workflow boundaries.
+ * This helper is the single cast point that projects TrustGraph payloads into
+ * typed runtime metadata handling.
+ */
+const pickTrustGraphResultFromContextSteps = (
+    contextStepResults: ContextStepResult[] | undefined
+): TrustGraphEvidenceIngestionResult | undefined => {
+    const trustGraphStep = contextStepResults?.find(
+        (result) =>
+            result.executionContext.toolName === TRUSTGRAPH_CONTEXT_STEP_NAME
+    );
+    const integrationContext = trustGraphStep?.integrationContext;
+    if (
+        integrationContext === undefined ||
+        integrationContext.kind !== TRUSTGRAPH_CONTEXT_STEP_NAME
+    ) {
+        return undefined;
+    }
+    const payload = integrationContext.payload as Record<string, unknown>;
+    const trustGraphResult = payload.trustGraphResult;
+    if (trustGraphResult === undefined || trustGraphResult === null) {
+        return undefined;
+    }
+    return trustGraphResult as TrustGraphEvidenceIngestionResult;
+};
+
 /**
  * Dependencies for the shared chat workflow.
  * The HTTP handler injects these so the core logic stays transport-agnostic.
@@ -541,7 +628,6 @@ export type RunChatMessagesInput = {
     workflowModeId?: string;
     workflowModeEscalationRequest?: WorkflowModeEscalationRequest;
     toolRequest?: ToolInvocationRequest;
-    contextStepRequest?: ContextStepRequest;
     contextStepRequests?: ContextStepRequest[];
     contextStepExecutor?: ContextStepExecutor;
     contextStepExecutorRegistry?: Record<string, ContextStepExecutor>;
@@ -703,7 +789,6 @@ export const createChatService = ({
         workflowModeId,
         workflowModeEscalationRequest,
         toolRequest,
-        contextStepRequest,
         contextStepRequests,
         contextStepExecutor,
         contextStepExecutorRegistry,
@@ -810,6 +895,14 @@ export const createChatService = ({
         const effectivePlannerStepExecutor = plannerStepExecutor;
         if (workflowExecutionEnabled) {
             const workflowPolicy: WorkflowPolicy = workflowProfile.policy;
+            const trustGraphContextStepRequest =
+                buildTrustGraphContextStepRequest(
+                    executionContractTrustGraphContext
+                );
+            const effectiveContextStepRequests = mergeContextStepRequests({
+                contextStepRequests,
+                trustGraphContextStepRequest,
+            });
             const workflowResult = await runReviewWorkflow({
                 generationRuntime,
                 generationRequest: effectiveGenerationRequest,
@@ -842,10 +935,20 @@ export const createChatService = ({
                 plannerStepRequest: effectivePlannerStepRequest,
                 plannerStepExecutor: effectivePlannerStepExecutor,
                 planContinuationBuilder,
-                contextStepRequest,
-                contextStepRequests,
+                contextStepRequests:
+                    effectiveContextStepRequests.length > 0
+                        ? effectiveContextStepRequests
+                        : undefined,
                 contextStepExecutor,
-                contextStepExecutorRegistry,
+                contextStepExecutorRegistry: {
+                    ...(contextStepExecutorRegistry ?? {}),
+                    [TRUSTGRAPH_CONTEXT_STEP_NAME]:
+                        createTrustGraphContextStepExecutor({
+                            runtimeOptions: executionContractTrustGraph,
+                            onWarn: (message, meta) =>
+                                logger.warn(message, meta),
+                        }),
+                },
             });
             workflowPlannerStepResult = workflowResult.plannerStepResult;
             workflowPlannerSummary =
@@ -1048,36 +1151,17 @@ export const createChatService = ({
             );
         }
 
-        let trustGraphResult: TrustGraphEvidenceIngestionResult | undefined;
-        if (
-            executionContractTrustGraph !== undefined &&
-            executionContractTrustGraphContext !== undefined
-        ) {
-            try {
-                trustGraphResult = await runEvidenceIngestion({
-                    queryIntent: executionContractTrustGraphContext.queryIntent,
-                    scopeTuple: executionContractTrustGraphContext.scopeTuple,
-                    budget: executionContractTrustGraph.budget,
-                    ownershipValidationPolicy:
-                        executionContractTrustGraph.ownershipValidationPolicy,
-                    scopeOwnershipValidator:
-                        executionContractTrustGraph.scopeOwnershipValidator,
-                    scopeValidationPolicy:
-                        executionContractTrustGraph.scopeValidationPolicy,
-                    adapter: executionContractTrustGraph.adapter,
-                });
-            } catch (error) {
-                logger.warn(
-                    'Execution Contract TrustGraph ingestion failed open in chat runtime.',
-                    {
-                        error:
-                            error instanceof Error
-                                ? error.message
-                                : String(error),
-                    }
-                );
-            }
+        let trustGraphResult: TrustGraphEvidenceIngestionResult | undefined =
+            pickTrustGraphResultFromContextSteps(workflowContextStepResults);
+        if (trustGraphResult === undefined) {
+            trustGraphResult = pickTrustGraphResultFromContextSteps(
+                workflowContextStepResult !== undefined
+                    ? [workflowContextStepResult]
+                    : undefined
+            );
         }
+        // Full TrustGraph cutover: advisory evidence ingestion now flows
+        // exclusively through Context Step execution.
         if (trustGraphResult !== undefined) {
             logTrustGraphRuntimeOutcome(trustGraphResult, ExecutionContract);
         }

--- a/packages/backend/src/services/contextIntegrations/trustgraph/index.ts
+++ b/packages/backend/src/services/contextIntegrations/trustgraph/index.ts
@@ -1,0 +1,9 @@
+/**
+ * @description: TrustGraph context integration entry point.
+ * @footnote-scope: core
+ * @footnote-module: TrustGraphContextIntegration
+ * @footnote-risk: low - Re-exports only.
+ * @footnote-ethics: medium - Re-exports only.
+ */
+export { createTrustGraphContextStepExecutor } from './trustGraphContextStepExecutor.js';
+export type { TrustGraphContextStepRuntimeOptions } from './trustGraphContextStepExecutor.js';

--- a/packages/backend/src/services/contextIntegrations/trustgraph/trustGraphContextStepExecutor.ts
+++ b/packages/backend/src/services/contextIntegrations/trustgraph/trustGraphContextStepExecutor.ts
@@ -1,0 +1,241 @@
+/**
+ * @description: Executes TrustGraph as a workflow context step before generation.
+ * @footnote-scope: core
+ * @footnote-module: TrustGraphContextStepExecutor
+ * @footnote-risk: medium - Incorrect parsing or mapping can degrade advisory evidence visibility.
+ * @footnote-ethics: high - TrustGraph evidence signals can influence response framing and reviewer oversight.
+ */
+import type { Citation } from '@footnote/contracts/ethics-core';
+import { runEvidenceIngestion } from '../../executionContractTrustGraph/trustGraphEvidenceIngestion.js';
+import type {
+    ScopeTuple,
+    TrustGraphEvidenceAdapter,
+    TrustGraphEvidenceIngestionResult,
+    TrustGraphOwnershipValidationPolicy,
+    ScopeOwnershipValidator,
+} from '../../executionContractTrustGraph/trustGraphEvidenceTypes.js';
+import type { ScopeValidationPolicy } from '../../executionContractTrustGraph/scopeValidator.js';
+import type {
+    ContextStepExecutor,
+    ContextStepResult,
+} from '../../workflowEngine.js';
+
+type TrustGraphContextStepInput = {
+    queryIntent: unknown;
+    scopeTuple: unknown;
+};
+
+export type TrustGraphContextStepRuntimeOptions = {
+    adapter?: TrustGraphEvidenceAdapter;
+    budget: {
+        timeoutMs: number;
+        maxCalls: number;
+    };
+    ownershipValidationPolicy: TrustGraphOwnershipValidationPolicy;
+    scopeOwnershipValidator?: ScopeOwnershipValidator;
+    scopeValidationPolicy?: Partial<
+        Pick<
+            ScopeValidationPolicy,
+            | 'requireProjectOrCollection'
+            | 'allowProjectAndCollectionTogether'
+            | 'ownershipValidationTimeoutMs'
+        >
+    >;
+};
+
+const parseTrustGraphContextStepInput = (
+    input: unknown
+): TrustGraphContextStepInput | undefined => {
+    if (input === null || typeof input !== 'object') {
+        return undefined;
+    }
+    const record = input as Record<string, unknown>;
+    return {
+        queryIntent: record.queryIntent,
+        scopeTuple: record.scopeTuple,
+    };
+};
+
+/**
+ * Runtime guard for ScopeTuple.
+ *
+ * TrustGraph scope validation is high-impact: if we pass malformed scope data,
+ * ownership checks can degrade silently. Keep this guard strict and fail-open
+ * by returning skipped context-step execution when parsing fails.
+ */
+const isScopeTuple = (input: unknown): input is ScopeTuple => {
+    if (input === null || typeof input !== 'object') {
+        return false;
+    }
+    const tuple = input as Record<string, unknown>;
+    if (typeof tuple.userId !== 'string' || tuple.userId.trim().length === 0) {
+        return false;
+    }
+    if (
+        tuple.projectId !== undefined &&
+        (typeof tuple.projectId !== 'string' ||
+            tuple.projectId.trim().length === 0)
+    ) {
+        return false;
+    }
+    if (
+        tuple.collectionId !== undefined &&
+        (typeof tuple.collectionId !== 'string' ||
+            tuple.collectionId.trim().length === 0)
+    ) {
+        return false;
+    }
+    return true;
+};
+
+/**
+ * Normalizes citation URLs to HTTPS policy.
+ *
+ * TrustGraph source refs may be canonical URLs or opaque refs. Opaque refs are
+ * projected to a stable HTTPS endpoint so trace/citation surfaces do not emit
+ * non-HTTP schemes.
+ */
+function resolveTrustGraphCitationUrl(sourceRef: string): string | undefined {
+    const normalized = sourceRef.trim();
+    if (/^https?:\/\//i.test(normalized)) {
+        return normalized.replace(/^http:\/\//i, 'https://');
+    }
+    return undefined;
+}
+
+/**
+ * Maps TrustGraph evidence refs into shared Citation[] shape.
+ *
+ * We only emit citations when adapter status is `success`; denied/timeout/error
+ * cases are represented via execution/provenance metadata instead.
+ */
+const buildCitations = (
+    result: TrustGraphEvidenceIngestionResult
+): Citation[] | undefined => {
+    if (result.adapterStatus !== 'success') {
+        return undefined;
+    }
+    const refs = result.predicateViews.P_EVID.sourceRefs;
+    if (refs.length === 0) {
+        return undefined;
+    }
+    return refs
+        .map((ref) => ({
+            ref,
+            url: resolveTrustGraphCitationUrl(ref),
+        }))
+        .filter(
+            (
+                entry
+            ): entry is {
+                ref: string;
+                url: string;
+            } => entry.url !== undefined
+        )
+        .map((entry) => ({
+            title: 'TrustGraph evidence',
+            url: entry.url,
+            snippet: entry.ref,
+        }));
+};
+
+export const createTrustGraphContextStepExecutor = ({
+    runtimeOptions,
+    onWarn,
+}: {
+    runtimeOptions?: TrustGraphContextStepRuntimeOptions;
+    onWarn?: (message: string, meta?: Record<string, unknown>) => void;
+}): ContextStepExecutor => {
+    const warn = onWarn ?? (() => undefined);
+
+    /**
+     * Context Step executor for TrustGraph.
+     *
+     * Fail-open guarantees:
+     * - malformed input => skipped
+     * - runtime failure => failed + reasonCode, generation continues
+     *
+     * Governance guarantees:
+     * - raw TrustGraph output is retained in integrationContext for backend
+     *   metadata/provenance mapping, not exposed directly to callers.
+     */
+    return async ({ request }): Promise<ContextStepResult> => {
+        if (runtimeOptions === undefined) {
+            return {
+                executionContext: {
+                    toolName: request.integrationName,
+                    status: 'skipped',
+                    reasonCode: 'tool_unavailable',
+                },
+            };
+        }
+        const parsed = parseTrustGraphContextStepInput(request.input);
+        if (
+            parsed === undefined ||
+            typeof parsed.queryIntent !== 'string' ||
+            parsed.queryIntent.trim().length === 0 ||
+            !isScopeTuple(parsed.scopeTuple)
+        ) {
+            return {
+                executionContext: {
+                    toolName: request.integrationName,
+                    status: 'skipped',
+                    reasonCode: 'tool_not_requested',
+                },
+            };
+        }
+        try {
+            const trustGraphResult = await runEvidenceIngestion({
+                queryIntent: parsed.queryIntent,
+                scopeTuple: parsed.scopeTuple,
+                budget: runtimeOptions.budget,
+                ownershipValidationPolicy:
+                    runtimeOptions.ownershipValidationPolicy,
+                scopeOwnershipValidator: runtimeOptions.scopeOwnershipValidator,
+                scopeValidationPolicy: runtimeOptions.scopeValidationPolicy,
+                adapter: runtimeOptions.adapter,
+            });
+            return {
+                executionContext: {
+                    toolName: request.integrationName,
+                    // Adapter `error` is treated as failed execution.
+                    // Other governance outcomes (for example scope_denied) stay
+                    // executed so provenance can report bounded outcomes.
+                    status:
+                        trustGraphResult.adapterStatus === 'error'
+                            ? 'failed'
+                            : 'executed',
+                    reasonCode:
+                        trustGraphResult.adapterStatus === 'timeout'
+                            ? 'tool_timeout'
+                            : trustGraphResult.adapterStatus === 'error'
+                              ? 'tool_execution_error'
+                              : undefined,
+                },
+                sources: buildCitations(trustGraphResult),
+                integrationContext: {
+                    kind: 'trustgraph',
+                    version: 'v1',
+                    payload: {
+                        trustGraphResult,
+                    },
+                },
+            };
+        } catch (error) {
+            warn(
+                'TrustGraph context step failed open; continuing without advisory context.',
+                {
+                    error:
+                        error instanceof Error ? error.message : String(error),
+                }
+            );
+            return {
+                executionContext: {
+                    toolName: request.integrationName,
+                    status: 'failed',
+                    reasonCode: 'tool_execution_error',
+                },
+            };
+        }
+    };
+};

--- a/packages/backend/src/services/contextIntegrations/trustgraph/trustGraphContextStepExecutor.ts
+++ b/packages/backend/src/services/contextIntegrations/trustgraph/trustGraphContextStepExecutor.ts
@@ -198,11 +198,12 @@ export const createTrustGraphContextStepExecutor = ({
             return {
                 executionContext: {
                     toolName: request.integrationName,
-                    // Adapter `error` is treated as failed execution.
+                    // Adapter `error` and `timeout` are treated as failed execution.
                     // Other governance outcomes (for example scope_denied) stay
                     // executed so provenance can report bounded outcomes.
                     status:
-                        trustGraphResult.adapterStatus === 'error'
+                        trustGraphResult.adapterStatus === 'error' ||
+                        trustGraphResult.adapterStatus === 'timeout'
                             ? 'failed'
                             : 'executed',
                     reasonCode:

--- a/packages/backend/src/services/plannerWorkflowSeams.ts
+++ b/packages/backend/src/services/plannerWorkflowSeams.ts
@@ -25,6 +25,7 @@ import type {
     GenerationRequest,
     RuntimeMessage,
 } from '@footnote/agent-runtime';
+import type { ContextStepRequest } from '@footnote/contracts/ethics-core';
 import type { PartialResponseTemperament } from '@footnote/contracts/ethics-core';
 import type {
     ChatPlan,
@@ -35,7 +36,6 @@ import type { ChatPlannerInvocationContext } from './chatPlannerInvocation.js';
 import type { ChatGenerationPlan } from './chatGenerationTypes.js';
 import type { ChatSurfacePolicyCoercion } from './chatSurfacePolicy.js';
 import type { CapabilityProfileId } from './modelCapabilityPolicy.js';
-import type { ContextStepRequest } from './workflowEngine.js';
 
 /** Workflow engine sends this to PlannerStepExecutor for the plan step. */
 export type PlannerStepRequest = {
@@ -113,7 +113,6 @@ export type PlannerApplicationResult = {
     capabilityReasonCode?: string;
     toolRequestContext: ToolInvocationRequest;
     toolExecutionContext?: ToolExecutionContext;
-    contextStepRequest?: ContextStepRequest;
     contextStepRequests?: ContextStepRequest[];
     plannerApplyOutcome: PlannerExecutionApplyOutcome;
     plannerMattered: boolean;
@@ -183,9 +182,7 @@ export type PlanContinuation = {
           generationRequest: GenerationRequest;
           plannerTemperament?: PartialResponseTemperament;
           conversationSnapshot: string;
-          // Backward-compatible single integration field for existing callers.
-          contextStepRequest?: ContextStepRequest;
-          // Preferred multi-integration field consumed by parallel context-step execution.
+          // Multi-integration field consumed by parallel context-step execution.
           contextStepRequests?: ContextStepRequest[];
       }
 );

--- a/packages/backend/src/services/plannerWorkflowSeams.ts
+++ b/packages/backend/src/services/plannerWorkflowSeams.ts
@@ -7,14 +7,16 @@
  * @footnote-ethics: high - Clear seam ownership preserves planner-advisory boundaries and policy authority.
  */
 import type {
+    ContextStepRequest,
     ExecutionReasonCode,
     ExecutionStatus,
+    PartialResponseTemperament,
     PlannerExecutionApplyOutcome,
     PlannerExecutionContractType,
     PlannerExecutionPurpose,
+    SteerabilityControlId,
     ToolExecutionContext,
     ToolInvocationRequest,
-    SteerabilityControlId,
 } from '@footnote/contracts/ethics-core';
 import type { ModelProfile } from '@footnote/contracts';
 import type {
@@ -25,8 +27,6 @@ import type {
     GenerationRequest,
     RuntimeMessage,
 } from '@footnote/agent-runtime';
-import type { ContextStepRequest } from '@footnote/contracts/ethics-core';
-import type { PartialResponseTemperament } from '@footnote/contracts/ethics-core';
 import type {
     ChatPlan,
     ChatPlannerCapabilityProfileOption,

--- a/packages/backend/src/services/workflowEngine.ts
+++ b/packages/backend/src/services/workflowEngine.ts
@@ -9,11 +9,10 @@ import type { WorkflowStepKind } from '@footnote/contracts/ethics-core';
 import type { WorkflowTerminationReason } from '@footnote/contracts/ethics-core';
 import type {
     BoundedReviewAssessSignals,
-    Citation,
+    ContextStepRequest as ContractContextStepRequest,
+    ContextStepResult as ContractContextStepResult,
     ExecutionStatus,
-    ToolClarification,
     ToolExecutionContext,
-    ToolInvocationReasonCode,
     PlannerExecutionApplyOutcome,
     PlannerExecutionContractType,
     PlannerExecutionPurpose,
@@ -172,11 +171,8 @@ export type RunBoundedReviewWorkflowInput = {
     plannerStepExecutor?: PlannerStepExecutor;
     // Caller-owned policy application. Engine only consumes continuation output.
     planContinuationBuilder?: PlanContinuationBuilder;
-    // Backward-compatible single integration input used by current callers.
-    contextStepRequest?: ContextStepRequest;
-    // Preferred multi-integration input. Engine executes eligible steps in parallel.
+    // Multi-integration input. Engine executes eligible steps in parallel.
     contextStepRequests?: ContextStepRequest[];
-    // Backward-compatible default executor for single-integration callers.
     contextStepExecutor?: ContextStepExecutor;
     // Preferred executor routing by integration name.
     contextStepExecutorRegistry?: Record<string, ContextStepExecutor>;
@@ -210,20 +206,9 @@ export type RunBoundedReviewWorkflowResult =
           contextStepResults?: ContextStepResult[];
       };
 
-export type ContextStepRequest = {
-    integrationName: string;
-    requested: boolean;
-    eligible: boolean;
-    reasonCode?: ToolInvocationReasonCode;
-    input?: Record<string, unknown>;
-};
+export type ContextStepRequest = ContractContextStepRequest;
 
-export type ContextStepResult = {
-    executionContext: ToolExecutionContext;
-    contextMessages?: string[];
-    clarification?: ToolClarification;
-    sources?: Citation[];
-};
+export type ContextStepResult = ContractContextStepResult;
 
 export type ContextStepExecutorInput = {
     request: ContextStepRequest;
@@ -735,7 +720,6 @@ export const runBoundedReviewWorkflow = async ({
     plannerStepRequest,
     plannerStepExecutor,
     planContinuationBuilder,
-    contextStepRequest,
     contextStepRequests,
     contextStepExecutor,
     contextStepExecutorRegistry,
@@ -794,7 +778,6 @@ export const runBoundedReviewWorkflow = async ({
     let messagesWithContext = messagesWithHints;
     let effectiveGenerationRequest = generationRequest;
     let effectiveMessagesWithHints = messagesWithHints;
-    let effectiveContextStepRequest = contextStepRequest;
     let effectiveContextStepRequests = contextStepRequests;
     let workflowTerminalAction: PlanTerminalAction | undefined;
     let planContinuation: PlanContinuation | undefined;
@@ -1036,9 +1019,6 @@ export const runBoundedReviewWorkflow = async ({
             } else {
                 effectiveGenerationRequest = planContinuation.generationRequest;
                 effectiveMessagesWithHints = planContinuation.messagesWithHints;
-                effectiveContextStepRequest =
-                    planContinuation.contextStepRequest ??
-                    effectiveContextStepRequest;
                 effectiveContextStepRequests =
                     planContinuation.contextStepRequests ??
                     effectiveContextStepRequests;
@@ -1128,8 +1108,8 @@ export const runBoundedReviewWorkflow = async ({
 
     /**
      * Resolve executor authority per context integration.
-     * Registry mapping is authoritative. Fallback executor preserves existing
-     * single-step call sites while migration to registry is in progress.
+     * Registry mapping is authoritative. Fallback executor is used only when
+     * no integration-specific executor is registered.
      */
     const selectContextStepExecutor = (
         request: ContextStepRequest
@@ -1141,12 +1121,9 @@ export const runBoundedReviewWorkflow = async ({
         }
         return contextStepExecutor;
     };
-    const requestedContextSteps = (
-        effectiveContextStepRequests ??
-        (effectiveContextStepRequest !== undefined
-            ? [effectiveContextStepRequest]
-            : [])
-    ).filter((request) => request.requested === true && request.eligible);
+    const requestedContextSteps = (effectiveContextStepRequests ?? []).filter(
+        (request) => request.requested === true && request.eligible
+    );
     const executableContextSteps = requestedContextSteps.filter(
         (request) => selectContextStepExecutor(request) !== undefined
     );
@@ -1295,6 +1272,11 @@ export const runBoundedReviewWorkflow = async ({
                     }),
                     ...(contextStepOutcome.result.sources !== undefined && {
                         sources: contextStepOutcome.result.sources,
+                    }),
+                    ...(contextStepOutcome.result.integrationContext !==
+                        undefined && {
+                        integrationContext:
+                            contextStepOutcome.result.integrationContext,
                     }),
                 };
                 executedContextStepResults.push(normalizedResult);

--- a/packages/backend/test/plannerResultApplier.test.ts
+++ b/packages/backend/test/plannerResultApplier.test.ts
@@ -166,7 +166,7 @@ test('PlannerResultApplier enforces single-tool policy and derives weather conte
     assert.equal(output.toolRequestContext.toolName, 'weather_forecast');
     assert.equal(output.toolRequestContext.requested, true);
     assert.equal(
-        output.contextStepRequest?.integrationName,
+        output.contextStepRequests?.[0]?.integrationName,
         'weather_forecast'
     );
     assert.deepEqual(output.generationForExecution.search, {

--- a/packages/backend/test/toolExecutionParity.test.ts
+++ b/packages/backend/test/toolExecutionParity.test.ts
@@ -82,18 +82,20 @@ test('weather success flows through workflow context-step: tool step recorded in
             enableAssessment: true,
             enableRevision: true,
         },
-        contextStepRequest: {
-            integrationName: 'weather_forecast',
-            requested: true,
-            eligible: true,
-            input: {
-                location: {
-                    type: 'lat_lon',
-                    latitude: 39.7684,
-                    longitude: -86.1581,
+        contextStepRequests: [
+            {
+                integrationName: 'weather_forecast',
+                requested: true,
+                eligible: true,
+                input: {
+                    location: {
+                        type: 'lat_lon',
+                        latitude: 39.7684,
+                        longitude: -86.1581,
+                    },
                 },
             },
-        },
+        ],
         contextStepExecutor: async ({ request }) => {
             const execution = await weatherForecastTool.fetchForecast(
                 request.input as {
@@ -190,12 +192,14 @@ test('weather failure preserves fail-open: generation runs, tool step recorded a
             enableAssessment: true,
             enableRevision: true,
         },
-        contextStepRequest: {
-            integrationName: 'weather_forecast',
-            requested: true,
-            eligible: true,
-            input: { location: 'Indianapolis' },
-        },
+        contextStepRequests: [
+            {
+                integrationName: 'weather_forecast',
+                requested: true,
+                eligible: true,
+                input: { location: 'Indianapolis' },
+            },
+        ],
         contextStepExecutor: async () => {
             try {
                 await weatherForecastTool.fetchForecast({
@@ -293,12 +297,14 @@ test('weather clarification short-circuits: no generation, clarification respons
             enableAssessment: true,
             enableRevision: true,
         },
-        contextStepRequest: {
-            integrationName: 'weather_forecast',
-            requested: true,
-            eligible: true,
-            input: { location: 'New York' },
-        },
+        contextStepRequests: [
+            {
+                integrationName: 'weather_forecast',
+                requested: true,
+                eligible: true,
+                input: { location: 'New York' },
+            },
+        ],
         contextStepExecutor: async () => ({
             executionContext: {
                 toolName: 'weather_forecast',

--- a/packages/backend/test/workflowEngine.test.ts
+++ b/packages/backend/test/workflowEngine.test.ts
@@ -1312,12 +1312,14 @@ test('runBoundedReviewWorkflow executes injected context step and records contex
             enableAssessment: true,
             enableRevision: true,
         },
-        contextStepRequest: {
-            integrationName: 'weather_forecast',
-            requested: true,
-            eligible: true,
-            input: { location: 'Indianapolis' },
-        },
+        contextStepRequests: [
+            {
+                integrationName: 'weather_forecast',
+                requested: true,
+                eligible: true,
+                input: { location: 'Indianapolis' },
+            },
+        ],
         contextStepExecutor: async () => ({
             executionContext: {
                 toolName: 'weather_forecast',
@@ -1500,12 +1502,14 @@ test('runBoundedReviewWorkflow records failed injected context step with reason 
             enableAssessment: true,
             enableRevision: true,
         },
-        contextStepRequest: {
-            integrationName: 'weather_forecast',
-            requested: true,
-            eligible: true,
-            input: { location: 'Indianapolis' },
-        },
+        contextStepRequests: [
+            {
+                integrationName: 'weather_forecast',
+                requested: true,
+                eligible: true,
+                input: { location: 'Indianapolis' },
+            },
+        ],
         contextStepExecutor: async () => ({
             executionContext: {
                 toolName: 'weather_forecast',
@@ -1577,12 +1581,14 @@ test('runBoundedReviewWorkflow stops before generation when injected context ste
             enableAssessment: true,
             enableRevision: true,
         },
-        contextStepRequest: {
-            integrationName: 'weather_forecast',
-            requested: true,
-            eligible: true,
-            input: { location: 'Springfield' },
-        },
+        contextStepRequests: [
+            {
+                integrationName: 'weather_forecast',
+                requested: true,
+                eligible: true,
+                input: { location: 'Springfield' },
+            },
+        ],
         contextStepExecutor: async () => ({
             executionContext: {
                 toolName: 'weather_forecast',

--- a/packages/contracts/src/ethics-core/index.ts
+++ b/packages/contracts/src/ethics-core/index.ts
@@ -34,6 +34,10 @@ export type {
     ToolInvocationIntent,
     ToolInvocationRequest,
     ToolExecutionContext,
+    ContextIntegrationName,
+    ContextStepRequest,
+    ContextStepIntegrationContext,
+    ContextStepResult,
     ToolClarification,
     ToolClarificationOption,
     CorrelationEnvelope,
@@ -108,6 +112,7 @@ export {
     PROVIDER_PREFERENCE_OUTCOME_STATES,
     TOOL_ALLOWANCE_STATES,
     GROUNDING_EVIDENCE_STATUSES,
+    CONTEXT_INTEGRATION_NAMES,
 } from './types.js';
 export { formatExecutionTimelineSummary } from './executionFormatting.js';
 export { deriveReviewRuntimeSummary } from './reviewRuntime.js';

--- a/packages/contracts/src/ethics-core/types.ts
+++ b/packages/contracts/src/ethics-core/types.ts
@@ -745,6 +745,52 @@ export type ToolExecutionContext = {
 };
 
 /**
+ * Context Step request envelope.
+ *
+ * Each integration receives provider-neutral input plus explicit
+ * requested/eligible state.
+ */
+export type ContextStepRequest = {
+    integrationName: ContextIntegrationName;
+    requested: boolean;
+    eligible: boolean;
+    reasonCode?: ToolInvocationReasonCode;
+    input?: Record<string, unknown>;
+};
+
+export const CONTEXT_INTEGRATION_NAMES = [
+    'weather_forecast',
+    'web_search',
+    'file_scan',
+    'trustgraph',
+    'reverse_image_search',
+] as const;
+
+export type ContextIntegrationName =
+    | (typeof CONTEXT_INTEGRATION_NAMES)[number]
+    | (string & {});
+
+export type ContextStepIntegrationContext = {
+    kind: ContextIntegrationName;
+    version: 'v1';
+    payload: unknown;
+};
+
+/**
+ * Context Step result envelope.
+ *
+ * `integrationContext` stays serializable and integration-scoped. Callers
+ * should narrow by `kind` before consuming payload fields.
+ */
+export type ContextStepResult = {
+    executionContext: ToolExecutionContext;
+    contextMessages?: string[];
+    clarification?: ToolClarification;
+    sources?: Citation[];
+    integrationContext?: ContextStepIntegrationContext;
+};
+
+/**
  * One backend-owned execution timeline entry for this response.
  *
  * This v1 shape is intentionally compact and is expected to grow once

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -25,6 +25,10 @@ export type {
     ToolInvocationIntent,
     ToolInvocationRequest,
     ToolExecutionContext,
+    ContextIntegrationName,
+    ContextStepRequest,
+    ContextStepIntegrationContext,
+    ContextStepResult,
     CorrelationEnvelope,
     EvaluatorAuthorityLevel,
     EvaluatorDecisionMode,
@@ -55,6 +59,7 @@ export {
 export {
     SAFETY_RULE_METADATA,
     type SafetyRuleMetadata,
+    CONTEXT_INTEGRATION_NAMES,
 } from './ethics-core/index.js';
 
 // Web API contracts (request/response envelopes)

--- a/packages/web/src/pages/TracePage.tsx
+++ b/packages/web/src/pages/TracePage.tsx
@@ -737,11 +737,6 @@ const TracePage = (): JSX.Element => {
             explanation: workflowSummary.explanation,
         },
     ];
-    const hasWorkflowPlanStep =
-        traceData.workflow?.steps.some((step) => step.stepKind === 'plan') ??
-        false;
-    const showDataCaveats = !hasWorkflowPlanStep || !traceData.trustGraph;
-
     return (
         <section className="site-section">
             <header className="site-header" aria-live="polite">
@@ -1000,32 +995,6 @@ const TracePage = (): JSX.Element => {
                     </pre>
                 </details>
             </article>
-
-            {showDataCaveats && (
-                <article className="card" aria-label="Data caveats">
-                    <h2>Data Caveats</h2>
-                    <dl>
-                        {!hasWorkflowPlanStep && (
-                            <div>
-                                <dt>Planner lineage</dt>
-                                <dd>
-                                    Planner steps appear only when real `plan`
-                                    steps exist in workflow metadata.
-                                </dd>
-                            </div>
-                        )}
-                        {!traceData.trustGraph && (
-                            <div>
-                                <dt>TrustGraph signals</dt>
-                                <dd>
-                                    TrustGraph evidence appears only when this
-                                    trace includes TrustGraph metadata.
-                                </dd>
-                            </div>
-                        )}
-                    </dl>
-                </article>
-            )}
         </section>
     );
 };


### PR DESCRIPTION
## Summary
- Completes TrustGraph Context Integration cutover to the Context Step pipeline.
- Removes remaining legacy request/fallback paths and aligns orchestration with Context Step request contracts.
- Hoists shared TrustGraph Context Step types into `packages/contracts` for cross-package reuse.
- Refreshes architecture/status/wiki docs to match runtime behavior and terminology.
- If TrustGraph data is unavailable, execution remains fail-open and proceeds without injecting TrustGraph context.