### PR TITLE
proposal: define canonical conversation-context boundary (messages + envelope)

### DIFF
--- a/docs/proposals/proposal_conversation_context_boundary.md
+++ b/docs/proposals/proposal_conversation_context_boundary.md
@@ -60,7 +60,7 @@ Recommended pattern:
 
 1. Canonical turns in `ConversationContextService` keep normalized role, metadata, and authority fields.
 2. A rendering adapter maps canonical turns to runtime-facing messages (`system`, `user`, `assistant`).
-3. Participant identity stays structured (`speakerId`, `speakerLabel`) and is only injected into visible text when needed.
+3. Participant identity stays structured (`speakerId`, `speakerLabel`) and follows an explicit projection policy.
 
 This keeps model input aligned with common LLM training formats while preserving Footnote-specific semantics outside provider-native payload shapes.
 
@@ -70,13 +70,63 @@ This keeps model input aligned with common LLM training formats while preserving
 
 Timestamp data should remain available as metadata by default and should not be dropped.
 
-Use temporal rendering rules:
+Use deterministic temporal rendering rules:
 
-- include one session-level time header when helpful (date + timezone)
+- include one session-level time header (date + timezone)
 - avoid per-turn transcript wrappers
-- include per-turn time only when context has meaningful gaps (for example, long pauses) or the query is time-sensitive
+- include per-turn time only when a configured time-gap threshold is met
 
 This preserves useful temporal context without teaching the model transcript wrapper styles.
+
+---
+
+## Messages And Envelope Split
+
+Model input should be split into two explicit channels:
+
+1. `messages`: runtime-facing role/content list used for generation.
+2. `contextEnvelope`: backend-owned structured metadata for context semantics.
+
+`messages` should remain role-aligned and minimal.
+`contextEnvelope` should carry speaker identity, timestamps, provenance-facing metadata, and reduction/cache metadata.
+
+Only explicit rendering rules may project `contextEnvelope` fields into model-visible message text.
+
+---
+
+## Speaker Label Policy
+
+`speakerLabel` handling should be explicit and deterministic:
+
+- Always store `speakerId` and `speakerLabel` in `contextEnvelope`.
+- Do not prepend labels in every message by default.
+- Project labels into model-visible text only when disambiguation is required (for example, multiple human participants in view).
+- Keep assistant identity stable and normalized across turns.
+
+This avoids accidental style bleed while preserving multi-party clarity.
+
+---
+
+## Segmentation And Reduction
+
+Conversation history should be represented as deterministic segments.
+
+Suggested segment model:
+
+- `segmentId` (stable hash from ordered turn ids + reduction config version)
+- `turnIds`
+- `startedAt` / `endedAt`
+- `reductionLevel` (`full`, `compact`, `summary`)
+- `summaryRef` (optional pointer to persisted summary content)
+
+Deterministic reduction policy:
+
+- Keep newest `N` turns unreduced.
+- Reduce older turns by segment age and token budget pressure.
+- Reuse existing summaries when `segmentId` is unchanged.
+- Only regenerate summaries when segment content or reduction config changes.
+
+This minimizes churn and creates a clean path for future cache-aware prompt assembly.
 
 ---
 
@@ -110,6 +160,7 @@ Guardrails:
 - avoid double-including both raw normalized conversation and rendered context output in the same model payload
 - preserve fail-open behavior by falling back to normalized role/content turns if context rendering fails
 - keep persona/system layering in prompt layers, not in context service
+- enforce one canonical source-of-truth path for generation history per request
 
 ---
 
