### PR TITLE
Fix Discord attachment grounding and reverse-image context flow

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -182,6 +182,9 @@ CHAT_CONTEXT_REVERSE_IMAGE_SEARCH_AUTORUN=true # Auto-run when image attachments
 CHAT_CONTEXT_REVERSE_IMAGE_SEARCH_ENABLED=true # Master enable/disable for reverse-image context integration
 CHAT_CONTEXT_REVERSE_IMAGE_SEARCH_MAX_MATCHES_PER_IMAGE=2 # Max surfaced reverse-image citations per image
 CHAT_CONTEXT_REVERSE_IMAGE_SEARCH_MIN_CONFIDENCE_PERCENT=35 # 0-100 confidence floor for surfacing direct reverse-image match context
+CHAT_CONTEXT_REVERSE_IMAGE_SEARCH_PROVIDER=none # Provider mode: none or serpapi
+CHAT_CONTEXT_REVERSE_IMAGE_SEARCH_SERPAPI_API_KEY= # Required when provider=serpapi
+CHAT_CONTEXT_REVERSE_IMAGE_SEARCH_PROVIDER_TIMEOUT_MS=12000 # HTTP timeout budget for reverse-image provider calls
 CHAT_WORKFLOW_MODE_ID=grounded # Workflow mode id: balanced or grounded
 TRACE_API_TOKEN= # Shared secret required for POST /api/traces (generate with: node -e "console.log(require('node:crypto').randomBytes(32).toString('hex'))")
 REFLECT_SERVICE_TOKEN= # Optional shared secret for trusted server-side callers of POST /api/reflect

--- a/.env.example
+++ b/.env.example
@@ -181,7 +181,6 @@ OPENAI_REQUEST_TIMEOUT_MS=180000 # Backend OpenAI request timeout budget (3 minu
 CHAT_CONTEXT_REVERSE_IMAGE_SEARCH_AUTORUN=true # Auto-run when image attachments are present unless planner explicitly disables
 CHAT_CONTEXT_REVERSE_IMAGE_SEARCH_ENABLED=true # Master enable/disable for reverse-image context integration
 CHAT_CONTEXT_REVERSE_IMAGE_SEARCH_MAX_MATCHES_PER_IMAGE=2 # Max surfaced reverse-image citations per image
-CHAT_CONTEXT_REVERSE_IMAGE_SEARCH_MIN_CONFIDENCE_PERCENT=35 # 0-100 confidence floor for surfacing direct reverse-image match context
 CHAT_CONTEXT_REVERSE_IMAGE_SEARCH_PROVIDER=none # Provider mode: none or serpapi
 CHAT_CONTEXT_REVERSE_IMAGE_SEARCH_SERPAPI_API_KEY= # Required when provider=serpapi
 CHAT_CONTEXT_REVERSE_IMAGE_SEARCH_PROVIDER_TIMEOUT_MS=12000 # HTTP timeout budget for reverse-image provider calls

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -69,6 +69,7 @@ Validate expected deployment env before deploy:
 - backend: `DEFAULT_MODEL`, `DEFAULT_REASONING_EFFORT`, `DEFAULT_VERBOSITY` (reflect defaults)
 - backend: `OLLAMA_BASE_URL`, `OLLAMA_API_KEY`, `OLLAMA_LOCAL_INFERENCE_ENABLED` (Ollama cloud/local behavior)
 - backend: `TRACE_API_RATE_LIMIT`, `TRACE_API_RATE_LIMIT_WINDOW_MS`, `TRACE_API_MAX_BODY_BYTES` (trace ingestion limits)
+- backend: `CHAT_CONTEXT_REVERSE_IMAGE_SEARCH_PROVIDER`, `CHAT_CONTEXT_REVERSE_IMAGE_SEARCH_SERPAPI_API_KEY`, `CHAT_CONTEXT_REVERSE_IMAGE_SEARCH_PROVIDER_TIMEOUT_MS` (reverse-image provider runtime)
 - backend: `LITESTREAM_REPLICA_URL` (SQLite replication target)
 - bot: `CLOUDINARY_CLOUD_NAME`, `CLOUDINARY_API_KEY`, `CLOUDINARY_API_SECRET` (optional image uploads)
 - bot: `BOT_PROFILE_ID`, `BOT_PROFILE_DISPLAY_NAME`, `BOT_PROFILE_PROMPT_OVERLAY_PATH` (optional persona overlays)

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -97,7 +97,7 @@ Validate expected deployment env before deploy:
   GitHub Actions deploys use `.github/workflows/fly-deploy.yml` and only need the `FLY_API_TOKEN` secret; app names come from `deploy/fly.*.toml`.
   Secrets per app:
     - backend: `OPENAI_API_KEY`, `TRACE_API_TOKEN`
-    - backend (optional): `TURNSTILE_SECRET_KEY`, `TURNSTILE_SITE_KEY`, `GITHUB_WEBHOOK_SECRET`, `LOG_LEVEL`
+    - backend (optional): `TURNSTILE_SECRET_KEY`, `TURNSTILE_SITE_KEY`, `GITHUB_WEBHOOK_SECRET`, `LOG_LEVEL`, `CHAT_CONTEXT_REVERSE_IMAGE_SEARCH_PROVIDER`, `CHAT_CONTEXT_REVERSE_IMAGE_SEARCH_SERPAPI_API_KEY`, `CHAT_CONTEXT_REVERSE_IMAGE_SEARCH_PROVIDER_TIMEOUT_MS` (required as optional backend secrets when `reverse_image_search` runtime provider mode is enabled)
     - bot: `DISCORD_TOKEN`, `DISCORD_CLIENT_ID`, `DISCORD_GUILD_ID`, `OPENAI_API_KEY`, `DISCORD_USER_ID`, `INCIDENT_PSEUDONYMIZATION_SECRET`, `TRACE_API_TOKEN`
     - bot (optional): `LOG_LEVEL`, `WEB_BASE_URL`, `CLOUDINARY_CLOUD_NAME`, `CLOUDINARY_API_KEY`, `CLOUDINARY_API_SECRET`, `BOT_PROFILE_ID`, `BOT_PROFILE_DISPLAY_NAME`, `BOT_PROFILE_PROMPT_OVERLAY_PATH`
 

