### PR TITLE
feat(chat): expose grounded/balanced mode controls across web and Discord

### DIFF
--- a/docs/api/openapi.yaml
+++ b/docs/api/openapi.yaml
@@ -1304,6 +1304,10 @@ components:
                     type: string
                     pattern: '^[a-z0-9][a-z0-9-]{0,31}$'
                     description: Optional response profile selector resolved by backend model routing.
+                modeId:
+                    type: string
+                    enum: [balanced, grounded]
+                    description: Optional user-facing posture selector for workflow mode routing.
                 generation:
                     type: object
                     properties:
@@ -2870,7 +2874,6 @@ components:
             required:
                 - turnstileSiteKey
             additionalProperties: false
-
 
     parameters:
         # Shared request parameters.

--- a/packages/backend/src/services/chatOrchestrator.ts
+++ b/packages/backend/src/services/chatOrchestrator.ts
@@ -361,7 +361,8 @@ export const createChatOrchestrator = ({
         // 2) derive Execution Contract preset from mode
         // 3) execute orchestration within that contract
         const workflowModeResolution = resolveWorkflowModeDecision({
-            modeId: runtimeConfig.chatWorkflow.modeId,
+            modeId:
+                normalizedRequest.modeId ?? runtimeConfig.chatWorkflow.modeId,
         });
         // Pick the run mode first, then derive the contract from it. That keeps
         // later branches from inventing their own policy rules.

--- a/packages/contracts/src/web/schemas.ts
+++ b/packages/contracts/src/web/schemas.ts
@@ -67,6 +67,7 @@ const ChatTriggerKindSchema = z.enum([
 ]);
 const ChatPersonaIdSchema = z.string().regex(/^[a-z0-9][a-z0-9-]{0,31}$/);
 const ChatProfileIdSchema = z.string().regex(/^[a-z0-9][a-z0-9-]{0,31}$/);
+const ChatModeIdSchema = z.enum(['balanced', 'grounded']);
 const ChatConversationMessageSchema = z
     .object({
         role: z.enum(['system', 'user', 'assistant']),
@@ -944,6 +945,7 @@ export const PostChatRequestSchema = z
         surface: ChatSurfaceSchema,
         botPersonaId: ChatPersonaIdSchema.optional(),
         profileId: ChatProfileIdSchema.optional(),
+        modeId: ChatModeIdSchema.optional(),
         generation: z
             .object({
                 reasoningEffort: z

--- a/packages/contracts/src/web/types.ts
+++ b/packages/contracts/src/web/types.ts
@@ -10,6 +10,7 @@ import type {
     PartialResponseTemperament,
     ResponseMetadata,
     TraceAxisScore,
+    WorkflowModeId,
 } from '../policy/index.js';
 import type {
     InternalImageRenderModelId,
@@ -322,6 +323,7 @@ export type PostChatRequest = {
     surface: ChatSurface;
     botPersonaId?: string;
     profileId?: string;
+    modeId?: WorkflowModeId;
     generation?: {
         reasoningEffort?: 'minimal' | 'low' | 'medium' | 'high';
         verbosity?: 'low' | 'medium' | 'high';

--- a/packages/discord-bot/src/commands/chat.ts
+++ b/packages/discord-bot/src/commands/chat.ts
@@ -11,7 +11,10 @@ import {
     SlashCommandBuilder,
     type SlashCommandStringOption,
 } from 'discord.js';
-import type { ResponseMetadata } from '@footnote/contracts/policy';
+import type {
+    ResponseMetadata,
+    WorkflowModeId,
+} from '@footnote/contracts/policy';
 import type { ChatProfileOption } from '@footnote/contracts/web';
 import { botApi } from '../api/botApi.js';
 import type { DiscordChatApiResponse } from '../api/index.js';
@@ -92,6 +95,16 @@ const buildChatCommandData = (
         .addStringOption((option) => addProfileOption(option, profileChoices))
         .addStringOption((option) =>
             option
+                .setName('mode')
+                .setDescription('Optional answer posture for this request')
+                .addChoices(
+                    { name: 'Grounded', value: 'grounded' },
+                    { name: 'Balanced', value: 'balanced' }
+                )
+                .setRequired(false)
+        )
+        .addStringOption((option) =>
+            option
                 .setName('reasoning_effort')
                 .setDescription('Reasoning effort hint for this request')
                 .addChoices(
@@ -152,6 +165,7 @@ const hasResponseMetadata = (value: unknown): value is ResponseMetadata =>
 
 const buildChatDetailsPrefix = (options: {
     profileId: string | null | undefined;
+    modeId: WorkflowModeId | null;
     reasoningEffort: ReasoningEffort | null;
     verbosity: Verbosity | null;
 }): string => {
@@ -160,6 +174,9 @@ const buildChatDetailsPrefix = (options: {
 
     if (trimmedProfileId) {
         details.push(`> profile_id: ${trimmedProfileId}`);
+    }
+    if (options.modeId) {
+        details.push(`> mode: ${options.modeId}`);
     }
     if (options.reasoningEffort) {
         details.push(`> reasoning_effort: ${options.reasoningEffort}`);
@@ -202,6 +219,9 @@ const chatCommand: ChatCommandWithProfiles = {
 
         const prompt = interaction.options.getString('prompt', true).trim();
         const profileId = interaction.options.getString('profile_id')?.trim();
+        const modeId = interaction.options.getString(
+            'mode'
+        ) as WorkflowModeId | null;
         const reasoningEffort = interaction.options.getString(
             'reasoning_effort'
         ) as ReasoningEffort | null;
@@ -214,6 +234,7 @@ const chatCommand: ChatCommandWithProfiles = {
                 surface: 'discord',
                 botPersonaId: runtimeConfig.profile.id,
                 ...(profileId && profileId.length > 0 ? { profileId } : {}),
+                ...(modeId ? { modeId } : {}),
                 trigger: {
                     kind: 'submit',
                     messageId: interaction.id,
@@ -248,7 +269,7 @@ const chatCommand: ChatCommandWithProfiles = {
                     ? response.metadata
                     : null;
                 const replyBody = clampReplyContent(
-                    `${buildChatDetailsPrefix({ profileId, reasoningEffort, verbosity })}${buildSearchUnavailablePrefix(metadata)}${response.message}`
+                    `${buildChatDetailsPrefix({ profileId, modeId, reasoningEffort, verbosity })}${buildSearchUnavailablePrefix(metadata)}${response.message}`
                 );
                 if (!metadata) {
                     await interaction.editReply({
@@ -297,7 +318,7 @@ const chatCommand: ChatCommandWithProfiles = {
 
             await interaction.editReply({
                 content: clampReplyContent(
-                    `${buildChatDetailsPrefix({ profileId, reasoningEffort, verbosity })}${renderNonMessageAction(response)}`
+                    `${buildChatDetailsPrefix({ profileId, modeId, reasoningEffort, verbosity })}${renderNonMessageAction(response)}`
                 ),
             });
         } catch (error) {

--- a/packages/web/src/components/AskPanel.tsx
+++ b/packages/web/src/components/AskPanel.tsx
@@ -38,6 +38,7 @@ const FALLBACK_REFLECTION =
  * response rendering.
  */
 const AskPanel = (): JSX.Element => {
+    const [modeId, setModeId] = useState<'balanced' | 'grounded'>('grounded');
     const [question, setQuestion] = useState('');
     const [status, setStatus] = useState('');
     const [answer, setAnswer] = useState('');
@@ -388,6 +389,7 @@ const AskPanel = (): JSX.Element => {
             const payload = await api.chatQuestion(
                 {
                     surface: 'web',
+                    modeId,
                     trigger: { kind: 'submit' },
                     latestUserInput: trimmedQuestion,
                     conversation: [
@@ -572,6 +574,30 @@ const AskPanel = (): JSX.Element => {
                         </div>
                     </div>
                     <form className="interaction-form" onSubmit={onSubmit}>
+                        <div className="interaction-mode-row">
+                            <label
+                                htmlFor="chat-mode-select"
+                                className="interaction-mode-label"
+                            >
+                                Mode
+                            </label>
+                            <select
+                                id="chat-mode-select"
+                                className="interaction-mode-select"
+                                value={modeId}
+                                onChange={(event) =>
+                                    setModeId(
+                                        event.target.value as
+                                            | 'balanced'
+                                            | 'grounded'
+                                    )
+                                }
+                                aria-label="Select chat mode"
+                            >
+                                <option value="grounded">Grounded</option>
+                                <option value="balanced">Balanced</option>
+                            </select>
+                        </div>
                         <div className="interaction-input-group">
                             <label htmlFor="question-input" className="sr-only">
                                 Ask a question

--- a/packages/web/src/components/AskPanel.tsx
+++ b/packages/web/src/components/AskPanel.tsx
@@ -578,6 +578,7 @@ const AskPanel = (): JSX.Element => {
                             <label
                                 htmlFor="chat-mode-select"
                                 className="interaction-mode-label"
+                                title="Choose the answer posture: grounded is stricter with evidence, balanced is more flexible."
                             >
                                 Mode
                             </label>
@@ -594,8 +595,18 @@ const AskPanel = (): JSX.Element => {
                                 }
                                 aria-label="Select chat mode"
                             >
-                                <option value="grounded">Grounded</option>
-                                <option value="balanced">Balanced</option>
+                                <option
+                                    value="grounded"
+                                    title="Grounded: stricter evidence posture and more cautious output."
+                                >
+                                    Grounded
+                                </option>
+                                <option
+                                    value="balanced"
+                                    title="Balanced: standard reviewed posture with a lighter evidence strictness."
+                                >
+                                    Balanced
+                                </option>
                             </select>
                         </div>
                         <div className="interaction-input-group">

--- a/packages/web/src/components/AskPanel.tsx
+++ b/packages/web/src/components/AskPanel.tsx
@@ -9,7 +9,10 @@
 import { FormEvent, useEffect, useRef, useState } from 'react';
 import { Turnstile, type TurnstileInstance } from '@marsidev/react-turnstile';
 import ProvenanceFooter from './ProvenanceFooter';
-import type { ResponseMetadata } from '@footnote/contracts/policy';
+import type {
+    ResponseMetadata,
+    WorkflowModeId,
+} from '@footnote/contracts/policy';
 import examplePrompts from '../data/examplePrompts.json';
 import { loadRuntimeConfig } from '../config';
 import { api, isApiClientError } from '../utils/api';
@@ -32,13 +35,17 @@ declare global {
 // Provide a stable fallback response in case the backend is unavailable so the space stays welcoming.
 const FALLBACK_REFLECTION =
     'I was unable to generate a response - please try again later.';
+const ALLOWED_WORKFLOW_MODE_IDS: ReadonlySet<WorkflowModeId> = new Set([
+    'balanced',
+    'grounded',
+]);
 
 /**
  * Main website ask panel that manages prompt input, Turnstile, and chat
  * response rendering.
  */
 const AskPanel = (): JSX.Element => {
-    const [modeId, setModeId] = useState<'balanced' | 'grounded'>('grounded');
+    const [modeId, setModeId] = useState<WorkflowModeId>('grounded');
     const [question, setQuestion] = useState('');
     const [status, setStatus] = useState('');
     const [answer, setAnswer] = useState('');
@@ -586,13 +593,16 @@ const AskPanel = (): JSX.Element => {
                                 id="chat-mode-select"
                                 className="interaction-mode-select"
                                 value={modeId}
-                                onChange={(event) =>
-                                    setModeId(
-                                        event.target.value as
-                                            | 'balanced'
-                                            | 'grounded'
-                                    )
-                                }
+                                onChange={(event) => {
+                                    const val = event.target.value;
+                                    if (
+                                        ALLOWED_WORKFLOW_MODE_IDS.has(
+                                            val as WorkflowModeId
+                                        )
+                                    ) {
+                                        setModeId(val as WorkflowModeId);
+                                    }
+                                }}
                                 aria-label="Select chat mode"
                             >
                                 <option

--- a/packages/web/src/styles/global.css
+++ b/packages/web/src/styles/global.css
@@ -1276,6 +1276,34 @@ section:has(.site-header-sticky) {
     gap: clamp(0.75rem, 2vw, 0.9rem);
 }
 
+.interaction-mode-row {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.5rem;
+}
+
+.interaction-mode-label {
+    font-family: var(--mono-font);
+    font-size: 0.82rem;
+    letter-spacing: 0.04em;
+    color: var(--subtle-text);
+}
+
+.interaction-mode-select {
+    border: 1px solid var(--border);
+    background-color: var(--bg);
+    color: var(--text);
+    font-family: var(--mono-font);
+    font-size: 0.82rem;
+    padding: 0.35rem 0.55rem;
+}
+
+.interaction-mode-select:focus {
+    outline: none;
+    border-color: color-mix(in srgb, var(--accent) 60%, var(--border) 40%);
+    box-shadow: 0 0 0 2px color-mix(in srgb, var(--accent) 20%, transparent 80%);
+}
+
 .interaction-label {
     flex-basis: 100%;
     font-family: var(--mono-font);


### PR DESCRIPTION
## Summary
Expose user-facing chat posture controls (grounded and alanced) across web + Discord, wire the selected mode through /api/chat, and add lightweight hover explanations in the web selector.

## What Changed
- Added modeId support to shared chat contracts and schema validation.
  - PostChatRequest now accepts modeId (alanced | grounded).
- Updated backend chat orchestration to prefer request-level mode selection when provided, while preserving existing runtime-config fallback behavior.
- Updated web chat UI:
  - Added a minimal two-option mode selector in the ask panel (default grounded).
  - Sends selected mode with each /api/chat request.
  - Added native hover tooltips on the mode label/options for quick posture guidance.
- Updated Discord /chat command:
  - Added optional mode slash parameter (grounded, alanced).
  - Passes selected mode to backend.
  - Includes selected mode in request-detail prefix shown in responses.
- Updated OpenAPI docs to include modeId in ChatRequest.

## Why
This implements bounded user steerability for answer posture so users can actually choose between the two intended postures (grounded default, alanced optional). It closes the gap between the product claim (“inspect and steer”) and the live UX by making mode choice visible, controllable, and traceable.

## Implementation Notes
- Scope intentionally stays minimal: no settings panel, no persistence changes, no new backend mode semantics.
- Backward compatibility is preserved because modeId is optional; omitted requests continue using existing default routing.
- Hover guidance uses native browser 	itle tooltips to keep complexity low while improving clarity.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Users can now select a chat mode (balanced or grounded) when submitting chat requests, allowing responses to be tailored to their preferred interaction style
  * Mode selection is available in the web interface via a new dropdown selector and in the Discord bot as an optional command parameter

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/footnote-ai/footnote/pull/357)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->