@@ -132,6 +183,29 @@ This is guidance to validate, not a permanent rule.
 The shape below is illustrative and should be aligned with existing backend contract types before implementation.
 
 ```ts
+type ConversationSegmentReductionLevel = 'full' | 'compact' | 'summary';
+
+type ConversationContextEnvelope = {
+    sessionTimeZone?: string;
+    sessionDate?: string;
+    temporalPolicy: {
+        gapMinutesForTurnTime: number;
+    };
+    participants: Array<{
+        speakerId: string;
+        speakerLabel: string;
+        roleHint: 'user' | 'assistant' | 'system';
+    }>;
+    segments: Array<{
+        segmentId: string;
+        turnIds: string[];
+        startedAt?: string;
+        endedAt?: string;
+        reductionLevel: ConversationSegmentReductionLevel;
+        summaryRef?: string;
+    }>;
+};
+
 type ConversationContextServiceInput = {
     requestId: string;
     surface: 'discord' | 'web' | 'api';
@@ -139,6 +213,17 @@ type ConversationContextServiceInput = {
     turns: SurfaceConversationTurn[];
     personaHints?: ConversationPersonaHints;
     workflowHints?: ConversationContextWorkflowHints;
+};
+
+type ConversationContextServiceOutput = {
+    messages: Array<{ role: 'system' | 'user' | 'assistant'; content: string }>;
+    contextEnvelope: ConversationContextEnvelope;
+    diagnostics?: {
+        stableTokenEstimate: number;
+        volatileTokenEstimate: number;
+        segmentCount: number;
+        summaryReuseCount: number;
+    };
 };
 ```
 
@@ -171,6 +256,8 @@ This avoids hard-coding legacy “normalized transcript request” assumptions i
 - Model-facing prompt material does not include transcript wrappers like `[n] At ... said:`.
 - Author/timestamp metadata remains available without transcript-style prose wrappers.
 - Runtime-facing conversation messages stay role-aligned (`system|user|assistant`) and serializable.
+- Conversation assembly uses explicit `messages` + `contextEnvelope` channels with deterministic projection rules.
+- Speaker labels are projected only by policy, not by default per-turn prefixing.
 - Prompt assembly still occurs through existing prompt-layer path.
 - No new implicit runtime/provider memory feature is enabled.
 - `chatOrchestrator` remains backend authority for orchestration and policy seams.
@@ -183,10 +270,10 @@ This avoids hard-coding legacy “normalized transcript request” assumptions i
 
 Track a small set of signals first:
 
-- stable-token vs volatile-token estimates
-- context block churn rate across turns
-- provider cache metadata when available
-- prompt assembly error/fallback counts
+- prompt assembly fallback rate
+- context-to-message projection rate
+- summary reuse rate
+- token delta before/after reduction
 
 These are enough to validate the boundary without overcommitting to low-level cache internals.
 

--- a/docs/proposals/proposal_conversation_context_boundary.md
+++ b/docs/proposals/proposal_conversation_context_boundary.md
@@ -37,6 +37,21 @@ It will not assemble final model prompts or own supplemental context such as per
 
 ---
 
+## Core Invariants
+
+The first implementation should be judged against a small set of architectural invariants:
+
+- One canonical conversation-history source is used per request.
+- `messages` is the runtime-facing generation channel.
+- `contextEnvelope` is the backend-owned semantics channel.
+- Projection from `contextEnvelope` into model-visible text is deterministic and policy-driven.
+- Prompt layers remain the authority for persona/system instruction ordering.
+- Fail-open behavior is preserved when context shaping is partial or unavailable.
+
+These invariants matter more than any specific first-pass formatting choice.
+
+---
+
 ## Context Block Model
 
 Each "context block" should carry:
@@ -238,6 +253,20 @@ This avoids hard-coding legacy “normalized transcript request” assumptions i
 - No automatic provider/runtime memory enablement.
 - No broad prompt system rewrite.
 - No change to backend authority for cost, provenance, review, or incident semantics.
+
+---
+
+## Long-Term Goals And Gating
+
+This boundary should be shaped with later cost and stability goals in mind, but those goals should stay gated behind the core invariants above.
+
+The design should leave room for:
+
+- stable segment identities for low-churn history handling
+- summary reuse for older context windows
+- cache-aware prompt assembly and cost reduction
+
+Those goals should influence the structure now, but they should not force early rollout of memory-like behavior, persistent summarization systems, or broader prompt refactors in the first implementation.
 
 ---
 

--- a/docs/proposals/proposal_conversation_context_boundary.md
+++ b/docs/proposals/proposal_conversation_context_boundary.md
@@ -1,6 +1,6 @@
 # Feature Proposal: Conversation Context Boundary
 