--- a/docs/architecture/context-integrations/README.md
+++ b/docs/architecture/context-integrations/README.md
@@ -137,3 +137,4 @@ where required. Footnote orchestration remains Context Step-owned.
 - [TrustGraph](./trustgraph.md)
 - [Weather Forecast](./weather-forecast.md)
 - [File Scanning](./file-scanning.md)
+- [Reverse Image Search](./reverse-image-search.md)

--- a/docs/architecture/context-integrations/reverse-image-search.md
+++ b/docs/architecture/context-integrations/reverse-image-search.md
@@ -12,7 +12,7 @@ It is bounded and fail-open.
 `reverse_image_search` currently handles:
 
 - image attachments (reverse lookup against configured provider)
-- confidence-gated advisory summaries and bounded source citations
+- advisory summaries and bounded source citations with confidence preserved as metadata (not a decision gate)
 
 It does not grant terminal authority or policy authority.
 

--- a/docs/architecture/context-integrations/reverse-image-search.md
+++ b/docs/architecture/context-integrations/reverse-image-search.md
@@ -1,0 +1,77 @@
+# Reverse Image Search Context Integration
+
+This document describes the backend-owned `reverse_image_search` context
+integration.
+
+`reverse_image_search` runs in workflow context-step execution and provides
+advisory public-reference signals for image attachments before generation.
+It is bounded and fail-open.
+
+## Scope
+
+`reverse_image_search` currently handles:
+
+- image attachments (reverse lookup against configured provider)
+- confidence-gated advisory summaries and bounded source citations
+
+It does not grant terminal authority or policy authority.
+
+## Execution model
+
+`reverse_image_search` is emitted through planner application when:
+
+- reverse-image integration is enabled
+- image attachments are present
+- planner did not explicitly disable reverse-image lookup
+- planner requested it or auto-run-with-image-attachments is enabled
+
+The workflow engine executes it through the context-step executor registry.
+
+## Provider runtime
+
+Runtime config controls whether a provider is available:
+
+- `CHAT_CONTEXT_REVERSE_IMAGE_SEARCH_ENABLED`
+- `CHAT_CONTEXT_REVERSE_IMAGE_SEARCH_AUTORUN`
+- `CHAT_CONTEXT_REVERSE_IMAGE_SEARCH_MIN_CONFIDENCE_PERCENT`
+- `CHAT_CONTEXT_REVERSE_IMAGE_SEARCH_MAX_MATCHES_PER_IMAGE`
+- `CHAT_CONTEXT_REVERSE_IMAGE_SEARCH_PROVIDER` (`none` or `serpapi`)
+- `CHAT_CONTEXT_REVERSE_IMAGE_SEARCH_SERPAPI_API_KEY` (required for `serpapi`)
+- `CHAT_CONTEXT_REVERSE_IMAGE_SEARCH_PROVIDER_TIMEOUT_MS`
+
+When provider mode is `none`, the integration stays fail-open unavailable.
+
+## Behavior
+
+- Requested + eligible with no image attachments:
+    - skipped with `tool_not_used`
+- Requested + eligible with images but no provider:
+    - skipped with `tool_unavailable`
+- Requested + eligible with images + provider:
+    - executed and emits bounded advisory context + citations
+- Not requested or not eligible:
+    - skipped with `tool_not_requested` (or incoming reason code)
+
+## Confidence handling
+
+Provider confidence is advisory only.
+
+- If confidence is below configured threshold:
+    - context reports low confidence and avoids asserting direct matches
+- If matches are empty:
+    - context reports no confident public matches
+- If lookup fails:
+    - context logs warning and continues without blocking generation
+
+## Fail-open semantics
+
+Provider/network/parse failures do not block generation.
+
+The integration emits bounded degraded context when possible and returns normal
+workflow control to generation.
+
+## Provenance and sources
+
+`reverse_image_search` outputs `sources` entries in context-step results so
+downstream metadata can include reverse-lookup influence in citations/provenance
+surfaces.

--- a/docs/architecture/context-integrations/reverse-image-search.md
+++ b/docs/architecture/context-integrations/reverse-image-search.md
@@ -33,7 +33,6 @@ Runtime config controls whether a provider is available:
 
 - `CHAT_CONTEXT_REVERSE_IMAGE_SEARCH_ENABLED`
 - `CHAT_CONTEXT_REVERSE_IMAGE_SEARCH_AUTORUN`
-- `CHAT_CONTEXT_REVERSE_IMAGE_SEARCH_MIN_CONFIDENCE_PERCENT`
 - `CHAT_CONTEXT_REVERSE_IMAGE_SEARCH_MAX_MATCHES_PER_IMAGE`
 - `CHAT_CONTEXT_REVERSE_IMAGE_SEARCH_PROVIDER` (`none` or `serpapi`)
 - `CHAT_CONTEXT_REVERSE_IMAGE_SEARCH_SERPAPI_API_KEY` (required for `serpapi`)
@@ -52,14 +51,16 @@ When provider mode is `none`, the integration stays fail-open unavailable.
 - Not requested or not eligible:
     - skipped with `tool_not_requested` (or incoming reason code)
 
-## Confidence handling
+## Match handling
 
-Provider confidence is advisory only.
+Provider match output is advisory only.
 
-- If confidence is below configured threshold:
-    - context reports low confidence and avoids asserting direct matches
 - If matches are empty:
-    - context reports no confident public matches
+    - context reports no matches for the image
+- If matches exist:
+    - context surfaces bounded match citations (capped by config)
+- If provider includes per-match confidence:
+    - confidence is preserved as advisory metadata, not as a control gate
 - If lookup fails:
     - context logs warning and continues without blocking generation
 

--- a/packages/backend/src/config/sections/services.ts
+++ b/packages/backend/src/config/sections/services.ts
@@ -21,6 +21,11 @@ const CHAT_WORKFLOW_MODE_IDS: ReadonlySet<WorkflowModeId> = new Set([
     'balanced',
     'grounded',
 ]);
