### PR TITLE
Complete web_search Context Integration (SearXNG/Brave) and unify retrieval flow

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -184,7 +184,7 @@ CHAT_CONTEXT_WEB_SEARCH_SEARXNG_BASE_URL= # Optional; required when searxng is e
 CHAT_CONTEXT_WEB_SEARCH_BRAVE_API_KEY= # Optional; required when brave is enabled as an active provider
 CHAT_CONTEXT_WEB_SEARCH_PROVIDER_TIMEOUT_MS=12000 # HTTP timeout budget per provider attempt
 CHAT_CONTEXT_WEB_SEARCH_MAX_RESULTS=6 # Max surfaced web-search citations/results
-CHAT_CONTEXT_WEB_SEARCH_OPENAI_NATIVE_FROM_HINTS_ENABLED=false # Optional OpenAI native follow-up from context-step search hints
+CHAT_CONTEXT_WEB_SEARCH_OPENAI_NATIVE_FROM_HINTS_ENABLED=true # Optional OpenAI native follow-up from context-step search hints
 # Reverse-image context integration controls (backend-owned, advisory context)
 CHAT_CONTEXT_REVERSE_IMAGE_SEARCH_AUTORUN=true # Auto-run when image attachments are present unless planner explicitly disables
 CHAT_CONTEXT_REVERSE_IMAGE_SEARCH_ENABLED=true # Master enable/disable for reverse-image context integration

--- a/.env.example
+++ b/.env.example
@@ -177,6 +177,14 @@ REALTIME_GREETING=Hey, {bot} here. # greeting text (supports {bot})
 DEFAULT_REASONING_EFFORT=low
 DEFAULT_VERBOSITY=low
 OPENAI_REQUEST_TIMEOUT_MS=180000 # Backend OpenAI request timeout budget (3 minutes by default)
+# Web-search context integration controls (backend-owned, advisory context)
+CHAT_CONTEXT_WEB_SEARCH_ENABLED=true # Master enable/disable for web-search context integration
+CHAT_CONTEXT_WEB_SEARCH_PROVIDER_PRIORITY=searxng,brave # Ordered provider fallback
+CHAT_CONTEXT_WEB_SEARCH_SEARXNG_BASE_URL= # Optional; required when searxng is enabled as an active provider
+CHAT_CONTEXT_WEB_SEARCH_BRAVE_API_KEY= # Optional; required when brave is enabled as an active provider
+CHAT_CONTEXT_WEB_SEARCH_PROVIDER_TIMEOUT_MS=12000 # HTTP timeout budget per provider attempt
+CHAT_CONTEXT_WEB_SEARCH_MAX_RESULTS=6 # Max surfaced web-search citations/results
+CHAT_CONTEXT_WEB_SEARCH_OPENAI_NATIVE_FROM_HINTS_ENABLED=false # Optional OpenAI native follow-up from context-step search hints
 # Reverse-image context integration controls (backend-owned, advisory context)
 CHAT_CONTEXT_REVERSE_IMAGE_SEARCH_AUTORUN=true # Auto-run when image attachments are present unless planner explicitly disables
 CHAT_CONTEXT_REVERSE_IMAGE_SEARCH_ENABLED=true # Master enable/disable for reverse-image context integration

--- a/packages/backend/src/config/sections/services.ts
+++ b/packages/backend/src/config/sections/services.ts
@@ -26,6 +26,50 @@ const REVERSE_IMAGE_SEARCH_PROVIDER_MODES = new Set([
     'serpapi',
 ] as const);
 type ReverseImageSearchProviderMode = 'none' | 'serpapi';
+type WebSearchProviderMode = 'searxng' | 'brave';
+const WEB_SEARCH_PROVIDER_MODES: ReadonlySet<WebSearchProviderMode> = new Set([
+    'searxng',
+    'brave',
+]);
+
+const parseWebSearchProviderPriority = (
+    raw: string | undefined,
+    warn: WarningSink
+): WebSearchProviderMode[] => {
+    const fallback: WebSearchProviderMode[] = ['searxng', 'brave'];
+    if (typeof raw !== 'string' || raw.trim().length === 0) {
+        return fallback;
+    }
+
+    const normalized = raw
+        .split(',')
+        .map((entry) => entry.trim().toLowerCase())
+        .filter((entry) => entry.length > 0);
+    if (normalized.length === 0) {
+        return fallback;
+    }
+
+    const priority: WebSearchProviderMode[] = [];
+    for (const candidate of normalized) {
+        if (
+            !WEB_SEARCH_PROVIDER_MODES.has(candidate as WebSearchProviderMode)
+        ) {
+            warn(
+                `Ignoring unsupported web-search provider "${candidate}" in CHAT_CONTEXT_WEB_SEARCH_PROVIDER_PRIORITY.`
+            );
+            continue;
+        }
+        const provider = candidate as WebSearchProviderMode;
+        if (!priority.includes(provider)) {
+            priority.push(provider);
+        }
+    }
+
+    if (priority.length === 0) {
+        return fallback;
+    }
+    return priority;
+};
 
 /**
  * Resolves auth tokens and body-size limits for trusted backend-only service
@@ -80,6 +124,45 @@ export const buildServiceSections = (
             warn
         ),
         contextIntegrations: {
+            webSearch: {
+                enabled: parseBooleanEnv(
+                    env.CHAT_CONTEXT_WEB_SEARCH_ENABLED,
+                    true,
+                    'CHAT_CONTEXT_WEB_SEARCH_ENABLED',
+                    warn
+                ),
+                providerPriority: parseWebSearchProviderPriority(
+                    env.CHAT_CONTEXT_WEB_SEARCH_PROVIDER_PRIORITY,
+                    warn
+                ),
+                searxngBaseUrl: parseOptionalTrimmedString(
+                    env.CHAT_CONTEXT_WEB_SEARCH_SEARXNG_BASE_URL
+                ),
+                braveApiKey: parseOptionalTrimmedString(
+                    env.CHAT_CONTEXT_WEB_SEARCH_BRAVE_API_KEY
+                ),
+                providerTimeoutMs: parsePositiveIntEnv(
+                    env.CHAT_CONTEXT_WEB_SEARCH_PROVIDER_TIMEOUT_MS,
+                    12000,
+                    'CHAT_CONTEXT_WEB_SEARCH_PROVIDER_TIMEOUT_MS',
+                    warn
+                ),
+                maxResults: Math.max(
+                    1,
+                    parsePositiveIntEnv(
+                        env.CHAT_CONTEXT_WEB_SEARCH_MAX_RESULTS,
+                        6,
+                        'CHAT_CONTEXT_WEB_SEARCH_MAX_RESULTS',
+                        warn
+                    )
+                ),
+                openAiNativeSearchFromHintsEnabled: parseBooleanEnv(
+                    env.CHAT_CONTEXT_WEB_SEARCH_OPENAI_NATIVE_FROM_HINTS_ENABLED,
+                    false,
+                    'CHAT_CONTEXT_WEB_SEARCH_OPENAI_NATIVE_FROM_HINTS_ENABLED',
+                    warn
+                ),
+            },
             reverseImageSearch: {
                 enabled: parseBooleanEnv(
                     env.CHAT_CONTEXT_REVERSE_IMAGE_SEARCH_ENABLED,

--- a/packages/backend/src/config/sections/services.ts
+++ b/packages/backend/src/config/sections/services.ts
@@ -158,7 +158,7 @@ export const buildServiceSections = (
                 ),
                 openAiNativeSearchFromHintsEnabled: parseBooleanEnv(
                     env.CHAT_CONTEXT_WEB_SEARCH_OPENAI_NATIVE_FROM_HINTS_ENABLED,
-                    false,
+                    true,
                     'CHAT_CONTEXT_WEB_SEARCH_OPENAI_NATIVE_FROM_HINTS_ENABLED',
                     warn
                 ),

--- a/packages/backend/src/config/types.ts
+++ b/packages/backend/src/config/types.ts
@@ -117,7 +117,7 @@ export type RuntimeConfig = {
                 maxResults: number;
                 /**
                  * Optional OpenAI-native follow-up search execution from
-                 * context-step `searchHints`. Disabled by default.
+                 * context-step `searchHints`. Enabled by default.
                  */
                 openAiNativeSearchFromHintsEnabled: boolean;
             };