-**Last Updated:** 2026-05-01
+**Last Updated:** 2026-05-09
 
 ---
 
@@ -52,6 +52,34 @@ This gives prompt assembly enough information to place blocks deliberately and e
 
 ---
 
+## Role-Aligned Rendering Strategy
+
+The canonical context representation should stay backend-owned and structured. Rendering to provider/runtime message formats should happen at the edge.
+
+Recommended pattern:
+
+1. Canonical turns in `ConversationContextService` keep normalized role, metadata, and authority fields.
+2. A rendering adapter maps canonical turns to runtime-facing messages (`system`, `user`, `assistant`).
+3. Participant identity stays structured (`speakerId`, `speakerLabel`) and is only injected into visible text when needed.
+
+This keeps model input aligned with common LLM training formats while preserving Footnote-specific semantics outside provider-native payload shapes.
+
+---
+
+## Temporal Metadata Policy
+
+Timestamp data should remain available as metadata by default and should not be dropped.
+
+Use temporal rendering rules:
+
+- include one session-level time header when helpful (date + timezone)
+- avoid per-turn transcript wrappers
+- include per-turn time only when context has meaningful gaps (for example, long pauses) or the query is time-sensitive
+
+This preserves useful temporal context without teaching the model transcript wrapper styles.
+
+---
+
 ## Authority And Visibility Rules
 
 The first version should keep five kinds of context separate:
@@ -76,6 +104,12 @@ This should plug into the existing prompt path rather than replace it. The main 
 - `packages/backend/src/services/chatOrchestrator.ts`
 
 `ConversationContextService` returns blocks. `conversationPromptLayers` still renders prompt text/messages and preserves policy-sensitive instruction order.
+
+Guardrails:
+
+- avoid double-including both raw normalized conversation and rendered context output in the same model payload
+- preserve fail-open behavior by falling back to normalized role/content turns if context rendering fails
+- keep persona/system layering in prompt layers, not in context service
 
 ---
 
@@ -136,6 +170,7 @@ This avoids hard-coding legacy “normalized transcript request” assumptions i
 
 - Model-facing prompt material does not include transcript wrappers like `[n] At ... said:`.
 - Author/timestamp metadata remains available without transcript-style prose wrappers.
+- Runtime-facing conversation messages stay role-aligned (`system|user|assistant`) and serializable.
 - Prompt assembly still occurs through existing prompt-layer path.
 - No new implicit runtime/provider memory feature is enabled.
 - `chatOrchestrator` remains backend authority for orchestration and policy seams.

--- a/docs/proposals/proposal_conversation_context_boundary.md
+++ b/docs/proposals/proposal_conversation_context_boundary.md
@@ -1,6 +1,6 @@
 # Feature Proposal: Conversation Context Boundary
 
-**Last Updated:** 2026-05-09
+**Last Updated:** 2026-05-10
 
 ---
 
@@ -24,16 +24,16 @@ A dedicated context boundary addresses this without touching orchestration or pr
 
 ## Boundary And Responsibilities
 
-The service has a narrow job: turn surface-specific input into typed context blocks.
+The service has a narrow job: turn surface-specific input into a canonical context package.
 
 `ConversationContextService`:
 
 - Accepts surface-native turns and session metadata.
-- Attaches authority and stability metadata.
-- Exposes blocks to prompt assembly.
+- Attaches authority and stability metadata in structured envelope fields.
+- Returns runtime-facing `messages` plus a backend-owned `contextEnvelope`.
 - Fails open when context shaping is partial or unavailable.
 
-It will not assemble final model prompts or own supplemental context such as persona instructions. Persona-related blocks may carry hints or metadata, but persona instruction text stays with the prompt layer.
+The envelope may contain structured context blocks, but prompt layers remain responsible for final prompt placement and instruction ordering. The service will not assemble final model prompts or own supplemental context such as persona instructions.
 
 ---
 
@@ -63,7 +63,7 @@ Each "context block" should carry:
 - `content` as structured parts, not transcript wrappers
 - optional `redaction` or `consent` metadata
 
-This gives prompt assembly enough information to place blocks deliberately and explain those choices later.
+This gives envelope- and prompt-assembly code enough information to place context deliberately and explain those choices later.
 
 ---
 