+const REVERSE_IMAGE_SEARCH_PROVIDER_MODES = new Set([
+    'none',
+    'serpapi',
+] as const);
+type ReverseImageSearchProviderMode = 'none' | 'serpapi';
 
 /**
  * Resolves auth tokens and body-size limits for trusted backend-only service
@@ -108,6 +113,22 @@ export const buildServiceSections = (
                         'CHAT_CONTEXT_REVERSE_IMAGE_SEARCH_MAX_MATCHES_PER_IMAGE',
                         warn
                     )
+                ),
+                provider: parseStringUnionEnv<ReverseImageSearchProviderMode>(
+                    env.CHAT_CONTEXT_REVERSE_IMAGE_SEARCH_PROVIDER,
+                    'none',
+                    'CHAT_CONTEXT_REVERSE_IMAGE_SEARCH_PROVIDER',
+                    REVERSE_IMAGE_SEARCH_PROVIDER_MODES,
+                    warn
+                ),
+                serpApiKey: parseOptionalTrimmedString(
+                    env.CHAT_CONTEXT_REVERSE_IMAGE_SEARCH_SERPAPI_API_KEY
+                ),
+                providerTimeoutMs: parsePositiveIntEnv(
+                    env.CHAT_CONTEXT_REVERSE_IMAGE_SEARCH_PROVIDER_TIMEOUT_MS,
+                    12000,
+                    'CHAT_CONTEXT_REVERSE_IMAGE_SEARCH_PROVIDER_TIMEOUT_MS',
+                    warn
                 ),
             },
         },

--- a/packages/backend/src/config/sections/services.ts
+++ b/packages/backend/src/config/sections/services.ts
@@ -93,18 +93,6 @@ export const buildServiceSections = (
                     'CHAT_CONTEXT_REVERSE_IMAGE_SEARCH_AUTORUN',
                     warn
                 ),
-                minConfidence: Math.max(
-                    0,
-                    Math.min(
-                        1,
-                        parseNonNegativeIntEnv(
-                            env.CHAT_CONTEXT_REVERSE_IMAGE_SEARCH_MIN_CONFIDENCE_PERCENT,
-                            35,
-                            'CHAT_CONTEXT_REVERSE_IMAGE_SEARCH_MIN_CONFIDENCE_PERCENT',
-                            warn
-                        ) / 100
-                    )
-                ),
                 maxMatchesPerImage: Math.max(
                     1,
                     parsePositiveIntEnv(

--- a/packages/backend/src/config/types.ts
+++ b/packages/backend/src/config/types.ts
@@ -110,8 +110,6 @@ export type RuntimeConfig = {
                  * image attachments unless planner explicitly disables it.
                  */
                 autoRunWithImageAttachments: boolean;
-                /** Minimum accepted reverse-match confidence as a 0.0-1.0 float. */
-                minConfidence: number;
                 /** Positive integer cap for matches surfaced per image attachment. */
                 maxMatchesPerImage: number;
                 /** Provider mode for reverse-image lookup execution. */

--- a/packages/backend/src/config/types.ts
+++ b/packages/backend/src/config/types.ts
@@ -114,6 +114,12 @@ export type RuntimeConfig = {
                 minConfidence: number;
                 /** Positive integer cap for matches surfaced per image attachment. */
                 maxMatchesPerImage: number;
+                /** Provider mode for reverse-image lookup execution. */
+                provider: 'none' | 'serpapi';
+                /** Optional SerpAPI key when provider mode is serpapi. */
+                serpApiKey: string | null;
+                /** Timeout budget for reverse-image provider requests. */
+                providerTimeoutMs: number;
             };
         };
     };

--- a/packages/backend/src/services/attachments/attachmentContext.ts
+++ b/packages/backend/src/services/attachments/attachmentContext.ts
@@ -19,9 +19,10 @@ const isValidChatAttachment = (value: unknown): value is ChatAttachment => {
         return false;
     }
     const candidate = value as Record<string, unknown>;
+    // Contract boundary: accept the shared web/discord attachment shape only.
+    // Do not require surface-specific fields (for example Discord ids/filenames).
     return (
-        typeof candidate.id === 'string' &&
-        typeof candidate.filename === 'string' &&
+        (candidate.kind === 'image' || candidate.kind === 'file') &&
         typeof candidate.url === 'string'
     );
 };

--- a/packages/backend/src/services/attachments/attachmentContext.ts
+++ b/packages/backend/src/services/attachments/attachmentContext.ts
@@ -19,6 +19,16 @@ const isValidChatAttachment = (value: unknown): value is ChatAttachment => {
         return false;
     }
     const candidate = value as Record<string, unknown>;