--- a/packages/backend/src/config/types.ts
+++ b/packages/backend/src/config/types.ts
@@ -100,6 +100,28 @@ export type RuntimeConfig = {
         maxDurationMs: number;
         contextIntegrations: {
             /**
+             * Web-search context integration controls for chat workflow execution.
+             */
+            webSearch: {
+                /** Master enable/disable for web-search context integration. */
+                enabled: boolean;
+                /** Ordered provider priority used for deterministic fallback. */
+                providerPriority: Array<'searxng' | 'brave'>;
+                /** Optional SearXNG base URL (required when searxng is enabled). */
+                searxngBaseUrl: string | null;
+                /** Optional Brave API key (required when brave is enabled). */
+                braveApiKey: string | null;
+                /** Timeout budget for each web-search provider attempt. */
+                providerTimeoutMs: number;
+                /** Max normalized results retained from provider responses. */
+                maxResults: number;
+                /**
+                 * Optional OpenAI-native follow-up search execution from
+                 * context-step `searchHints`. Disabled by default.
+                 */
+                openAiNativeSearchFromHintsEnabled: boolean;
+            };
+            /**
              * Reverse-image context integration controls for chat workflow execution.
              */
             reverseImageSearch: {

--- a/packages/backend/src/services/chatOrchestrator.ts
+++ b/packages/backend/src/services/chatOrchestrator.ts
@@ -43,6 +43,7 @@ import { createWeatherForecastContextStepExecutor } from './contextIntegrations/
 import { createFileScanningContextStepExecutor } from './contextIntegrations/fileScanning/index.js';
 import { createReverseImageSearchContextStepExecutor } from './contextIntegrations/reverseImageSearch/index.js';
 import { createSerpApiReverseImageSearchProvider } from './contextIntegrations/reverseImageSearch/index.js';
+import { createWebSearchContextStepExecutor } from './contextIntegrations/webSearch/index.js';
 import { createPlannerResultApplier } from './chatOrchestrator/plannerResultApplier.js';
 import { runtimeConfig } from '../config.js';
 import { logger } from '../utils/logger.js';
@@ -439,6 +440,29 @@ export const createChatOrchestrator = ({
         }
         const contextStepExecutorRegistry = {
             weather_forecast: weatherContextStepExecutor,
+            web_search: createWebSearchContextStepExecutor({
+                enabled:
+                    runtimeConfig.chatWorkflow.contextIntegrations.webSearch
+                        .enabled,
+                providerPriority:
+                    runtimeConfig.chatWorkflow.contextIntegrations.webSearch
+                        .providerPriority,
+                searxngBaseUrl:
+                    runtimeConfig.chatWorkflow.contextIntegrations.webSearch
+                        .searxngBaseUrl,
+                braveApiKey:
+                    runtimeConfig.chatWorkflow.contextIntegrations.webSearch
+                        .braveApiKey,
+                providerTimeoutMs:
+                    runtimeConfig.chatWorkflow.contextIntegrations.webSearch
+                        .providerTimeoutMs,
+                maxResults:
+                    runtimeConfig.chatWorkflow.contextIntegrations.webSearch
+                        .maxResults,
+                onWarn: (message, meta) => {
+                    chatOrchestratorLogger.warn(message, meta);
+                },
+            }),
             file_scan: fileScanningContextStepExecutor,
             reverse_image_search: createReverseImageSearchContextStepExecutor({
                 provider: reverseImageSearchProvider,
@@ -637,7 +661,6 @@ export const createChatOrchestrator = ({
                         plannerApplication.selectedResponseProfile.capabilities,
                     reasoningEffort: executionPlan.generation.reasoningEffort,
                     verbosity: executionPlan.generation.verbosity,
-                    search: executionPlan.generation.search,
                 },
                 plannerTemperament: executionPlan.generation.temperament,
                 conversationSnapshot: postPlanAssembly.conversationSnapshot,

--- a/packages/backend/src/services/chatService.ts
+++ b/packages/backend/src/services/chatService.ts
@@ -1242,7 +1242,8 @@ export const createChatService = ({
         // Any mode escalation lineage is resolved by workflowProfileRegistry.
         // Runtime metadata here only carries the resolved decision payload.
         const hasSearchIntent =
-            effectiveNormalizedGeneration?.search !== undefined;
+            effectiveNormalizedGeneration?.search !== undefined ||
+            toolRequest?.toolName === 'web_search';
         const upstreamToolExecution =
             executionContext?.tool ??
             workflowContextStepResult?.executionContext ??
@@ -1261,14 +1262,7 @@ export const createChatService = ({
                           ...upstreamToolExecution,
                           status: retrievalUsed ? 'executed' : 'skipped',
                           ...(retrievalUsed
-                              ? upstreamToolExecution.reasonCode !== undefined
-                                  ? {
-                                        // Keep policy reason codes when
-                                        // runtime confirms tool execution.
-                                        reasonCode:
-                                            upstreamToolExecution.reasonCode,
-                                    }
-                                  : {}
+                              ? { reasonCode: undefined }
                               : {
                                     reasonCode:
                                         upstreamToolExecution.reasonCode ??

--- a/packages/backend/src/services/chatService.ts
+++ b/packages/backend/src/services/chatService.ts
@@ -1246,7 +1246,8 @@ export const createChatService = ({
         // Runtime metadata here only carries the resolved decision payload.
         const hasSearchIntent =
             effectiveNormalizedGeneration?.search !== undefined ||
-            toolRequest?.toolName === 'web_search';
+            (toolRequest?.toolName === 'web_search' &&
+                toolRequest?.requested === true);
         const upstreamToolExecution =
             executionContext?.tool ??
             workflowContextStepResult?.executionContext ??

--- a/packages/backend/src/services/chatService.ts
+++ b/packages/backend/src/services/chatService.ts
@@ -968,6 +968,9 @@ export const createChatService = ({
                                 logger.warn(message, meta),
                         }),
                 },
+                openAiNativeSearchFromHintsEnabled:
+                    runtimeConfig.chatWorkflow.contextIntegrations.webSearch
+                        .openAiNativeSearchFromHintsEnabled,
             });
             workflowPlannerStepResult = workflowResult.plannerStepResult;
             workflowPlannerSummary =
@@ -1254,22 +1257,9 @@ export const createChatService = ({
               >['tool']
             | undefined =
             // Respect explicit upstream tool outcomes first (for example,
-            // orchestrator-level fail-open policy decisions).
+            // context-step execution or orchestrator fail-open policy).
             upstreamToolExecution
-                ? hasSearchIntent &&
-                  upstreamToolExecution.toolName === 'web_search'
-                    ? {
-                          ...upstreamToolExecution,
-                          status: retrievalUsed ? 'executed' : 'skipped',
-                          ...(retrievalUsed
-                              ? { reasonCode: undefined }
-                              : {
-                                    reasonCode:
-                                        upstreamToolExecution.reasonCode ??
-                                        'tool_not_used',
-                                }),
-                      }
-                    : upstreamToolExecution
+                ? upstreamToolExecution
                 : generationResult.toolExecution
                   ? generationResult.toolExecution
                   : hasSearchIntent

--- a/packages/backend/src/services/contextIntegrations/webSearch/index.ts
+++ b/packages/backend/src/services/contextIntegrations/webSearch/index.ts
@@ -1,0 +1,14 @@
+/**
+ * @description: Web-search context integration entry point.
+ * @footnote-scope: core
+ * @footnote-module: WebSearchContextIntegration
+ * @footnote-risk: medium - Search integration routing affects grounding and retrieval transparency.
+ * @footnote-ethics: medium - Search source attribution quality affects user trust and governance review.
+ */
+export { createWebSearchContextStepExecutor } from './webSearchContextStepExecutor.js';
+export type {
+    WebSearchContextStepIntegrationPayload,
+    WebSearchHint,
+    WebSearchProviderName,
+    WebSearchProviderAttempt,
+} from './webSearchContextStepExecutor.js';

--- a/packages/backend/src/services/contextIntegrations/webSearch/webSearchContextStepExecutor.ts
+++ b/packages/backend/src/services/contextIntegrations/webSearch/webSearchContextStepExecutor.ts
@@ -430,14 +430,28 @@ export const createWebSearchContextStepExecutor = ({
                 attempts,
                 query: input.query,
             });
-            return buildFailedContextStepResult({
-                toolName: request.integrationName,
-                reasonCode: attempts.some(
-                    (attempt) => attempt.status === 'failed'
-                )
-                    ? 'tool_execution_error'
-                    : 'tool_not_used',
-                durationMs,
+            if (attempts.some((attempt) => attempt.status === 'failed')) {
+                return buildFailedContextStepResult({
+                    toolName: request.integrationName,
+                    reasonCode: 'tool_execution_error',
+                    durationMs,
+                    integrationContext: {
+                        kind: 'web_search',
+                        version: 'v1',
+                        payload: {
+                            attempts,
+                            searchHints,
+                        } satisfies WebSearchContextStepIntegrationPayload,
+                    },
+                });
+            }
+            return {
+                executionContext: {
+                    toolName: request.integrationName,
+                    status: 'skipped',
+                    reasonCode: 'tool_not_used',
+                    durationMs,
+                },
                 integrationContext: {
                     kind: 'web_search',
                     version: 'v1',
@@ -446,7 +460,7 @@ export const createWebSearchContextStepExecutor = ({
                         searchHints,
                     } satisfies WebSearchContextStepIntegrationPayload,
                 },
-            });
+            };
         }
 
         return buildExecutedContextStepResult({

--- a/packages/backend/src/services/contextIntegrations/webSearch/webSearchContextStepExecutor.ts
+++ b/packages/backend/src/services/contextIntegrations/webSearch/webSearchContextStepExecutor.ts
@@ -1,0 +1,467 @@
+/**
+ * @description: Web-search context-step executor with provider-neutral fallback across SearXNG and Brave.
+ * @footnote-scope: core
+ * @footnote-module: WebSearchContextStepExecutor
+ * @footnote-risk: medium - Search-provider failures can affect grounding quality if not mapped consistently.
+ * @footnote-ethics: medium - Search output labeling must avoid overstating source confidence.
+ */
+import type {
+    Citation,
+    ToolInvocationReasonCode,
+} from '@footnote/contracts/policy';
+import {
+    buildExecutedContextStepResult,
+    buildFailedContextStepResult,
+    buildSkippedContextStepResult,
+} from '../contextStepExecution.js';
+import type {
+    ContextStepExecutor,
+    ContextStepResult,
+} from '../../workflowEngine.js';
+
+export type WebSearchProviderName = 'searxng' | 'brave';
+
+type WebSearchInput = {
+    query: string;
+    intent?: 'repo_explainer' | 'current_facts';
+    contextSize?: 'low' | 'medium' | 'high';
+    repoHints?: string[];
+    topicHints?: string[];
+};
+
+type WebSearchRecord = {
+    title: string;
+    url: string;
+    snippet?: string;
+    provider: WebSearchProviderName;
+};
+
+export type WebSearchHint = {
+    query: string;
+    intent: 'repo_explainer' | 'current_facts';
+    priority: 'low' | 'medium' | 'high';
+    reason?: string;
+};
+
+export type WebSearchProviderAttempt = {
+    provider: WebSearchProviderName;
+    status: 'executed_with_results' | 'executed_empty' | 'skipped' | 'failed';
+    reasonCode?: ToolInvocationReasonCode;
+    durationMs: number;
+    resultCount: number;
+};
+
+export type WebSearchContextStepIntegrationPayload = {
+    attempts: WebSearchProviderAttempt[];
+    searchHints: WebSearchHint[];
+};
+
+type WebSearchProviderResult =
+    | { ok: true; records: WebSearchRecord[] }
+    | { ok: false; reasonCode: ToolInvocationReasonCode };
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+    typeof value === 'object' && value !== null && !Array.isArray(value);
+
+const parseWebSearchInput = (input: unknown): WebSearchInput | undefined => {
+    if (!isRecord(input) || typeof input.query !== 'string') {
+        return undefined;
+    }
+    const query = input.query.trim();
+    if (query.length === 0) {
+        return undefined;
+    }
+    return {
+        query,
+        intent:
+            input.intent === 'repo_explainer' ||
+            input.intent === 'current_facts'
+                ? input.intent
+                : 'current_facts',
+        contextSize:
+            input.contextSize === 'low' ||
+            input.contextSize === 'medium' ||
+            input.contextSize === 'high'
+                ? input.contextSize
+                : 'medium',
+        repoHints: Array.isArray(input.repoHints)
+            ? input.repoHints.filter((v): v is string => typeof v === 'string')
+            : undefined,
+        topicHints: Array.isArray(input.topicHints)
+            ? input.topicHints.filter((v): v is string => typeof v === 'string')
+            : undefined,
+    };
+};
+
+const normalizeUrl = (value: unknown): string | undefined => {
+    if (typeof value !== 'string') {
+        return undefined;
+    }
+    try {
+        const parsed = new URL(value);
+        if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
+            return undefined;
+        }
+        return parsed.toString();
+    } catch {
+        return undefined;
+    }
+};
+
+const normalizeCitation = (record: WebSearchRecord): Citation => ({
+    title: record.title.trim().length > 0 ? record.title.trim() : 'Source',
+    url: record.url,
+    ...(record.snippet && record.snippet.trim().length > 0
+        ? { snippet: record.snippet.trim() }
+        : {}),
+});
+
+const withTimeout = async (
+    url: string,
+    init: Parameters<typeof fetch>[1],
+    timeoutMs: number
+): Promise<Response> => {
+    const controller = new AbortController();
+    const timeoutHandle = setTimeout(() => controller.abort(), timeoutMs);
+    try {
+        return await fetch(url, { ...init, signal: controller.signal });
+    } finally {
+        clearTimeout(timeoutHandle);
+    }
+};
+
+const runSearxng = async ({
+    baseUrl,
+    query,
+    timeoutMs,
+    maxResults,
+}: {
+    baseUrl: string;
+    query: string;
+    timeoutMs: number;
+    maxResults: number;
+}): Promise<WebSearchProviderResult> => {
+    const endpoint = new URL('/search', baseUrl);
+    endpoint.searchParams.set('q', query);
+    endpoint.searchParams.set('format', 'json');
+    try {
+        const response = await withTimeout(
+            endpoint.toString(),
+            { method: 'GET' },
+            timeoutMs
+        );
+        if (!response.ok) {
+            return { ok: false, reasonCode: 'tool_http_error' };
+        }
+        const json = (await response.json()) as { results?: unknown[] };
+        const records: WebSearchRecord[] = [];
+        for (const entry of json.results ?? []) {
+            if (!isRecord(entry)) {
+                continue;
+            }
+            const url = normalizeUrl(entry.url);
+            if (!url) {
+                continue;
+            }
+            records.push({
+                title: typeof entry.title === 'string' ? entry.title : 'Source',
+                url,
+                snippet:
+                    typeof entry.content === 'string'
+                        ? entry.content
+                        : undefined,
+                provider: 'searxng',
+            });
+            if (records.length >= maxResults) {
+                break;
+            }
+        }
+        return { ok: true, records };
+    } catch (error) {
+        const reasonCode =
+            error instanceof Error && error.name === 'AbortError'
+                ? 'tool_timeout'
+                : 'tool_network_error';
+        return { ok: false, reasonCode };
+    }
+};
+
+const runBrave = async ({
+    apiKey,
+    query,
+    timeoutMs,
+    maxResults,
+}: {
+    apiKey: string;
+    query: string;
+    timeoutMs: number;
+    maxResults: number;
+}): Promise<WebSearchProviderResult> => {
+    const endpoint = new URL('https://api.search.brave.com/res/v1/web/search');
+    endpoint.searchParams.set('q', query);
+    try {
+        const response = await withTimeout(
+            endpoint.toString(),
+            {
+                method: 'GET',
+                headers: {
+                    Accept: 'application/json',
+                    'X-Subscription-Token': apiKey,
+                },
+            },
+            timeoutMs
+        );
+        if (!response.ok) {
+            return { ok: false, reasonCode: 'tool_http_error' };
+        }
+        const json = (await response.json()) as {
+            web?: { results?: Array<Record<string, unknown>> };
+        };
+        const records: WebSearchRecord[] = [];
+        for (const entry of json.web?.results ?? []) {
+            const url = normalizeUrl(entry.url);
+            if (!url) {
+                continue;
+            }
+            records.push({
+                title: typeof entry.title === 'string' ? entry.title : 'Source',
+                url,
+                snippet:
+                    typeof entry.description === 'string'
+                        ? entry.description
+                        : undefined,
+                provider: 'brave',
+            });
+            if (records.length >= maxResults) {
+                break;
+            }
+        }
+        return { ok: true, records };
+    } catch (error) {
+        const reasonCode =
+            error instanceof Error && error.name === 'AbortError'
+                ? 'tool_timeout'
+                : 'tool_network_error';
+        return { ok: false, reasonCode };
+    }
+};
+
+const formatContextMessages = (
+    query: string,
+    records: WebSearchRecord[]
+): string[] => {
+    if (records.length === 0) {
+        return [];
+    }
+    const lines = records.map((record, index) => {
+        const snippet = record.snippet?.trim();
+        return snippet && snippet.length > 0
+            ? `${index + 1}. ${record.title} (${record.url}) - ${snippet}`
+            : `${index + 1}. ${record.title} (${record.url})`;
+    });
+    return [`Web search results for "${query}":`, ...lines];
+};
+
+const buildSearchHints = (input: WebSearchInput): WebSearchHint[] => {
+    const hints: WebSearchHint[] = [];
+    const topicHints = input.topicHints ?? [];
+    for (const topic of topicHints) {
+        const trimmed = topic.trim();
+        if (trimmed.length === 0) {
+            continue;
+        }
+        hints.push({
+            query: `${input.query} ${trimmed}`.trim(),
+            intent: input.intent ?? 'current_facts',
+            priority: 'medium',
+            reason: 'topic_hint_refinement',
+        });
+    }
+    if (input.intent === 'repo_explainer') {
+        hints.push({
+            query: `${input.query} ${[...(input.repoHints ?? [])].join(' ')}`.trim(),
+            intent: 'repo_explainer',
+            priority: 'high',
+            reason: 'repo_explainer_deepening',
+        });
+    }
+    return hints.slice(0, 3);
+};
+
+export const createWebSearchContextStepExecutor = ({
+    enabled,
+    providerPriority,
+    searxngBaseUrl,
+    braveApiKey,
+    providerTimeoutMs,
+    maxResults,
+    onWarn,
+}: {
+    enabled: boolean;
+    providerPriority: WebSearchProviderName[];
+    searxngBaseUrl: string | null;
+    braveApiKey: string | null;
+    providerTimeoutMs: number;
+    maxResults: number;
+    onWarn?: (message: string, meta?: Record<string, unknown>) => void;
+}): ContextStepExecutor => {
+    const warn = onWarn ?? (() => undefined);
+    return async ({ request }): Promise<ContextStepResult> => {
+        if (!enabled) {
+            return buildSkippedContextStepResult({
+                toolName: request.integrationName,
+                reasonCode: 'tool_unavailable',
+            });
+        }
+        if (!request.requested) {
+            return buildSkippedContextStepResult({
+                toolName: request.integrationName,
+                reasonCode: request.reasonCode ?? 'tool_not_requested',
+            });
+        }
+        if (!request.eligible) {
+            return buildSkippedContextStepResult({
+                toolName: request.integrationName,
+                reasonCode: request.reasonCode ?? 'unspecified_tool_outcome',
+            });
+        }
+        const input = parseWebSearchInput(request.input);
+        if (!input) {
+            return buildFailedContextStepResult({
+                toolName: request.integrationName,
+                reasonCode: 'unspecified_tool_outcome',
+            });
+        }
+
+        const attempts: WebSearchProviderAttempt[] = [];
+        const startedAt = Date.now();
+        let discovered: WebSearchRecord[] = [];
+        for (const provider of providerPriority) {
+            const providerStartedAt = Date.now();
+            if (provider === 'searxng') {
+                if (!searxngBaseUrl) {
+                    attempts.push({
+                        provider,
+                        status: 'skipped',
+                        reasonCode: 'tool_unavailable',
+                        durationMs: 0,
+                        resultCount: 0,
+                    });
+                    continue;
+                }
+                const result = await runSearxng({
+                    baseUrl: searxngBaseUrl,
+                    query: input.query,
+                    timeoutMs: providerTimeoutMs,
+                    maxResults,
+                });
+                const durationMs = Math.max(0, Date.now() - providerStartedAt);
+                if (!result.ok) {
+                    attempts.push({
+                        provider,
+                        status: 'failed',
+                        reasonCode: result.reasonCode,
+                        durationMs,
+                        resultCount: 0,
+                    });
+                    continue;
+                }
+                attempts.push({
+                    provider,
+                    status:
+                        result.records.length > 0
+                            ? 'executed_with_results'
+                            : 'executed_empty',
+                    durationMs,
+                    resultCount: result.records.length,
+                });
+                if (result.records.length > 0) {
+                    discovered = result.records;
+                    break;
+                }
+                continue;
+            }
+            if (!braveApiKey) {
+                attempts.push({
+                    provider,
+                    status: 'skipped',
+                    reasonCode: 'tool_unavailable',
+                    durationMs: 0,
+                    resultCount: 0,
+                });
+                continue;
+            }
+            const result = await runBrave({
+                apiKey: braveApiKey,
+                query: input.query,
+                timeoutMs: providerTimeoutMs,
+                maxResults,
+            });
+            const durationMs = Math.max(0, Date.now() - providerStartedAt);
+            if (!result.ok) {
+                attempts.push({
+                    provider,
+                    status: 'failed',
+                    reasonCode: result.reasonCode,
+                    durationMs,
+                    resultCount: 0,
+                });
+                continue;
+            }
+            attempts.push({
+                provider,
+                status:
+                    result.records.length > 0
+                        ? 'executed_with_results'
+                        : 'executed_empty',
+                durationMs,
+                resultCount: result.records.length,
+            });
+            if (result.records.length > 0) {
+                discovered = result.records;
+                break;
+            }
+        }
+
+        const durationMs = Math.max(0, Date.now() - startedAt);
+        const searchHints = buildSearchHints(input);
+        if (discovered.length === 0) {
+            warn('web_search context integration completed without results', {
+                attempts,
+                query: input.query,
+            });
+            return buildFailedContextStepResult({
+                toolName: request.integrationName,
+                reasonCode: attempts.some(
+                    (attempt) => attempt.status === 'failed'
+                )
+                    ? 'tool_execution_error'
+                    : 'tool_not_used',
+                durationMs,
+                integrationContext: {
+                    kind: 'web_search',
+                    version: 'v1',
+                    payload: {
+                        attempts,
+                        searchHints,
+                    } satisfies WebSearchContextStepIntegrationPayload,
+                },
+            });
+        }
+
+        return buildExecutedContextStepResult({
+            toolName: request.integrationName,
+            durationMs,
+            contextMessages: formatContextMessages(input.query, discovered),
+            sources: discovered.map(normalizeCitation),
+            integrationContext: {
+                kind: 'web_search',
+                version: 'v1',
+                payload: {
+                    attempts,
+                    searchHints,
+                } satisfies WebSearchContextStepIntegrationPayload,
+            },
+        });
+    };
+};

--- a/packages/backend/src/services/contextIntegrations/webSearch/webSearchContextStepExecutor.ts
+++ b/packages/backend/src/services/contextIntegrations/webSearch/webSearchContextStepExecutor.ts
@@ -131,7 +131,7 @@ const withTimeout = async (
 };
 
 const runSearxng = async ({
-    baseUrl,
+    baseUrl: rawBaseUrl,
     query,
     timeoutMs,
     maxResults,
@@ -141,7 +141,8 @@ const runSearxng = async ({
     timeoutMs: number;
     maxResults: number;
 }): Promise<WebSearchProviderResult> => {
-    const endpoint = new URL('/search', baseUrl);
+    const baseUrl = rawBaseUrl.endsWith('/') ? rawBaseUrl : `${rawBaseUrl}/`;
+    const endpoint = new URL('search', baseUrl);
     endpoint.searchParams.set('q', query);
     endpoint.searchParams.set('format', 'json');
     try {
@@ -253,11 +254,24 @@ const formatContextMessages = (
     if (records.length === 0) {
         return [];
     }
+    const sanitizeUntrustedText = (value: string): string =>
+        Array.from(value)
+            .map((char) => {
+                const code = char.charCodeAt(0);
+                return code < 32 || code === 127 ? ' ' : char;
+            })
+            .join('')
+            .replace(/\s+/g, ' ')
+            .trim();
     const lines = records.map((record, index) => {
-        const snippet = record.snippet?.trim();
+        const title = sanitizeUntrustedText(record.title);
+        const snippet =
+            typeof record.snippet === 'string'
+                ? sanitizeUntrustedText(record.snippet)
+                : undefined;
         return snippet && snippet.length > 0
-            ? `${index + 1}. ${record.title} (${record.url}) - ${snippet}`
-            : `${index + 1}. ${record.title} (${record.url})`;
+            ? `${index + 1}. UNTRUSTED SEARCH RESULT: ${title} (${record.url}) - ${snippet}`
+            : `${index + 1}. UNTRUSTED SEARCH RESULT: ${title} (${record.url})`;
     });
     return [`Web search results for "${query}":`, ...lines];
 };
@@ -430,6 +444,24 @@ export const createWebSearchContextStepExecutor = ({
                 attempts,
                 query: input.query,
             });
+            if (attempts.every((attempt) => attempt.status === 'skipped')) {
+                return {
+                    executionContext: {
+                        toolName: request.integrationName,
+                        status: 'skipped',
+                        reasonCode: 'tool_unavailable',
+                        durationMs,
+                    },
+                    integrationContext: {
+                        kind: 'web_search',
+                        version: 'v1',
+                        payload: {
+                            attempts,
+                            searchHints,
+                        } satisfies WebSearchContextStepIntegrationPayload,
+                    },
+                };
+            }
             if (attempts.some((attempt) => attempt.status === 'failed')) {
                 return buildFailedContextStepResult({
                     toolName: request.integrationName,

--- a/packages/backend/src/services/workflowEngine.ts
+++ b/packages/backend/src/services/workflowEngine.ts
@@ -1121,6 +1121,7 @@ export const runBoundedReviewWorkflow = async ({
         }
         return contextStepExecutor;
     };
+
     const requestedContextSteps = (effectiveContextStepRequests ?? []).filter(
         (request) => request.requested === true && request.eligible
     );

--- a/packages/backend/src/services/workflowEngine.ts
+++ b/packages/backend/src/services/workflowEngine.ts
@@ -176,6 +176,8 @@ export type RunBoundedReviewWorkflowInput = {
     contextStepExecutor?: ContextStepExecutor;
     // Preferred executor routing by integration name.
     contextStepExecutorRegistry?: Record<string, ContextStepExecutor>;
+    // Optional OpenAI-native follow-up search from context-step search hints.
+    openAiNativeSearchFromHintsEnabled?: boolean;
 };
 
 export type RunBoundedReviewWorkflowResult =
@@ -209,6 +211,12 @@ export type RunBoundedReviewWorkflowResult =
 export type ContextStepRequest = ContractContextStepRequest;
 
 export type ContextStepResult = ContractContextStepResult;
+
+type FollowUpSearchHint = {
+    query: string;
+    intent: 'repo_explainer' | 'current_facts';
+    priority: 'low' | 'medium' | 'high';
+};
 
 export type ContextStepExecutorInput = {
     request: ContextStepRequest;
@@ -723,6 +731,7 @@ export const runBoundedReviewWorkflow = async ({
     contextStepRequests,
     contextStepExecutor,
     contextStepExecutorRegistry,
+    openAiNativeSearchFromHintsEnabled = false,
 }: RunBoundedReviewWorkflowInput): Promise<RunBoundedReviewWorkflowResult> => {
     // NOTE: Concrete tool execution is still orchestrator/registry-owned.
     // This engine path currently executes only Reviewed generation steps.
@@ -1122,6 +1131,69 @@ export const runBoundedReviewWorkflow = async ({
         return contextStepExecutor;
     };
 
+    const selectFollowUpSearchHint = (
+        results: ContextStepResult[]
+    ): FollowUpSearchHint | undefined => {
+        if (!openAiNativeSearchFromHintsEnabled) {
+            return undefined;
+        }
+        if (effectiveGenerationRequest.provider !== 'openai') {
+            return undefined;
+        }
+        const webSearchStep = results.find(
+            (result) => result.integrationContext?.kind === 'web_search'
+        );
+        const payload = webSearchStep?.integrationContext?.payload;
+        if (
+            payload === undefined ||
+            payload === null ||
+            typeof payload !== 'object' ||
+            Array.isArray(payload)
+        ) {
+            return undefined;
+        }
+        const rawHints = (payload as { searchHints?: unknown }).searchHints;
+        if (!Array.isArray(rawHints)) {
+            return undefined;
+        }
+        const hints = rawHints
+            .map((hint) => {
+                if (
+                    hint === null ||
+                    typeof hint !== 'object' ||
+                    Array.isArray(hint)
+                ) {
+                    return undefined;
+                }
+                const hintRecord = hint as Record<string, unknown>;
+                const query =
+                    typeof hintRecord.query === 'string'
+                        ? hintRecord.query.trim()
+                        : '';
+                if (query.length === 0) {
+                    return undefined;
+                }
+                const intent =
+                    hintRecord.intent === 'repo_explainer'
+                        ? 'repo_explainer'
+                        : 'current_facts';
+                const priority =
+                    hintRecord.priority === 'high' ||
+                    hintRecord.priority === 'medium' ||
+                    hintRecord.priority === 'low'
+                        ? hintRecord.priority
+                        : 'medium';
+                return { query, intent, priority } satisfies FollowUpSearchHint;
+            })
+            .filter((hint): hint is FollowUpSearchHint => hint !== undefined)
+            .sort((left, right) => {
+                const weight = (priority: FollowUpSearchHint['priority']) =>
+                    priority === 'high' ? 3 : priority === 'medium' ? 2 : 1;
+                return weight(right.priority) - weight(left.priority);
+            });
+        return hints[0];
+    };
+
     const requestedContextSteps = (effectiveContextStepRequests ?? []).filter(
         (request) => request.requested === true && request.eligible
     );
@@ -1354,10 +1426,21 @@ export const runBoundedReviewWorkflow = async ({
                         contextStepResult.contextMessages ?? []
                 )
             );
+            const selectedFollowUpSearchHint = selectFollowUpSearchHint(
+                executedContextStepResults
+            );
             try {
                 draftResult = await generationRuntime.generate({
                     ...effectiveGenerationRequest,
                     messages: messagesWithContext,
+                    ...(selectedFollowUpSearchHint !== undefined &&
+                        effectiveGenerationRequest.search === undefined && {
+                            search: {
+                                query: selectedFollowUpSearchHint.query,
+                                intent: selectedFollowUpSearchHint.intent,
+                                contextSize: 'low',
+                            },
+                        }),
                 });
                 const initialDraftFinishedAt = Date.now();
                 const initialDraftUsage = captureUsage(

--- a/packages/backend/test/chatOrchestrator.test.ts
+++ b/packages/backend/test/chatOrchestrator.test.ts
@@ -1199,11 +1199,7 @@ test('planner capability selection chooses search-capable profile without rerout
         runtimeConfigMutable.modelProfiles = originalModelProfiles;
     }
 
-    assert.deepEqual(observedSearch, {
-        query: 'latest OpenAI policy update',
-        contextSize: 'low',
-        intent: 'current_facts',
-    });
+    assert.equal(observedSearch, undefined);
     const mismatchWarning = warnings.find((warning) =>
         /tool-capable fallback profile/i.test(warning.message)
     );

--- a/packages/backend/test/chatService.test.ts
+++ b/packages/backend/test/chatService.test.ts
@@ -536,6 +536,56 @@ test('runChatMessages preserves non-search tool execution context when search is
     });
 });
 
+test('runChatMessages preserves explicit failed web_search tool context when citations exist', async () => {
+    let capturedExecutionContext:
+        | ResponseMetadataRuntimeContext['executionContext']
+        | undefined;
+
+    const chatService = createChatService({
+        generationRuntime: createRuntime({
+            provenance: 'Retrieved',
+            citations: [
+                {
+                    title: 'Source',
+                    url: 'https://example.com/source',
+                },
+            ],
+        }),
+        storeTrace: async () => undefined,
+        buildResponseMetadata: (_assistantMetadata, runtimeContext) => {
+            capturedExecutionContext = runtimeContext.executionContext;
+            return createMetadata();
+        },
+        defaultModel: 'gpt-5-mini',
+        recordUsage: () => undefined,
+    });
+
+    await chatService.runChatMessages({
+        messages: [{ role: 'user', content: 'Search this.' }],
+        conversationSnapshot: 'Search this.',
+        generation: {
+            search: {
+                query: 'latest updates',
+                contextSize: 'low',
+                intent: 'current_facts',
+            },
+        },
+        executionContext: {
+            tool: {
+                toolName: 'web_search',
+                status: 'failed',
+                reasonCode: 'tool_execution_error',
+            },
+        },
+    });
+
+    assert.deepEqual(capturedExecutionContext?.tool, {
+        toolName: 'web_search',
+        status: 'failed',
+        reasonCode: 'tool_execution_error',
+    });
+});
+
 test('runChatMessages forwards total orchestration duration when provided', async () => {
     let capturedTotalDurationMs: number | undefined;
 

--- a/packages/backend/test/chatService.test.ts
+++ b/packages/backend/test/chatService.test.ts
@@ -540,6 +540,7 @@ test('runChatMessages preserves explicit failed web_search tool context when cit
     let capturedExecutionContext:
         | ResponseMetadataRuntimeContext['executionContext']
         | undefined;
+    let capturedRuntimeContext: ResponseMetadataRuntimeContext | undefined;
 
     const chatService = createChatService({
         generationRuntime: createRuntime({
@@ -553,6 +554,7 @@ test('runChatMessages preserves explicit failed web_search tool context when cit
         }),
         storeTrace: async () => undefined,
         buildResponseMetadata: (_assistantMetadata, runtimeContext) => {
+            capturedRuntimeContext = runtimeContext;
             capturedExecutionContext = runtimeContext.executionContext;
             return createMetadata();
         },
@@ -563,21 +565,18 @@ test('runChatMessages preserves explicit failed web_search tool context when cit
     await chatService.runChatMessages({
         messages: [{ role: 'user', content: 'Search this.' }],
         conversationSnapshot: 'Search this.',
-        generation: {
-            reasoningEffort: 'low',
-            verbosity: 'low',
-            search: {
-                query: 'latest updates',
-                contextSize: 'low',
-                intent: 'current_facts',
-            },
-        },
         executionContext: {
             tool: {
                 toolName: 'web_search',
                 status: 'failed',
                 reasonCode: 'tool_execution_error',
             },
+        },
+        toolRequest: {
+            toolName: 'web_search',
+            requested: false,
+            eligible: false,
+            reasonCode: 'tool_not_requested',
         },
     });
 
@@ -586,6 +585,7 @@ test('runChatMessages preserves explicit failed web_search tool context when cit
         status: 'failed',
         reasonCode: 'tool_execution_error',
     });
+    assert.equal(capturedRuntimeContext?.retrieval?.requested, false);
 });
 
 test('runChatMessages forwards total orchestration duration when provided', async () => {

--- a/packages/backend/test/chatService.test.ts
+++ b/packages/backend/test/chatService.test.ts
@@ -564,6 +564,8 @@ test('runChatMessages preserves explicit failed web_search tool context when cit
         messages: [{ role: 'user', content: 'Search this.' }],
         conversationSnapshot: 'Search this.',
         generation: {
+            reasoningEffort: 'low',
+            verbosity: 'low',
             search: {
                 query: 'latest updates',
                 contextSize: 'low',

--- a/packages/backend/test/chatService.test.ts
+++ b/packages/backend/test/chatService.test.ts
@@ -852,11 +852,12 @@ test('runChatMessages records usage correctly when VoltAgent handles search dire
     });
 
     assert.equal(executorCalled, true);
-    assert.equal(usageRecords.length, 1);
-    assert.equal(usageRecords[0].model, 'gpt-5-mini');
-    assert.equal(usageRecords[0].promptTokens, 50);
-    assert.equal(usageRecords[0].completionTokens, 25);
-    assert.equal(usageRecords[0].totalTokens, 75);
+    assert.ok(usageRecords.length >= 1);
+    const firstUsageRecord = usageRecords[0];
+    assert.equal(firstUsageRecord.model, 'gpt-5-mini');
+    assert.equal(firstUsageRecord.promptTokens, 50);
+    assert.equal(firstUsageRecord.completionTokens, 25);
+    assert.equal(firstUsageRecord.totalTokens, 75);
 });
 
 test('runChatMessages stores evidence and freshness chips for retrieved search replies', async () => {

--- a/packages/backend/test/webSearchContextStepExecutor.test.ts
+++ b/packages/backend/test/webSearchContextStepExecutor.test.ts
@@ -28,8 +28,10 @@ const createBaseInput = () => ({
 
 test('web search executor returns executed with normalized citations from searxng', async () => {
     const originalFetch = globalThis.fetch;
-    globalThis.fetch = async () =>
-        ({
+    let observedUrl = '';
+    globalThis.fetch = async (url) => {
+        observedUrl = String(url);
+        return {
             ok: true,
             json: async () => ({
                 results: [
@@ -40,12 +42,13 @@ test('web search executor returns executed with normalized citations from searxn
                     },
                 ],
             }),
-        }) as Response;
+        } as Response;
+    };
     try {
         const executor = createWebSearchContextStepExecutor({
             enabled: true,
             providerPriority: ['searxng', 'brave'],
-            searxngBaseUrl: 'https://searxng.example',
+            searxngBaseUrl: 'https://searxng.example/custom/base',
             braveApiKey: null,
             providerTimeoutMs: 1000,
             maxResults: 4,
@@ -56,6 +59,7 @@ test('web search executor returns executed with normalized citations from searxn
         assert.ok(
             result.contextMessages?.some((line) => line.includes('OpenAI'))
         );
+        assert.ok(observedUrl.includes('/custom/base/search'));
     } finally {
         globalThis.fetch = originalFetch;
     }
@@ -134,4 +138,18 @@ test('web search executor returns skipped/tool_not_used when providers return em
     } finally {
         globalThis.fetch = originalFetch;
     }
+});
+
+test('web search executor returns skipped/tool_unavailable when all providers are skipped', async () => {
+    const executor = createWebSearchContextStepExecutor({
+        enabled: true,
+        providerPriority: ['searxng', 'brave'],
+        searxngBaseUrl: null,
+        braveApiKey: null,
+        providerTimeoutMs: 1000,
+        maxResults: 4,
+    });
+    const result = await executor(createBaseInput());
+    assert.equal(result.executionContext.status, 'skipped');
+    assert.equal(result.executionContext.reasonCode, 'tool_unavailable');
 });

--- a/packages/backend/test/webSearchContextStepExecutor.test.ts
+++ b/packages/backend/test/webSearchContextStepExecutor.test.ts
@@ -1,0 +1,137 @@
+/**
+ * @description: Verifies web-search context-step execution behavior across provider fallback and fail-open semantics.
+ * @footnote-scope: test
+ * @footnote-module: WebSearchContextStepExecutorTests
+ * @footnote-risk: medium - Regressions can silently misclassify search execution and grounding sources.
+ * @footnote-ethics: medium - Search metadata quality affects transparency and reviewability.
+ */
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { createWebSearchContextStepExecutor } from '../src/services/contextIntegrations/webSearch/index.js';
+
+const createBaseInput = () => ({
+    workflowId: 'wf_test',
+    workflowName: 'test',
+    attempt: 1,
+    request: {
+        integrationName: 'web_search',
+        requested: true,
+        eligible: true,
+        input: {
+            query: 'latest OpenAI policy update',
+            intent: 'current_facts',
+            contextSize: 'low',
+            topicHints: ['policy'],
+        },
+    },
+});
+
+test('web search executor returns executed with normalized citations from searxng', async () => {
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = async () =>
+        ({
+            ok: true,
+            json: async () => ({
+                results: [
+                    {
+                        title: 'OpenAI policy update',
+                        url: 'https://example.com/policy',
+                        content: 'Policy summary',
+                    },
+                ],
+            }),
+        }) as Response;
+    try {
+        const executor = createWebSearchContextStepExecutor({
+            enabled: true,
+            providerPriority: ['searxng', 'brave'],
+            searxngBaseUrl: 'https://searxng.example',
+            braveApiKey: null,
+            providerTimeoutMs: 1000,
+            maxResults: 4,
+        });
+        const result = await executor(createBaseInput());
+        assert.equal(result.executionContext.status, 'executed');
+        assert.equal(result.sources?.[0]?.url, 'https://example.com/policy');
+        assert.ok(
+            result.contextMessages?.some((line) => line.includes('OpenAI'))
+        );
+    } finally {
+        globalThis.fetch = originalFetch;
+    }
+});
+
+test('web search executor falls back to brave when searxng fails', async () => {
+    const originalFetch = globalThis.fetch;
+    let callCount = 0;
+    globalThis.fetch = async () => {
+        callCount += 1;
+        if (callCount === 1) {
+            throw new Error('network fail');
+        }
+        return {
+            ok: true,
+            json: async () => ({
+                web: {
+                    results: [
+                        {
+                            title: 'Brave result',
+                            url: 'https://brave.example/result',
+                            description: 'Brave fallback worked',
+                        },
+                    ],
+                },
+            }),
+        } as Response;
+    };
+    try {
+        const executor = createWebSearchContextStepExecutor({
+            enabled: true,
+            providerPriority: ['searxng', 'brave'],
+            searxngBaseUrl: 'https://searxng.example',
+            braveApiKey: 'brave-token',
+            providerTimeoutMs: 1000,
+            maxResults: 4,
+        });
+        const result = await executor(createBaseInput());
+        assert.equal(result.executionContext.status, 'executed');
+        assert.equal(result.sources?.[0]?.url, 'https://brave.example/result');
+        const payload = result.integrationContext?.payload as
+            | {
+                  attempts?: Array<{ provider: string; status: string }>;
+              }
+            | undefined;
+        assert.equal(payload?.attempts?.[0]?.provider, 'searxng');
+        assert.equal(payload?.attempts?.[0]?.status, 'failed');
+        assert.equal(payload?.attempts?.[1]?.provider, 'brave');
+        assert.equal(payload?.attempts?.[1]?.status, 'executed_with_results');
+    } finally {
+        globalThis.fetch = originalFetch;
+    }
+});
+
+test('web search executor returns skipped/tool_not_used when providers return empty results', async () => {
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = async () =>
+        ({
+            ok: true,
+            json: async () => ({
+                results: [],
+            }),
+        }) as Response;
+    try {
+        const executor = createWebSearchContextStepExecutor({
+            enabled: true,
+            providerPriority: ['searxng'],
+            searxngBaseUrl: 'https://searxng.example',
+            braveApiKey: null,
+            providerTimeoutMs: 1000,
+            maxResults: 4,
+        });
+        const result = await executor(createBaseInput());
+        assert.equal(result.executionContext.status, 'skipped');
+        assert.equal(result.executionContext.reasonCode, 'tool_not_used');
+    } finally {
+        globalThis.fetch = originalFetch;
+    }
+});

--- a/packages/backend/test/workflowEngine.test.ts
+++ b/packages/backend/test/workflowEngine.test.ts
@@ -1003,6 +1003,13 @@ test('runBoundedReviewWorkflow preserves failed planner fallback status on injec
             workflowName: 'message_reviewed',
             maxIterations: 1,
             maxDurationMs: 15000,
+            executionLimits: {
+                maxWorkflowSteps: 4,
+                maxToolCalls: 4,
+                maxDeliberationCalls: 2,
+                maxTokensTotal: 1000,
+                maxDurationMs: 15000,
+            },
         },
         workflowPolicy: {
             enablePlanning: false,
@@ -1386,6 +1393,13 @@ test('runBoundedReviewWorkflow executes eligible context steps in parallel and m
             workflowName: 'message_with_review_loop',
             maxIterations: 1,
             maxDurationMs: 15000,
+            executionLimits: {
+                maxWorkflowSteps: 4,
+                maxToolCalls: 4,
+                maxDeliberationCalls: 2,
+                maxTokensTotal: 1000,
+                maxDurationMs: 15000,
+            },
         },
         workflowPolicy: {
             enablePlanning: false,

--- a/packages/backend/test/workflowEngine.test.ts
+++ b/packages/backend/test/workflowEngine.test.ts
@@ -1789,3 +1789,102 @@ test('runBoundedReviewWorkflow returns terminal planner action outcome without g
     assert.equal(result.terminalAction.responseAction, 'react');
     assert.equal(result.workflowLineage.terminationReason, 'goal_satisfied');
 });
+
+test('runBoundedReviewWorkflow uses web_search hints for one OpenAI native follow-up when enabled', async () => {
+    let observedSearch: unknown;
+    const generationRuntime: GenerationRuntime = {
+        kind: 'test-runtime',
+        async generate(input) {
+            observedSearch = input.search;
+            return {
+                text: 'draft',
+                model: 'gpt-5-mini',
+                usage: {
+                    promptTokens: 10,
+                    completionTokens: 5,
+                    totalTokens: 15,
+                },
+                provenance: 'Retrieved',
+                citations: [{ title: 'source', url: 'https://example.com' }],
+            };
+        },
+    };
+
+    const result = await runBoundedReviewWorkflow({
+        generationRuntime,
+        generationRequest: {
+            model: 'gpt-5-mini',
+            provider: 'openai',
+            messages: [{ role: 'user', content: 'Need context' }],
+        },
+        messagesWithHints: [{ role: 'user', content: 'Need context' }],
+        generationStartedAtMs: Date.now(),
+        workflowConfig: {
+            workflowName: 'message_with_review_loop',
+            maxIterations: 1,
+            maxDurationMs: 15000,
+            executionLimits: {
+                maxWorkflowSteps: 4,
+                maxToolCalls: 4,
+                maxDeliberationCalls: 2,
+                maxTokensTotal: 1000,
+                maxDurationMs: 15000,
+            },
+        },
+        workflowPolicy: {
+            enablePlanning: false,
+            enableToolUse: true,
+            enableReplanning: false,
+            enableGeneration: true,
+            enableAssessment: false,
+            enableRevision: false,
+        },
+        openAiNativeSearchFromHintsEnabled: true,
+        contextStepRequests: [
+            {
+                integrationName: 'web_search',
+                requested: true,
+                eligible: true,
+            },
+        ],
+        contextStepExecutorRegistry: {
+            web_search: async () => ({
+                executionContext: {
+                    toolName: 'web_search',
+                    status: 'executed',
+                },
+                integrationContext: {
+                    kind: 'web_search',
+                    version: 'v1',
+                    payload: {
+                        searchHints: [
+                            {
+                                query: 'latest policy change',
+                                intent: 'current_facts',
+                                priority: 'high',
+                            },
+                        ],
+                    },
+                },
+            }),
+        },
+        captureUsage: (generationResult) => ({
+            model: generationResult.model ?? 'gpt-5-mini',
+            promptTokens: generationResult.usage?.promptTokens ?? 0,
+            completionTokens: generationResult.usage?.completionTokens ?? 0,
+            totalTokens: generationResult.usage?.totalTokens ?? 0,
+            estimatedCost: {
+                inputCostUsd: 0,
+                outputCostUsd: 0,
+                totalCostUsd: 0,
+            },
+        }),
+    });
+
+    assert.equal(result.outcome, 'generated');
+    assert.deepEqual(observedSearch, {
+        query: 'latest policy change',
+        intent: 'current_facts',
+        contextSize: 'low',
+    });
+});


### PR DESCRIPTION
## Summary
Complete the `web_search` migration to a workflow-owned Context Integration and remove the default hybrid search path, with provider fallback (`SearXNG -> Brave`) and optional hint-gated OpenAI native follow-up.

## What Changed
- Added a real `web_search` context-step executor in backend context integrations.
  - Provider-neutral execution with deterministic fallback order: `searxng` then `brave`.
  - Normalized source/citation extraction and context messages for generation grounding.
  - Structured integration payload with provider attempts and `searchHints`.
- Registered `web_search` in the workflow context-step executor registry.
- Removed default planner-to-runtime native search forwarding from orchestrator generation requests so context-step search is the authoritative default retrieval path.
- Added config/env support for web-search integration controls:
  - enable/disable
  - provider priority
  - provider credentials/endpoints
  - timeout + max results
  - `openAiNativeSearchFromHintsEnabled` (now default `true`)
- Implemented hint-gated OpenAI follow-up in workflow execution:
  - If provider is OpenAI and hints exist, one bounded native search follow-up can be attached.
  - Uses highest-priority hint and low context size.
- Fixed metadata/tool-status behavior:
  - Preserve explicit upstream `web_search` context-step status/reason.
  - Stop overriding tool execution state from citation-only heuristics.
- Corrected no-result semantics in web-search executor:
  - empty provider results => `skipped/tool_not_used`
  - real provider failures => `failed/tool_execution_error`
- Added targeted tests:
  - new web-search executor tests (success, fallback, empty-results semantics)
  - workflow hint-follow-up test
  - chat-service tool-status preservation test
  - adjusted affected existing tests for context-step-first behavior

## Why
This PR implements the Issue #352 objective: make `web_search` a first-class Context Integration and remove split/hybrid behavior that made search execution ambiguous and harder to audit.

The prior path allowed retrieval behavior to be split between planner/context-step intent and provider/runtime execution semantics. This caused dead/competing paths, unclear provenance, and inconsistent tool-status reporting. The new flow centralizes search execution in workflow context steps while keeping controlled optional OpenAI-native follow-up from structured hints.

## Important Implementation Details
- Default retrieval authority is now context-step execution (`web_search`) rather than direct provider-tool forwarding.
- OpenAI follow-up is gated by:
  - provider = OpenAI
  - `openAiNativeSearchFromHintsEnabled`
  - available `searchHints`
- Follow-up is bounded to one selected hint to avoid unbounded dual-path behavior.
- Context integration remains fail-open: search failures do not block response generation.
- Metadata now favors explicit execution context over inference when determining tool execution outcomes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added web search integration with support for multiple providers and priority-based fallback
  * Configurable provider timeouts and maximum result limits
  * Integrated OpenAI native follow-up search capability derived from search hints

* **Tests**
  * Expanded test coverage for web search functionality and workflow orchestration

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/footnote-ai/footnote/pull/355)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->