@@ -122,9 +122,9 @@ This avoids accidental style bleed while preserving multi-party clarity.
 
 ---
 
-## Segmentation And Reduction
+## Future-Compatible Segmentation Metadata
 
-Conversation history should be represented as deterministic segments.
+Conversation history shape should leave room for deterministic segments, without requiring reduction behavior in the first implementation.
 
 Suggested segment model:
 
@@ -134,14 +134,14 @@ Suggested segment model:
 - `reductionLevel` (`full`, `compact`, `summary`)
 - `summaryRef` (optional pointer to persisted summary content)
 
-Deterministic reduction policy:
+Future reduction behavior may use policies such as:
 
 - Keep newest `N` turns unreduced.
 - Reduce older turns by segment age and token budget pressure.
 - Reuse existing summaries when `segmentId` is unchanged.
 - Only regenerate summaries when segment content or reduction config changes.
 
-This minimizes churn and creates a clean path for future cache-aware prompt assembly.
+This section is intentionally forward-looking. Initial implementation should not silently inherit summary-generation or cache orchestration behavior.
 
 ---
 
@@ -168,7 +168,7 @@ This should plug into the existing prompt path rather than replace it. The main 
 - `packages/backend/src/services/prompts/conversationPromptLayers.ts`
 - `packages/backend/src/services/chatOrchestrator.ts`
 
-`ConversationContextService` returns blocks. `conversationPromptLayers` still renders prompt text/messages and preserves policy-sensitive instruction order.
+`ConversationContextService` returns a canonical context package (`messages` + `contextEnvelope`). `conversationPromptLayers` still renders prompt text/messages and preserves policy-sensitive instruction order.
 
 Guardrails:
 
@@ -301,8 +301,8 @@ Track a small set of signals first:
 
 - prompt assembly fallback rate
 - context-to-message projection rate
-- summary reuse rate
-- token delta before/after reduction
+- block churn rate across turns
+- stable-token vs volatile-token estimate
 
 These are enough to validate the boundary without overcommitting to low-level cache internals.
 


### PR DESCRIPTION
## Summary
This PR upgrades the conversation-context proposal into a clear backend boundary contract for first implementation.

## What Changed
- Reworked `docs/proposals/proposal_conversation_context_boundary.md` from transcript-focused framing into a canonical context-package architecture.
- Defined explicit output contract: `ConversationContextService` returns runtime-facing `messages` plus backend-owned `contextEnvelope`.
- Added core invariants to constrain implementation:
  - one canonical conversation history source per request
  - deterministic projection from envelope metadata into model-visible text
  - prompt-layer authority for system/persona ordering
  - fail-open behavior when shaping fails
- Added deterministic rendering policies:
  - role-aligned messages (`system|user|assistant`)
  - temporal policy (session header + gap-based per-turn time)
  - explicit `speakerLabel` projection rules
- Clarified guardrails in prompt assembly to prevent duplicate history inclusion.
- Added forward-looking section for segmentation metadata and reduction compatibility while explicitly keeping summary/cache behavior out of first implementation scope.
- Updated acceptance criteria and starter metrics to align with v1 scope.

## Why
The immediate issue was transcript-format bleed (e.g., wrapper text leaking into model response style). The proposal now defines a strict boundary that preserves useful metadata (time, speaker identity, authority/visibility) without coupling generation to transcript prose. This keeps the backend/runtime seam stable and avoids the service becoming a second prompt system.

## Implementation Notes
- This PR is docs-only and does not change runtime behavior.
- The proposal now distinguishes clearly between:
  - generation channel: `messages`
  - semantics/control channel: `contextEnvelope`
- Structured context blocks remain valid as envelope-internal structures, while prompt layers remain responsible for final prompt placement and instruction ordering.
- Long-term cost goals (summary reuse, cache-aware assembly) are intentionally gated and not part of first-pass implementation requirements.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Updated conversation context service proposal with refined specifications, including deterministic rendering rules, segmentation metadata structure, type definitions, and acceptance criteria for improved clarity on service boundaries and integration patterns.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/footnote-ai/footnote/pull/354)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->