+    const rawUrl =
+        typeof candidate.url === 'string' ? candidate.url.trim() : '';
+    if (rawUrl.length === 0) {
+        return false;
+    }
+    try {
+        new URL(rawUrl);
+    } catch {
+        return false;
+    }
     // Contract boundary: accept the shared web/discord attachment shape only.
     // Do not require surface-specific fields (for example Discord ids/filenames).
     return (

--- a/packages/backend/src/services/chatOrchestrator.ts
+++ b/packages/backend/src/services/chatOrchestrator.ts
@@ -443,9 +443,6 @@ export const createChatOrchestrator = ({
             reverse_image_search: createReverseImageSearchContextStepExecutor({
                 provider: reverseImageSearchProvider,
                 logger: chatOrchestratorLogger,
-                minConfidence:
-                    runtimeConfig.chatWorkflow.contextIntegrations
-                        .reverseImageSearch.minConfidence,
                 maxMatchesPerImage:
                     runtimeConfig.chatWorkflow.contextIntegrations
                         .reverseImageSearch.maxMatchesPerImage,

--- a/packages/backend/src/services/chatOrchestrator.ts
+++ b/packages/backend/src/services/chatOrchestrator.ts
@@ -42,6 +42,7 @@ import { resolveWeatherClarificationContinuation } from './tools/weatherClarific
 import { createWeatherForecastContextStepExecutor } from './contextIntegrations/weather/index.js';
 import { createFileScanningContextStepExecutor } from './contextIntegrations/fileScanning/index.js';
 import { createReverseImageSearchContextStepExecutor } from './contextIntegrations/reverseImageSearch/index.js';
+import { createSerpApiReverseImageSearchProvider } from './contextIntegrations/reverseImageSearch/index.js';
 import { createPlannerResultApplier } from './chatOrchestrator/plannerResultApplier.js';
 import { runtimeConfig } from '../config.js';
 import { logger } from '../utils/logger.js';
@@ -412,10 +413,35 @@ export const createChatOrchestrator = ({
                     internalImageDescriptionTaskService,
                 logger: chatOrchestratorLogger,
             });
+        const reverseImageSearchProvider =
+            runtimeConfig.chatWorkflow.contextIntegrations.reverseImageSearch
+                .provider === 'serpapi' &&
+            runtimeConfig.chatWorkflow.contextIntegrations.reverseImageSearch
+                .serpApiKey
+                ? createSerpApiReverseImageSearchProvider({
+                      apiKey: runtimeConfig.chatWorkflow.contextIntegrations
+                          .reverseImageSearch.serpApiKey,
+                      requestTimeoutMs:
+                          runtimeConfig.chatWorkflow.contextIntegrations
+                              .reverseImageSearch.providerTimeoutMs,
+                      logger: chatOrchestratorLogger,
+                  })
+                : null;
+        if (
+            runtimeConfig.chatWorkflow.contextIntegrations.reverseImageSearch
+                .provider === 'serpapi' &&
+            !runtimeConfig.chatWorkflow.contextIntegrations.reverseImageSearch
+                .serpApiKey
+        ) {
+            chatOrchestratorLogger.warn(
+                'reverse_image_search provider is set to serpapi, but CHAT_CONTEXT_REVERSE_IMAGE_SEARCH_SERPAPI_API_KEY is missing; integration will fail open as unavailable.'
+            );
+        }
         const contextStepExecutorRegistry = {
             weather_forecast: weatherContextStepExecutor,
             file_scan: fileScanningContextStepExecutor,
             reverse_image_search: createReverseImageSearchContextStepExecutor({
+                provider: reverseImageSearchProvider,
                 logger: chatOrchestratorLogger,
                 minConfidence:
                     runtimeConfig.chatWorkflow.contextIntegrations

--- a/packages/backend/src/services/chatOrchestrator.ts
+++ b/packages/backend/src/services/chatOrchestrator.ts
@@ -413,14 +413,16 @@ export const createChatOrchestrator = ({
                     internalImageDescriptionTaskService,
                 logger: chatOrchestratorLogger,
             });
+        const reverseImageSearchProviderMode =
+            runtimeConfig.chatWorkflow.contextIntegrations.reverseImageSearch
+                .provider;
+        const reverseImageSearchSerpApiKey =
+            runtimeConfig.chatWorkflow.contextIntegrations.reverseImageSearch.serpApiKey?.trim();
         const reverseImageSearchProvider =
-            runtimeConfig.chatWorkflow.contextIntegrations.reverseImageSearch
-                .provider === 'serpapi' &&
-            runtimeConfig.chatWorkflow.contextIntegrations.reverseImageSearch
-                .serpApiKey
+            reverseImageSearchProviderMode === 'serpapi' &&
+            reverseImageSearchSerpApiKey
                 ? createSerpApiReverseImageSearchProvider({
-                      apiKey: runtimeConfig.chatWorkflow.contextIntegrations
-                          .reverseImageSearch.serpApiKey,
+                      apiKey: reverseImageSearchSerpApiKey,
                       requestTimeoutMs:
                           runtimeConfig.chatWorkflow.contextIntegrations
                               .reverseImageSearch.providerTimeoutMs,
@@ -428,10 +430,8 @@ export const createChatOrchestrator = ({
                   })
                 : null;
         if (
-            runtimeConfig.chatWorkflow.contextIntegrations.reverseImageSearch
-                .provider === 'serpapi' &&
-            !runtimeConfig.chatWorkflow.contextIntegrations.reverseImageSearch
-                .serpApiKey
+            reverseImageSearchProviderMode === 'serpapi' &&
+            !reverseImageSearchSerpApiKey
         ) {
             chatOrchestratorLogger.warn(
                 'reverse_image_search provider is set to serpapi, but CHAT_CONTEXT_REVERSE_IMAGE_SEARCH_SERPAPI_API_KEY is missing; integration will fail open as unavailable.'

--- a/packages/backend/src/services/chatOrchestrator/plannerResultApplier.ts
+++ b/packages/backend/src/services/chatOrchestrator/plannerResultApplier.ts
@@ -214,6 +214,8 @@ export const createPlannerResultApplier = (
                 reverseImageSearchConfig.autoRunWithImageAttachments)
                 ? reverseImageSearchAttachmentContextStep
                 : undefined;
+        // File scan is backend-owned attachment grounding and should run for
+        // any attachment payload (image or non-image) when attachments exist.
         const fileScanContextStepRequest = hasAttachments
             ? buildAttachmentContextStep({
                   integrationName: FILE_SCAN_INTEGRATION_NAME,

--- a/packages/backend/src/services/contextIntegrations/reverseImageSearch/index.ts
+++ b/packages/backend/src/services/contextIntegrations/reverseImageSearch/index.ts
@@ -6,6 +6,7 @@
  * @footnote-ethics: low - Re-exports only.
  */
 export { createReverseImageSearchContextStepExecutor } from './reverseImageSearchContextStepExecutor.js';
+export { createSerpApiReverseImageSearchProvider } from './serpApiReverseImageSearchProvider.js';
 export type {
     ReverseImageSearchMatch,
     ReverseImageSearchProvider,

--- a/packages/backend/src/services/contextIntegrations/reverseImageSearch/reverseImageSearchContextStepExecutor.ts
+++ b/packages/backend/src/services/contextIntegrations/reverseImageSearch/reverseImageSearchContextStepExecutor.ts
@@ -52,31 +52,15 @@ export type ReverseImageSearchProvider = {
 type CreateReverseImageSearchContextStepExecutorOptions = {
     provider?: ReverseImageSearchProvider | null;
     logger: ReverseImageSearchExecutorLogger;
-    minConfidence?: number;
     maxMatchesPerImage?: number;
 };
 
 const REVERSE_IMAGE_SEARCH_NAME = 'reverse_image_search';
-const DEFAULT_MIN_CONFIDENCE = 0.35;
 const DEFAULT_MATCH_LIMIT = 2;
-
-const normalizeConfidence = (confidence: number | undefined): number | null => {
-    if (confidence === undefined || !Number.isFinite(confidence)) {
-        return null;
-    }
-    if (confidence < 0) {
-        return 0;
-    }
-    if (confidence > 1) {
-        return 1;
-    }
-    return confidence;
-};
 
 export const createReverseImageSearchContextStepExecutor = ({
     provider,
     logger,
-    minConfidence = DEFAULT_MIN_CONFIDENCE,
     maxMatchesPerImage = DEFAULT_MATCH_LIMIT,
 }: CreateReverseImageSearchContextStepExecutorOptions): ContextStepExecutor => {
     const execute: ContextStepExecutor = async (
@@ -130,33 +114,13 @@ export const createReverseImageSearchContextStepExecutor = ({
             });
             if (taskResult.status === 'executed') {
                 const result = taskResult.value;
-                const normalizedConfidence = normalizeConfidence(
-                    result.confidence
-                );
-                if (
-                    normalizedConfidence !== null &&
-                    normalizedConfidence < minConfidence
-                ) {
-                    contextMessages.push(
-                        `[${label}] reverse image search confidence was low (${normalizedConfidence.toFixed(2)}); continuing without asserting a match.`
-                    );
-                    sources.push(
-                        buildAttachmentCitation({
-                            attachment,
-                            title: `${label} (low-confidence reverse lookup)`,
-                            snippet: `Provider ${result.providerId} returned low confidence; advisory signal only.`,
-                        })
-                    );
-                    continue;
-                }
-
                 const topMatches = result.matches.slice(
                     0,
                     Math.max(1, maxMatchesPerImage)
                 );
                 if (topMatches.length === 0) {
                     contextMessages.push(
-                        `[${label}] reverse image search found no confident public matches.`
+                        `[${label}] reverse image search returned no matches for this image.`
                     );
                     sources.push(
                         buildAttachmentCitation({
@@ -179,8 +143,16 @@ export const createReverseImageSearchContextStepExecutor = ({
                     sources.push({
                         title: match.title,
                         url: match.url,
-                        ...(match.snippet !== undefined && {
-                            snippet: match.snippet,
+                        ...((match.snippet !== undefined ||
+                            match.confidence !== undefined) && {
+                            snippet: [
+                                match.snippet,
+                                match.confidence !== undefined
+                                    ? `Provider confidence: ${match.confidence.toFixed(2)}`
+                                    : undefined,
+                            ]
+                                .filter((part): part is string => Boolean(part))
+                                .join(' | '),
                         }),
                     });
                 }

--- a/packages/backend/src/services/contextIntegrations/reverseImageSearch/serpApiReverseImageSearchProvider.ts
+++ b/packages/backend/src/services/contextIntegrations/reverseImageSearch/serpApiReverseImageSearchProvider.ts
@@ -150,24 +150,12 @@ export const createSerpApiReverseImageSearchProvider = ({
                     : undefined;
             const graphTitle = asString(knowledgeGraph?.title);
             const sourceName = asString(knowledgeGraph?.source?.name);
-            const providerConfidenceSignals = matches
-                .map((match) => match.confidence)
-                .filter(
-                    (confidence): confidence is number =>
-                        typeof confidence === 'number' &&
-                        Number.isFinite(confidence)
-                );
-            const providerConfidence =
-                providerConfidenceSignals.length > 0
-                    ? Math.max(...providerConfidenceSignals)
-                    : undefined;
-
             const summary =
                 matches.length > 0
                     ? `Reverse image search found ${matches.length} related public match${matches.length === 1 ? '' : 'es'}.`
                     : graphTitle
                       ? `Reverse image search found no direct visual matches, but detected likely subject: ${graphTitle}${sourceName ? ` (${sourceName})` : ''}.`
-                      : 'Reverse image search found no confident public matches.';
+                      : 'Reverse image search returned no matches for this image.';
 
             if (matches.length === 0 && graphTitle === undefined) {
                 logger.warn(
@@ -179,9 +167,6 @@ export const createSerpApiReverseImageSearchProvider = ({
             return {
                 providerId: 'serpapi_google_lens',
                 summary,
-                ...(providerConfidence !== undefined && {
-                    confidence: providerConfidence,
-                }),
                 matches,
             };
         },

--- a/packages/backend/src/services/contextIntegrations/reverseImageSearch/serpApiReverseImageSearchProvider.ts
+++ b/packages/backend/src/services/contextIntegrations/reverseImageSearch/serpApiReverseImageSearchProvider.ts
@@ -1,0 +1,189 @@
+/**
+ * @description: SerpAPI-backed reverse image search provider for chat context integration.
+ * Converts Google Lens-style response payloads into bounded advisory matches for provenance context.
+ * @footnote-scope: core
+ * @footnote-module: SerpApiReverseImageSearchProvider
+ * @footnote-risk: medium - Incorrect provider parsing can hide useful sources or surface malformed citations.
+ * @footnote-ethics: medium - Reverse-image matches can influence user trust, so output stays bounded and fail-open.
+ */
+import type {
+    ReverseImageSearchProvider,
+    ReverseImageSearchProviderResponse,
+} from './reverseImageSearchContextStepExecutor.js';
+
+type ReverseImageSearchLogger = {
+    warn: (message: string, meta?: Record<string, unknown>) => void;
+};
+
+type CreateSerpApiReverseImageSearchProviderOptions = {
+    apiKey: string;
+    requestTimeoutMs: number;
+    logger: ReverseImageSearchLogger;
+    fetchImpl?: typeof fetch;
+};
+
+type SerpApiVisualMatch = {
+    title?: unknown;
+    link?: unknown;
+    snippet?: unknown;
+    confidence?: unknown;
+};
+
+type SerpApiKnowledgeGraph = {
+    title?: unknown;
+    source?: {
+        name?: unknown;
+    };
+};
+
+type SerpApiResponse = {
+    visual_matches?: unknown;
+    knowledge_graph?: unknown;
+};
+
+const asString = (value: unknown): string | undefined =>
+    typeof value === 'string' && value.trim().length > 0
+        ? value.trim()
+        : undefined;
+
+const toVisualMatches = (value: unknown): SerpApiVisualMatch[] =>
+    Array.isArray(value)
+        ? value.filter(
+              (entry): entry is SerpApiVisualMatch =>
+                  typeof entry === 'object' && entry !== null
+          )
+        : [];
+
+const parseConfidence = (value: unknown): number | undefined => {
+    if (typeof value === 'number' && Number.isFinite(value)) {
+        if (value >= 0 && value <= 1) {
+            return value;
+        }
+        if (value > 1 && value <= 100) {
+            return value / 100;
+        }
+        return undefined;
+    }
+    if (typeof value !== 'string') {
+        return undefined;
+    }
+    const normalized = value.trim().replace(/%$/, '');
+    if (normalized.length === 0) {
+        return undefined;
+    }
+    const parsed = Number(normalized);
+    if (!Number.isFinite(parsed)) {
+        return undefined;
+    }
+    if (parsed >= 0 && parsed <= 1) {
+        return parsed;
+    }
+    if (parsed > 1 && parsed <= 100) {
+        return parsed / 100;
+    }
+    return undefined;
+};
+
+/**
+ * Builds a reverse-image provider that calls SerpAPI Google Lens endpoint.
+ *
+ * Fail-open contract:
+ * - Throws only for transport/provider errors.
+ * - Returns empty matches for parseable but non-match payloads.
+ */
+export const createSerpApiReverseImageSearchProvider = ({
+    apiKey,
+    requestTimeoutMs,
+    logger,
+    fetchImpl = fetch,
+}: CreateSerpApiReverseImageSearchProviderOptions): ReverseImageSearchProvider => {
+    return {
+        search: async ({
+            imageUrl,
+            context,
+        }): Promise<ReverseImageSearchProviderResponse> => {
+            const endpoint = new URL('https://serpapi.com/search.json');
+            endpoint.searchParams.set('engine', 'google_lens');
+            endpoint.searchParams.set('url', imageUrl);
+            endpoint.searchParams.set('api_key', apiKey);
+
+            const signal = AbortSignal.timeout(requestTimeoutMs);
+            const response = await fetchImpl(endpoint.toString(), {
+                method: 'GET',
+                signal,
+            });
+            if (!response.ok) {
+                const body = await response.text().catch(() => '');
+                throw new Error(
+                    `SerpAPI reverse image search failed with HTTP ${response.status}: ${body.slice(0, 200)}`
+                );
+            }
+
+            const raw = (await response.json()) as SerpApiResponse;
+            const visualMatches = toVisualMatches(raw.visual_matches);
+            const matches = visualMatches
+                .map((match) => {
+                    const title = asString(match.title);
+                    const url = asString(match.link);
+                    if (!title || !url) {
+                        return null;
+                    }
+                    const confidence = parseConfidence(match.confidence);
+                    return {
+                        title,
+                        url,
+                        ...(asString(match.snippet) !== undefined && {
+                            snippet: asString(match.snippet),
+                        }),
+                        ...(confidence !== undefined && { confidence }),
+                    };
+                })
+                .filter(
+                    (match): match is NonNullable<typeof match> =>
+                        match !== null
+                );
+
+            const knowledgeGraph =
+                typeof raw.knowledge_graph === 'object' &&
+                raw.knowledge_graph !== null
+                    ? (raw.knowledge_graph as SerpApiKnowledgeGraph)
+                    : undefined;
+            const graphTitle = asString(knowledgeGraph?.title);
+            const sourceName = asString(knowledgeGraph?.source?.name);
+            const providerConfidenceSignals = matches
+                .map((match) => match.confidence)
+                .filter(
+                    (confidence): confidence is number =>
+                        typeof confidence === 'number' &&
+                        Number.isFinite(confidence)
+                );
+            const providerConfidence =
+                providerConfidenceSignals.length > 0
+                    ? Math.max(...providerConfidenceSignals)
+                    : undefined;
+
+            const summary =
+                matches.length > 0
+                    ? `Reverse image search found ${matches.length} related public match${matches.length === 1 ? '' : 'es'}.`
+                    : graphTitle
+                      ? `Reverse image search found no direct visual matches, but detected likely subject: ${graphTitle}${sourceName ? ` (${sourceName})` : ''}.`
+                      : 'Reverse image search found no confident public matches.';
+
+            if (matches.length === 0 && graphTitle === undefined) {
+                logger.warn(
+                    'reverse_image_search: SerpAPI returned no visual matches.',
+                    { imageUrl, hasContext: Boolean(context) }
+                );
+            }
+
+            return {
+                providerId: 'serpapi_google_lens',
+                summary,
+                ...(providerConfidence !== undefined && {
+                    confidence: providerConfidence,
+                }),
+                matches,
+            };
+        },
+    };
+};

--- a/packages/backend/src/services/contextIntegrations/reverseImageSearch/serpApiReverseImageSearchProvider.ts
+++ b/packages/backend/src/services/contextIntegrations/reverseImageSearch/serpApiReverseImageSearchProvider.ts
@@ -54,6 +54,15 @@ const toVisualMatches = (value: unknown): SerpApiVisualMatch[] =>
           )
         : [];
 
+const sanitizeUrlForLogs = (value: string): string => {
+    try {
+        const parsed = new URL(value);
+        return `${parsed.origin}${parsed.pathname}`;
+    } catch {
+        return '[invalid_url]';
+    }
+};
+
 const parseConfidence = (value: unknown): number | undefined => {
     if (typeof value === 'number' && Number.isFinite(value)) {
         if (value >= 0 && value <= 1) {
@@ -115,7 +124,7 @@ export const createSerpApiReverseImageSearchProvider = ({
             if (!response.ok) {
                 const body = await response.text().catch(() => '');
                 throw new Error(
-                    `SerpAPI reverse image search failed with HTTP ${response.status}: ${body.slice(0, 200)}`
+                    `SerpAPI reverse image search failed with HTTP ${response.status} (response body omitted; length=${body.length}).`
                 );
             }
 
@@ -160,7 +169,10 @@ export const createSerpApiReverseImageSearchProvider = ({
             if (matches.length === 0 && graphTitle === undefined) {
                 logger.warn(
                     'reverse_image_search: SerpAPI returned no visual matches.',
-                    { imageUrl, hasContext: Boolean(context) }
+                    {
+                        imageUrl: sanitizeUrlForLogs(imageUrl),
+                        hasContext: Boolean(context),
+                    }
                 );
             }
 

--- a/packages/backend/test/attachmentContext.test.ts
+++ b/packages/backend/test/attachmentContext.test.ts
@@ -32,10 +32,29 @@ test('getAttachmentsFromUnknownInput accepts contract-shaped chat attachments', 
     assert.equal(attachments[1]?.kind, 'file');
 });
 
+test('getAttachmentsFromUnknownInput accepts minimal contract shape without id or filename', () => {
+    const attachments = getAttachmentsFromUnknownInput([
+        {
+            kind: 'image',
+            url: 'https://cdn.example.com/a.png',
+        },
+        {
+            kind: 'file',
+            url: 'https://cdn.example.com/spec.pdf',
+        },
+    ]);
+
+    assert.equal(attachments.length, 2);
+    assert.equal(attachments[0]?.kind, 'image');
+    assert.equal(attachments[0]?.url, 'https://cdn.example.com/a.png');
+    assert.equal(attachments[1]?.kind, 'file');
+});
+
 test('getAttachmentsFromUnknownInput drops malformed entries', () => {
     const attachments = getAttachmentsFromUnknownInput([
         { kind: 'image', contentType: 'image/png' },
         { kind: 'file', url: 1234 },
+        { kind: 'file', url: '' },
         { kind: 'other', url: 'https://example.com/other.bin' },
     ]);
 

--- a/packages/backend/test/attachmentContext.test.ts
+++ b/packages/backend/test/attachmentContext.test.ts
@@ -1,0 +1,64 @@
+/**
+ * @description: Verifies shared attachment normalization for chat context integrations.
+ * Ensures Discord/web attachment payloads remain compatible with backend attachment-aware steps.
+ * @footnote-scope: test
+ * @footnote-module: AttachmentContextTests
+ * @footnote-risk: medium - Invalid normalization can silently disable attachment-grounded tools.
+ * @footnote-ethics: medium - Attachment handling influences what evidence the assistant can use.
+ */
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import {
+    getAttachmentsFromUnknownInput,
+    isImageAttachment,
+} from '../src/services/attachments/attachmentContext.js';
+
+test('getAttachmentsFromUnknownInput accepts contract-shaped chat attachments', () => {
+    const attachments = getAttachmentsFromUnknownInput([
+        {
+            kind: 'image',
+            url: 'https://example.com/photo.jpg',
+            contentType: 'image/jpeg',
+        },
+        {
+            kind: 'file',
+            url: 'https://example.com/doc.txt',
+            contentType: 'text/plain',
+        },
+    ]);
+
+    assert.equal(attachments.length, 2);
+    assert.equal(attachments[0]?.kind, 'image');
+    assert.equal(attachments[1]?.kind, 'file');
+});
+
+test('getAttachmentsFromUnknownInput drops malformed entries', () => {
+    const attachments = getAttachmentsFromUnknownInput([
+        { kind: 'image', contentType: 'image/png' },
+        { kind: 'file', url: 1234 },
+        { kind: 'other', url: 'https://example.com/other.bin' },
+    ]);
+
+    assert.deepEqual(attachments, []);
+});
+
+test('isImageAttachment uses kind or image content type', () => {
+    const byKind = isImageAttachment({
+        kind: 'image',
+        url: 'https://example.com/image.bin',
+    });
+    const byType = isImageAttachment({
+        kind: 'file',
+        url: 'https://example.com/image.png',
+        contentType: 'image/png',
+    });
+    const nonImage = isImageAttachment({
+        kind: 'file',
+        url: 'https://example.com/readme.md',
+        contentType: 'text/markdown',
+    });
+
+    assert.equal(byKind, true);
+    assert.equal(byType, true);
+    assert.equal(nonImage, false);
+});

--- a/packages/backend/test/serpApiReverseImageSearchProvider.test.ts
+++ b/packages/backend/test/serpApiReverseImageSearchProvider.test.ts
@@ -1,0 +1,91 @@
+/**
+ * @description: Validates SerpAPI reverse-image provider mapping and fail-open error behavior.
+ * @footnote-scope: test
+ * @footnote-module: SerpApiReverseImageSearchProviderTests
+ * @footnote-risk: medium - Parser regressions can drop citations or misclassify provider outcomes.
+ * @footnote-ethics: medium - Reverse-image context quality affects user trust in provenance signals.
+ */
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { createSerpApiReverseImageSearchProvider } from '../src/services/contextIntegrations/reverseImageSearch/index.js';
+
+test('SerpAPI provider maps visual matches into citations', async () => {
+    const provider = createSerpApiReverseImageSearchProvider({
+        apiKey: 'test-key',
+        requestTimeoutMs: 1000,
+        logger: { warn: () => undefined },
+        fetchImpl: async () =>
+            new Response(
+                JSON.stringify({
+                    visual_matches: [
+                        {
+                            title: 'Example Match',
+                            link: 'https://example.com/match',
+                            snippet: 'Matched listing',
+                            confidence: '82%',
+                        },
+                    ],
+                }),
+                { status: 200 }
+            ),
+    });
+
+    const result = await provider.search({
+        imageUrl: 'https://images.example.com/input.jpg',
+    });
+    assert.equal(result.providerId, 'serpapi_google_lens');
+    assert.equal(result.matches.length, 1);
+    assert.equal(result.matches[0]?.title, 'Example Match');
+    assert.equal(result.matches[0]?.url, 'https://example.com/match');
+    assert.equal(result.matches[0]?.confidence, 0.82);
+    assert.equal(result.confidence, 0.82);
+});
+
+test('SerpAPI provider returns empty matches with no visual hits', async () => {
+    let warned = false;
+    const provider = createSerpApiReverseImageSearchProvider({
+        apiKey: 'test-key',
+        requestTimeoutMs: 1000,
+        logger: {
+            warn: () => {
+                warned = true;
+            },
+        },
+        fetchImpl: async () =>
+            new Response(
+                JSON.stringify({
+                    visual_matches: [],
+                    knowledge_graph: { title: 'Cargo vessel' },
+                }),
+                { status: 200 }
+            ),
+    });
+
+    const result = await provider.search({
+        imageUrl: 'https://images.example.com/input.jpg',
+    });
+    assert.equal(result.matches.length, 0);
+    assert.equal(warned, false);
+    assert.equal(typeof result.summary, 'string');
+    assert.equal(result.confidence, undefined);
+});
+
+test('SerpAPI provider throws on non-2xx response', async () => {
+    const provider = createSerpApiReverseImageSearchProvider({
+        apiKey: 'test-key',
+        requestTimeoutMs: 1000,
+        logger: { warn: () => undefined },
+        fetchImpl: async () =>
+            new Response('bad request', {
+                status: 400,
+            }),
+    });
+
+    await assert.rejects(
+        () =>
+            provider.search({
+                imageUrl: 'https://images.example.com/input.jpg',
+            }),
+        /SerpAPI reverse image search failed/
+    );
+});

--- a/packages/backend/test/serpApiReverseImageSearchProvider.test.ts
+++ b/packages/backend/test/serpApiReverseImageSearchProvider.test.ts
@@ -38,7 +38,7 @@ test('SerpAPI provider maps visual matches into citations', async () => {
     assert.equal(result.matches[0]?.title, 'Example Match');
     assert.equal(result.matches[0]?.url, 'https://example.com/match');
     assert.equal(result.matches[0]?.confidence, 0.82);
-    assert.equal(result.confidence, 0.82);
+    assert.equal(result.confidence, undefined);
 });
 
 test('SerpAPI provider returns empty matches with no visual hits', async () => {

--- a/packages/config-spec/src/env-spec.ts
+++ b/packages/config-spec/src/env-spec.ts
@@ -1729,7 +1729,8 @@ export const envEntries = [
         section: 'chat-workflow',
         required: false,
         secret: false,
-        kind: 'string',
+        kind: 'enum',
+        allowedValues: ['none', 'serpapi'] as const,
         description:
             'Reverse-image provider mode (`none` or `serpapi`). `none` keeps the integration fail-open unavailable.',
         defaultValue: literal('none'),

--- a/packages/config-spec/src/env-spec.ts
+++ b/packages/config-spec/src/env-spec.ts
@@ -1737,6 +1737,48 @@ export const envEntries = [
     }),
 
     defineEnv({
+        key: 'CHAT_CONTEXT_REVERSE_IMAGE_SEARCH_PROVIDER',
+        owner: 'backend',
+        stage: 'runtime',
+        section: 'chat-workflow',
+        required: false,
+        secret: false,
+        kind: 'string',
+        description:
+            'Reverse-image provider mode (`none` or `serpapi`). `none` keeps the integration fail-open unavailable.',
+        defaultValue: literal('none'),
+        usedBy: ['packages/backend/src/config.ts'],
+    }),
+
+    defineEnv({
+        key: 'CHAT_CONTEXT_REVERSE_IMAGE_SEARCH_SERPAPI_API_KEY',
+        owner: 'backend',
+        stage: 'runtime',
+        section: 'chat-workflow',
+        required: false,
+        secret: true,
+        kind: 'string',
+        description:
+            'SerpAPI key used when reverse-image provider mode is set to `serpapi`.',
+        defaultValue: literal(''),
+        usedBy: ['packages/backend/src/config.ts'],
+    }),
+
+    defineEnv({
+        key: 'CHAT_CONTEXT_REVERSE_IMAGE_SEARCH_PROVIDER_TIMEOUT_MS',
+        owner: 'backend',
+        stage: 'runtime',
+        section: 'chat-workflow',
+        required: false,
+        secret: false,
+        kind: 'integer',
+        description:
+            'Timeout budget for reverse-image provider HTTP requests in milliseconds.',
+        defaultValue: literal(12000),
+        usedBy: ['packages/backend/src/config.ts'],
+    }),
+
+    defineEnv({
         key: 'WEB_API_RATE_LIMIT_IP',
         owner: 'backend',
         stage: 'runtime',

--- a/packages/config-spec/src/env-spec.ts
+++ b/packages/config-spec/src/env-spec.ts
@@ -1709,20 +1709,6 @@ export const envEntries = [
     }),
 
     defineEnv({
-        key: 'CHAT_CONTEXT_REVERSE_IMAGE_SEARCH_MIN_CONFIDENCE_PERCENT',
-        owner: 'backend',
-        stage: 'runtime',
-        section: 'chat-workflow',
-        required: false,
-        secret: false,
-        kind: 'integer',
-        description:
-            'Minimum confidence percentage (0-100) before reverse-image matches are surfaced as direct advisory context.',
-        defaultValue: literal(35),
-        usedBy: ['packages/backend/src/config.ts'],
-    }),
-
-    defineEnv({
         key: 'CHAT_CONTEXT_REVERSE_IMAGE_SEARCH_MAX_MATCHES_PER_IMAGE',
         owner: 'backend',
         stage: 'runtime',


### PR DESCRIPTION
## Summary
Fix Discord image-context grounding so attachments reliably reach backend context integrations, and enable reverse-image lookup with clearer, match-based advisory behavior.

## What Changed
- Fixed attachment normalization at the backend boundary to accept the shared chat attachment contract (`kind`, `url`, optional `contentType`) instead of requiring non-contract fields.
- Added regression tests for attachment normalization and image/file classification behavior.
- Added a reverse-image provider adapter (`serpapi`) and wired it into chat orchestration when configured.
- Added reverse-image provider runtime configuration:
  - `CHAT_CONTEXT_REVERSE_IMAGE_SEARCH_PROVIDER`
  - `CHAT_CONTEXT_REVERSE_IMAGE_SEARCH_SERPAPI_API_KEY`
  - `CHAT_CONTEXT_REVERSE_IMAGE_SEARCH_PROVIDER_TIMEOUT_MS`
- Simplified reverse-image handling to be match-based advisory:
  - removed global confidence-threshold gating
  - removed synthesized top-level confidence
  - preserved provider confidence per match when available
  - improved no-match context wording for model usefulness
- Added provider-focused tests for success/empty/error paths.
- Updated docs:
  - added architecture doc for reverse image search context integration
  - linked context-integration docs from the architecture index
  - kept deploy docs focused on deploy/runtime setup details
- Updated env spec and `.env.example` to match current runtime knobs (including removing obsolete min-confidence config).

## Why
This branch addresses a real Discord failure where image attachments were present in the user message but `file_scan` was skipped as `tool_not_used`.

Root causes:
1. Attachment contract mismatch caused attachments to be sanitized out before context-step execution.
2. Reverse-image integration had no provider runtime path, so it could not execute lookups.
3. Confidence heuristics based on match count were opaque and not source-faithful.

The changes make attachment-grounded behavior deterministic, configurable, and easier to reason about from trace outputs.

## Important Implementation Details
- `file_scan` is still fail-open and advisory; generation is never blocked by scan failures.
- `reverse_image_search` remains advisory and bounded by `maxMatchesPerImage`.
- Reverse-image decisions now rely on match presence rather than a global confidence gate.
- Provider confidence, if present, is preserved per match as metadata only (not control authority).
- If reverse-image provider mode is `none` or key is missing, runtime behavior remains explicit fail-open unavailable (`tool_unavailable`).

## Validation
- `pnpm lint:fix`
- `pnpm lint`
- `pnpm validate-footnote-tags`
- `pnpm review`
- `docker compose -f deploy/compose.yml build`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added SerpAPI provider integration for reverse image search functionality.

* **Configuration**
  * Updated reverse image search configuration to use provider-based setup with timeout settings.
  * Removed minimum confidence threshold setting.

* **Documentation**
  * Added comprehensive architecture documentation for reverse image search integration and provider configuration behavior.

* **Tests**
  * Added test coverage for reverse image search provider functionality.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/footnote-ai/footnote/pull/351)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->