### PR TITLE
Fix TRACE short-circuit metadata and refresh About/Onboarding content

### DIFF
--- a/packages/backend/src/services/chatService.ts
+++ b/packages/backend/src/services/chatService.ts
@@ -115,6 +115,7 @@ const buildContextStepShortCircuit = ({
     workflowContextStepResult,
     workflowContextStepResults,
     executionContext,
+    plannerTemperament,
     toolRequest,
     model,
     defaultModel,
@@ -125,6 +126,7 @@ const buildContextStepShortCircuit = ({
     workflowContextStepResult: ContextStepResult | undefined;
     workflowContextStepResults?: ContextStepResult[];
     executionContext: ResponseMetadataRuntimeContext['executionContext'];
+    plannerTemperament?: PartialResponseTemperament;
     toolRequest: ToolInvocationRequest | undefined;
     model: string | undefined;
     defaultModel: string;
@@ -151,6 +153,7 @@ const buildContextStepShortCircuit = ({
     const buildGenerationMetadataContext = () => ({
         modelVersion: model ?? defaultModel,
         conversationSnapshot,
+        plannerTemperament,
         executionContext: {
             ...executionContext,
             generation: {
@@ -1004,6 +1007,7 @@ export const createChatService = ({
                         workflowContextStepResult,
                         workflowContextStepResults,
                         executionContext,
+                        plannerTemperament: effectivePlannerTemperament,
                         toolRequest,
                         model,
                         defaultModel,
@@ -1040,6 +1044,7 @@ export const createChatService = ({
                         workflowContextStepResult,
                         workflowContextStepResults,
                         executionContext,
+                        plannerTemperament: effectivePlannerTemperament,
                         toolRequest,
                         model,
                         defaultModel,

--- a/packages/backend/test/chatService.test.ts
+++ b/packages/backend/test/chatService.test.ts
@@ -194,6 +194,75 @@ test('runChatMessages passes planner temperament into response metadata runtime 
     });
 });
 
+test('runChatMessages preserves planner temperament for context-step short-circuit message metadata', async () => {
+    let capturedPlannerTemperament:
+        | import('@footnote/contracts/policy').PartialResponseTemperament
+        | undefined;
+
+    const chatService = createChatService({
+        generationRuntime: createRuntime(),
+        storeTrace: async () => undefined,
+        buildResponseMetadata: (_assistantMetadata, runtimeContext) => {
+            capturedPlannerTemperament = runtimeContext.plannerTemperament;
+            return createMetadata();
+        },
+        defaultModel: 'gpt-5-mini',
+        recordUsage: () => undefined,
+        runReviewWorkflow: async (_input) =>
+            ({
+                outcome: 'no_generation',
+                workflowLineage: {
+                    workflowId: 'wf_short_circuit_clarification',
+                    workflowName: 'message_reviewed',
+                    status: 'degraded',
+                    terminationReason: 'transition_blocked_by_policy',
+                    stepCount: 0,
+                    maxSteps: 3,
+                    maxDurationMs: 15000,
+                    steps: [],
+                },
+                contextStepResults: [
+                    {
+                        executionContext: {
+                            toolName: 'weather_forecast',
+                            status: 'executed',
+                            clarification: {
+                                reasonCode: 'ambiguous_location',
+                                question: 'Which Springfield?',
+                                options: [
+                                    {
+                                        id: 'springfield_il',
+                                        label: 'Springfield, IL',
+                                    },
+                                    {
+                                        id: 'springfield_mo',
+                                        label: 'Springfield, MO',
+                                    },
+                                ],
+                            },
+                        },
+                    },
+                ],
+            }) as RunBoundedReviewWorkflowResult,
+    });
+
+    await chatService.runChatMessages({
+        messages: [{ role: 'user', content: 'Weather in Springfield' }],
+        conversationSnapshot: 'Weather in Springfield',
+        plannerTemperament: {
+            tightness: 5,
+            attribution: 4,
+            caution: 4,
+        },
+    });
+
+    assert.deepEqual(capturedPlannerTemperament, {
+        tightness: 5,
+        attribution: 4,
+        caution: 4,
+    });
+});
+
 test('runChatMessages passes structured retrieval facts into response metadata runtime context', async () => {
     let capturedRetrieval: ResponseMetadataRetrievalContext | undefined;
 

--- a/packages/web/src/pages/AboutPage.tsx
+++ b/packages/web/src/pages/AboutPage.tsx
@@ -1,10 +1,10 @@
 /**
- * @description: Renders the public About page for Footnote with a plain
- * explanation of what the project is, what it shows, and where to go next.
+ * @description: Renders the public About page with concrete expectations for
+ * what Footnote shows, what trace records mean, and current project status.
  * @footnote-scope: web
  * @footnote-module: AboutPage
- * @footnote-risk: low - Inaccurate copy can misstate what the product shows or overstate project guarantees.
- * @footnote-ethics: medium - This page shapes user expectations about transparency, review, and self-hosting limits.
+ * @footnote-risk: low - Copy errors can misstate product behavior and contribution readiness.
+ * @footnote-ethics: medium - This page sets trust expectations and must avoid overclaiming verification guarantees.
  */
 
 import Header from '@components/Header';
@@ -13,11 +13,12 @@ import StickySectionToc from '@components/StickySectionToc';
 import { Link } from 'react-router-dom';
 
 type AboutSectionId =
-    | 'why-footnote-exists'
-    | 'reading-a-response'
-    | 'what-a-trace-is'
-    | 'open-source-and-self-hosting'
-    | 'developers';
+    | 'what-it-is'
+    | 'what-you-see'
+    | 'trace-page'
+    | 'what-it-is-not'
+    | 'open-source'
+    | 'get-involved';
 
 type SectionLink = {
     id: AboutSectionId;
@@ -25,14 +26,12 @@ type SectionLink = {
 };
 
 const sectionLinks: SectionLink[] = [
-    { id: 'why-footnote-exists', label: 'A better way to read AI' },
-    { id: 'reading-a-response', label: 'Inside a response' },
-    { id: 'what-a-trace-is', label: 'The record' },
-    {
-        id: 'open-source-and-self-hosting',
-        label: 'Open source',
-    },
-    { id: 'developers', label: 'Get involved' },
+    { id: 'what-it-is', label: 'What it is' },
+    { id: 'what-you-see', label: 'What you see in a response' },
+    { id: 'trace-page', label: 'The trace page' },
+    { id: 'what-it-is-not', label: 'What it is not' },
+    { id: 'open-source', label: 'Project status and self-hosting' },
+    { id: 'get-involved', label: 'Get involved' },
 ];
 
 const AboutPage = (): JSX.Element => (
@@ -42,12 +41,12 @@ const AboutPage = (): JSX.Element => (
             <header className="page-hero" aria-labelledby="about-title">
                 <h1 id="about-title">AI that carries receipts.</h1>
                 <p className="page-hero__summary">
-                    Footnote is an AI framework that tries to show its work.
+                    Ask a question. Get an answer plus a record you can review.
                 </p>
                 <p>
-                    Ask a question and Footnote gives you a response with
-                    receipts: source links, confidence and safety notes, and a
-                    trace page for digging deeper.
+                    Footnote is pre-1.0 and under active development. The core
+                    provenance and trace flow is working today. We are still
+                    expanding features and polish.
                 </p>
             </header>
 
@@ -60,93 +59,111 @@ const AboutPage = (): JSX.Element => (
                 <article className="page-content__main">
                     <section
                         className="page-section"
-                        id="why-footnote-exists"
-                        aria-labelledby="why-footnote-exists-title"
+                        id="what-it-is"
+                        aria-labelledby="what-it-is-title"
                     >
-                        <h2 id="why-footnote-exists-title">
-                            A better way to read AI
+                        <h2 id="what-it-is-title">What it is</h2>
+                        <p>
+                            Footnote is an AI framework focused on transparent
+                            responses. It attaches review signals and provenance
+                            metadata to answers so you can inspect how a
+                            response was produced.
+                        </p>
+                    </section>
+
+                    <section
+                        className="page-section"
+                        id="what-you-see"
+                        aria-labelledby="what-you-see-title"
+                    >
+                        <h2 id="what-you-see-title">
+                            What you see in a response
                         </h2>
                         <p>
-                            AI can be impressively fluent and still leave you
-                            guessing about where an answer came from. Footnote
-                            is built to make that gap visible. It keeps answers
-                            tied to the context behind them, so people can see
-                            what an answer is standing on.
+                            A response can include source links when available,
+                            a safety tier, and a link to the trace page.
                         </p>
                         <p>
-                            Footnote does not try to pretend every answer is
-                            perfect. It helps people slow down, look at what the
-                            answer is based on, and decide for themselves
-                            whether it feels solid enough to trust. It is part
-                            of a bigger question about steerability: how to give
-                            people more control over the direction of an answer,
-                            with more visibility into how it was produced.
+                            Those fields are not decoration. They are the review
+                            surface: where evidence came from, what risk posture
+                            the system reported, and where to inspect run
+                            details.
                         </p>
                     </section>
 
                     <section
                         className="page-section"
-                        id="reading-a-response"
-                        aria-labelledby="reading-a-response-title"
+                        id="trace-page"
+                        aria-labelledby="trace-page-title"
                     >
-                        <h2 id="reading-a-response-title">Inside a response</h2>
+                        <h2 id="trace-page-title">The trace page</h2>
                         <p>
-                            Footnote tries to give you more than the answer on
-                            its own. Alongside a response, you may see source
-                            links, notes about confidence or safety, tradeoffs
-                            or constraints when they matter, and a trace page
-                            with more detail about how it came together.
+                            The trace page records model/runtime details,
+                            workflow steps, and external-source usage when it
+                            exists.
+                        </p>
+                        <p>
+                            The trace does not prove an answer is correct. It
+                            gives you a concrete record to verify and question.
                         </p>
                     </section>
 
                     <section
                         className="page-section"
-                        id="what-a-trace-is"
-                        aria-labelledby="what-a-trace-is-title"
+                        id="what-it-is-not"
+                        aria-labelledby="what-it-is-not-title"
                     >
-                        <h2 id="what-a-trace-is-title">The record</h2>
+                        <h2 id="what-it-is-not-title">What it is not</h2>
                         <p>
-                            A trace keeps the trail Footnote followed while
-                            answering: sources, model and runtime details,
-                            safety notes, and workflow steps when they matter.
-                        </p>
-                        <p>
-                            It does not prove the answer is right. It gives you
-                            a record you can open, follow, and question when you
-                            want to understand how the response came together.
+                            Footnote is not a replacement for judgment, and it
+                            is not a guaranteed fact-checking oracle. It helps
+                            you review answer context. You still decide whether
+                            the output is reliable enough for your use case.
                         </p>
                     </section>
 
                     <section
                         className="page-section"
-                        id="open-source-and-self-hosting"
-                        aria-labelledby="open-source-and-self-hosting-title"
+                        id="open-source"
+                        aria-labelledby="open-source-title"
                     >
-                        <h2 id="open-source-and-self-hosting-title">
-                            Open source
+                        <h2 id="open-source-title">
+                            Project status and self-hosting
                         </h2>
                         <p>
-                            Footnote is open source and built to run outside the
-                            hosted demo. You can try the browser demo, run your
-                            own copy from the repo, or self-host it with your
-                            own setup.
+                            Footnote is open source. You can run it from the
+                            repository and self-host it with your own provider
+                            and infrastructure choices.
                         </p>
                         <p>
-                            If you use hosted model providers (e.g. Ollama
-                            cloud, OpenAI), ensure you understand their privacy
-                            and retention rules.
+                            If you use hosted providers, review their privacy
+                            and retention policies separately.
                         </p>
                     </section>
 
                     <section
                         className="page-section"
-                        id="developers"
-                        aria-labelledby="developers-title"
+                        id="get-involved"
+                        aria-labelledby="get-involved-title"
                     >
-                        <h2 id="developers-title">Get involved</h2>
-                        <p>Want to help us work on Footnote?</p>
+                        <h2 id="get-involved-title">Get involved</h2>
                         <p>
-                            <Link to="/onboarding">Start here</Link>!
+                            Useful contributions include backend workflow
+                            improvements, web trace UX, and docs that reduce
+                            onboarding friction.
+                        </p>
+                        <p>
+                            Start with the{' '}
+                            <Link to="/onboarding">Onboarding page</Link> and
+                            the project on{' '}
+                            <a
+                                href="https://github.com/footnote-ai/footnote"
+                                target="_blank"
+                                rel="noreferrer"
+                            >
+                                GitHub
+                            </a>
+                            .
                         </p>
                     </section>
                 </article>

--- a/packages/web/src/pages/AboutPage.tsx
+++ b/packages/web/src/pages/AboutPage.tsx
@@ -13,12 +13,12 @@ import StickySectionToc from '@components/StickySectionToc';
 import { Link } from 'react-router-dom';
 
 type AboutSectionId =
-    | 'what-it-is'
-    | 'what-you-see'
-    | 'trace-page'
-    | 'what-it-is-not'
-    | 'open-source'
-    | 'get-involved';
+    | 'why-footnote-exists'
+    | 'reading-a-response'
+    | 'what-the-trace-shows'
+    | 'limits'
+    | 'project-status'
+    | 'contributing';
 
 type SectionLink = {
     id: AboutSectionId;
@@ -26,12 +26,12 @@ type SectionLink = {
 };
 
 const sectionLinks: SectionLink[] = [
-    { id: 'what-it-is', label: 'What it is' },
-    { id: 'what-you-see', label: 'What you see in a response' },
-    { id: 'trace-page', label: 'The trace page' },
-    { id: 'what-it-is-not', label: 'What it is not' },
-    { id: 'open-source', label: 'Project status and self-hosting' },
-    { id: 'get-involved', label: 'Get involved' },
+    { id: 'why-footnote-exists', label: 'Why Footnote exists' },
+    { id: 'reading-a-response', label: 'Reading a response' },
+    { id: 'what-the-trace-shows', label: 'What the trace shows' },
+    { id: 'limits', label: 'Limits' },
+    { id: 'project-status', label: 'Project status' },
+    { id: 'contributing', label: 'Contributing' },
 ];
 
 const AboutPage = (): JSX.Element => (
@@ -41,12 +41,14 @@ const AboutPage = (): JSX.Element => (
             <header className="page-hero" aria-labelledby="about-title">
                 <h1 id="about-title">AI that carries receipts.</h1>
                 <p className="page-hero__summary">
-                    Ask a question. Get an answer plus a record you can review.
+                    Footnote is an attempt to make AI answers easier to inspect,
+                    question, and challenge.
                 </p>
                 <p>
-                    Footnote is pre-1.0 and under active development. The core
-                    provenance and trace flow is working today. We are still
-                    expanding features and polish.
+                    AI can be useful and still leave you uneasy about what to
+                    trust. Footnote is pre-1.0 and under active development. It
+                    does not solve that problem, but it tries to leave more of
+                    the trail attached to the answer.
                 </p>
             </header>
 
@@ -59,101 +61,135 @@ const AboutPage = (): JSX.Element => (
                 <article className="page-content__main">
                     <section
                         className="page-section"
-                        id="what-it-is"
-                        aria-labelledby="what-it-is-title"
+                        id="why-footnote-exists"
+                        aria-labelledby="why-footnote-exists-title"
                     >
-                        <h2 id="what-it-is-title">What it is</h2>
-                        <p>
-                            Footnote is an AI framework focused on transparent
-                            responses. It attaches review signals and provenance
-                            metadata to answers so you can inspect how a
-                            response was produced.
-                        </p>
-                    </section>
-
-                    <section
-                        className="page-section"
-                        id="what-you-see"
-                        aria-labelledby="what-you-see-title"
-                    >
-                        <h2 id="what-you-see-title">
-                            What you see in a response
+                        <h2 id="why-footnote-exists-title">
+                            Why Footnote exists
                         </h2>
                         <p>
-                            A response can include source links when available,
-                            a safety tier, and a link to the trace page.
+                            A lot of AI tools are built to keep the interaction
+                            smooth. You ask a question, get a polished answer,
+                            and move on. The problem is that the smoothness can
+                            hide a lot. You may not know where the answer came
+                            from, how much it relied on outside material, or
+                            what changed between the question you asked and the
+                            answer you got back.
                         </p>
                         <p>
-                            Those fields are not decoration. They are the review
-                            surface: where evidence came from, what risk posture
-                            the system reported, and where to inspect run
-                            details.
+                            Footnote starts from the idea that this uncertainty
+                            matters. The goal is not to make AI feel magical. It
+                            is to make it easier to look at a response and ask:
+                            what is this answer standing on, and how much
+                            confidence should I place in it?
                         </p>
                     </section>
 
                     <section
                         className="page-section"
-                        id="trace-page"
-                        aria-labelledby="trace-page-title"
+                        id="reading-a-response"
+                        aria-labelledby="reading-a-response-title"
                     >
-                        <h2 id="trace-page-title">The trace page</h2>
-                        <p>
-                            The trace page records model/runtime details,
-                            workflow steps, and external-source usage when it
-                            exists.
-                        </p>
-                        <p>
-                            The trace does not prove an answer is correct. It
-                            gives you a concrete record to verify and question.
-                        </p>
-                    </section>
-
-                    <section
-                        className="page-section"
-                        id="what-it-is-not"
-                        aria-labelledby="what-it-is-not-title"
-                    >
-                        <h2 id="what-it-is-not-title">What it is not</h2>
-                        <p>
-                            Footnote is not a replacement for judgment, and it
-                            is not a guaranteed fact-checking oracle. It helps
-                            you review answer context. You still decide whether
-                            the output is reliable enough for your use case.
-                        </p>
-                    </section>
-
-                    <section
-                        className="page-section"
-                        id="open-source"
-                        aria-labelledby="open-source-title"
-                    >
-                        <h2 id="open-source-title">
-                            Project status and self-hosting
+                        <h2 id="reading-a-response-title">
+                            Reading a response
                         </h2>
                         <p>
-                            Footnote is open source. You can run it from the
-                            repository and self-host it with your own provider
-                            and infrastructure choices.
+                            Footnote is built around the answer, but not around
+                            the answer alone. When sources are available, it can
+                            show them. It can also show a safety tier and a link
+                            to the trace for that response.
                         </p>
                         <p>
-                            If you use hosted providers, review their privacy
-                            and retention policies separately.
+                            Those details are there to slow the experience down
+                            in a useful way. Instead of treating the response as
+                            a finished product, the page gives you a few handles
+                            for checking what kind of answer you are looking at
+                            and whether it deserves more scrutiny.
                         </p>
                     </section>
 
                     <section
                         className="page-section"
-                        id="get-involved"
-                        aria-labelledby="get-involved-title"
+                        id="what-the-trace-shows"
+                        aria-labelledby="what-the-trace-shows-title"
                     >
-                        <h2 id="get-involved-title">Get involved</h2>
+                        <h2 id="what-the-trace-shows-title">
+                            What the trace shows
+                        </h2>
                         <p>
-                            Useful contributions include backend workflow
-                            improvements, web trace UX, and docs that reduce
-                            onboarding friction.
+                            The trace is the place to look when you want more
+                            than the surface answer. It can show what model ran,
+                            which workflow steps happened, and which outside
+                            sources were used when they were part of the run.
                         </p>
                         <p>
-                            Start with the{' '}
+                            That record does not prove the answer is correct.
+                            What it does is give you something concrete to
+                            inspect. If a claim feels shaky, the trace gives you
+                            a better starting point than a blank box and a
+                            confident tone.
+                        </p>
+                    </section>
+
+                    <section
+                        className="page-section"
+                        id="limits"
+                        aria-labelledby="limits-title"
+                    >
+                        <h2 id="limits-title">Limits</h2>
+                        <p>
+                            Footnote is not a replacement for judgment. It is
+                            not a guarantee that an answer is true, fair, or
+                            complete. It is also not a substitute for checking
+                            important claims yourself when the stakes are high.
+                        </p>
+                        <p>
+                            The project is trying to make AI answers less
+                            opaque, not to remove the need for human judgment.
+                            If Footnote is doing its job well, it should make it
+                            easier to question a response rather than easier to
+                            surrender to it.
+                        </p>
+                    </section>
+
+                    <section
+                        className="page-section"
+                        id="project-status"
+                        aria-labelledby="project-status-title"
+                    >
+                        <h2 id="project-status-title">Project status</h2>
+                        <p>
+                            Footnote is open source and still early. The core
+                            idea is here: responses can carry sources, traces,
+                            and other context that make them easier to examine.
+                            But the project is still being shaped, and there is
+                            a lot of room to improve both the experience and the
+                            underlying systems.
+                        </p>
+                        <p>
+                            You can run it from the repository and self-host it
+                            with your own provider and infrastructure choices.
+                            If you use hosted providers, their privacy and
+                            retention rules still matter and should be reviewed
+                            on their own terms.
+                        </p>
+                    </section>
+
+                    <section
+                        className="page-section"
+                        id="contributing"
+                        aria-labelledby="contributing-title"
+                    >
+                        <h2 id="contributing-title">Contributing</h2>
+                        <p>
+                            Useful contributions are not limited to model or
+                            backend work. Clearer docs, better trace UX,
+                            stronger review flows, and sharper product writing
+                            all matter here.
+                        </p>
+                        <p>
+                            If the project feels aligned with the questions you
+                            already have about AI, start with the{' '}
                             <Link to="/onboarding">Onboarding page</Link> and
                             the project on{' '}
                             <a

--- a/packages/web/src/pages/AboutPage.tsx
+++ b/packages/web/src/pages/AboutPage.tsx
@@ -13,12 +13,10 @@ import StickySectionToc from '@components/StickySectionToc';
 import { Link } from 'react-router-dom';
 
 type AboutSectionId =
-    | 'why-footnote-exists'
+    | 'the-mission'
     | 'reading-a-response'
-    | 'what-the-trace-shows'
-    | 'limits'
-    | 'project-status'
-    | 'contributing';
+    | 'project-state'
+    | 'contribute';
 
 type SectionLink = {
     id: AboutSectionId;
@@ -26,12 +24,10 @@ type SectionLink = {
 };
 
 const sectionLinks: SectionLink[] = [
-    { id: 'why-footnote-exists', label: 'Why Footnote exists' },
+    { id: 'the-mission', label: 'The mission' },
     { id: 'reading-a-response', label: 'Reading a response' },
-    { id: 'what-the-trace-shows', label: 'What the trace shows' },
-    { id: 'limits', label: 'Limits' },
-    { id: 'project-status', label: 'Project status' },
-    { id: 'contributing', label: 'Contributing' },
+    { id: 'project-state', label: 'Project state' },
+    { id: 'contribute', label: 'Contribute' },
 ];
 
 const AboutPage = (): JSX.Element => (
@@ -41,14 +37,13 @@ const AboutPage = (): JSX.Element => (
             <header className="page-hero" aria-labelledby="about-title">
                 <h1 id="about-title">AI that carries receipts.</h1>
                 <p className="page-hero__summary">
-                    Footnote is an attempt to make AI answers easier to inspect,
-                    question, and challenge.
+                    Footnote is a project about making AI easier to question.
                 </p>
                 <p>
-                    AI can be useful and still leave you uneasy about what to
-                    trust. Footnote is pre-1.0 and under active development. It
-                    does not solve that problem, but it tries to leave more of
-                    the trail attached to the answer.
+                    A lot of people have had the same experience with AI:
+                    something answers quickly, sounds sure of itself, and still
+                    leaves you with no clear way to tell what to trust. Footnote
+                    is one attempt to build something better.
                 </p>
             </header>
 
@@ -61,35 +56,33 @@ const AboutPage = (): JSX.Element => (
                 <article className="page-content__main">
                     <section
                         className="page-section"
-                        id="why-footnote-exists"
-                        aria-labelledby="why-footnote-exists-title"
+                        id="the-mission"
+                        aria-labelledby="the-mission-title"
                     >
-                        <h2 id="why-footnote-exists-title">
-                            Why Footnote exists
-                        </h2>
+                        <h2 id="the-mission-title">The mission</h2>
                         <p>
-                            A lot of AI tools are built to keep the interaction
-                            smooth. You ask a question, get a polished answer,
-                            and move on. The problem is that the smoothness can
-                            hide a lot. You may not know where the answer came
-                            from, how much it relied on outside material, or
-                            what changed between the question you asked and the
-                            answer you got back.
+                            Footnote is not trying to make AI feel smoother,
+                            faster, or more impressive than it already does. It
+                            is trying to make it less of a black box. That
+                            starts with answers you can examine, but it does not
+                            end there.
                         </p>
                         <p>
-                            That uncertainty is not just a technical flaw. It
-                            changes the relationship between the person and the
-                            answer. A system that sounds sure of itself can make
-                            it easy to slide from usefulness into unearned
-                            trust, especially when there is very little for the
-                            reader to inspect.
+                            The project is also about privacy, ownership, and
+                            choice. People should have more say in how a system
+                            is run, where their data goes, which model or
+                            provider they rely on, and what trade-offs they are
+                            being asked to accept. If a person cares about
+                            hosting something themselves, using a different
+                            provider, or avoiding a setup that feels wrong to
+                            them, that should be a practical option.
                         </p>
                         <p>
-                            Footnote starts from the idea that this uncertainty
-                            matters. The goal is not to make AI feel magical. It
-                            is to make it easier to look at a response and ask:
-                            what is this answer standing on, and how much
-                            confidence should I place in it?
+                            Under all of that is a simple idea: trust should be
+                            earned. Not by tone, not by polish, and not by
+                            pretending the system is wiser than it is. If
+                            Footnote is doing its job, it should leave people
+                            with more room to inspect, question, and choose.
                         </p>
                     </section>
 
@@ -102,99 +95,70 @@ const AboutPage = (): JSX.Element => (
                             Reading a response
                         </h2>
                         <p>
-                            Footnote is built around the answer, but not around
-                            the answer alone. When sources are available, it can
-                            show them. It can also show a safety tier and a link
-                            to the trace for that response.
+                            The easiest way to explain Footnote is to show what
+                            sits around an answer. The response itself is only
+                            one part. Around it, you may see sources, a safety
+                            label, TRACE information, and a link to open the
+                            full trace page.
+                        </p>
+                        <div
+                            className="card"
+                            aria-label="Response diagram placeholder"
+                        >
+                            <p>
+                                <strong>Placeholder:</strong> labeled diagram of
+                                one response, including the answer, sources,
+                                safety label, TRACE panel, and trace link.
+                            </p>
+                        </div>
+                        <p>
+                            The point of those pieces is not to decorate the
+                            answer. They give you places to look when you want
+                            to understand what the answer is leaning on. A
+                            source link can show where a claim came from. A
+                            safety label can tell you that extra care may be
+                            needed. TRACE is a compact picture of how the answer
+                            was shaped. The trace link opens the fuller record.
                         </p>
                         <p>
-                            Each of those pieces is there for a reason. Sources
-                            help you follow specific claims back to something
-                            outside the assistant. A safety tier is a signal
-                            about the posture of the response, not a stamp of
-                            truth. The trace is where you go when the surface
-                            answer is not enough.
+                            If you open the trace page, you get more than a
+                            short summary. You can see what ran, which steps
+                            happened, and what sources were involved when they
+                            were part of the answer. That still does not prove
+                            the answer is right. What it gives you is something
+                            real to inspect instead of a polished answer with no
+                            paper trail.
                         </p>
-                        <p>
-                            Those details are there to slow the experience down
-                            in a useful way. Instead of treating the response as
-                            a finished product, the page gives you a few handles
-                            for checking what kind of answer you are looking at
-                            and whether it deserves more scrutiny.
-                        </p>
+                        <div
+                            className="card"
+                            aria-label="Trace diagram placeholder"
+                        >
+                            <p>
+                                <strong>Placeholder:</strong> one or more
+                                labeled snippets of the trace page, showing the
+                                main sections worth explaining.
+                            </p>
+                        </div>
                     </section>
 
                     <section
                         className="page-section"
-                        id="what-the-trace-shows"
-                        aria-labelledby="what-the-trace-shows-title"
+                        id="project-state"
+                        aria-labelledby="project-state-title"
                     >
-                        <h2 id="what-the-trace-shows-title">
-                            What the trace shows
-                        </h2>
-                        <p>
-                            The trace is the place to look when you want more
-                            than the surface answer. It can show what model ran,
-                            which workflow steps happened, and which outside
-                            sources were used when they were part of the run.
-                        </p>
-                        <p>
-                            That matters because it replaces some of the usual
-                            black-box feeling with a visible record. Instead of
-                            being asked to trust the answer because it arrived
-                            fluently, you have something to examine when you
-                            need to understand how it came together.
-                        </p>
-                        <p>
-                            That record does not prove the answer is correct.
-                            What it does is give you something concrete to
-                            inspect. If a claim feels shaky, the trace gives you
-                            a better starting point than a blank box and a
-                            confident tone.
-                        </p>
-                    </section>
-
-                    <section
-                        className="page-section"
-                        id="limits"
-                        aria-labelledby="limits-title"
-                    >
-                        <h2 id="limits-title">Limits</h2>
-                        <p>
-                            Footnote is not a replacement for judgment. It is
-                            not a guarantee that an answer is true, fair, or
-                            complete. It is also not a substitute for checking
-                            important claims yourself when the stakes are high.
-                        </p>
-                        <p>
-                            The project is trying to make AI answers less
-                            opaque, not to remove the need for human judgment.
-                            If Footnote is doing its job well, it should make it
-                            easier to question a response rather than easier to
-                            surrender to it.
-                        </p>
-                    </section>
-
-                    <section
-                        className="page-section"
-                        id="project-status"
-                        aria-labelledby="project-status-title"
-                    >
-                        <h2 id="project-status-title">Project status</h2>
+                        <h2 id="project-state-title">Project state</h2>
                         <p>
                             Footnote is open source and still early. The core
-                            idea is here: responses can carry sources, traces,
-                            and other context that make them easier to examine.
-                            But the project is still being shaped, and there is
-                            a lot of room to improve both the experience and the
-                            underlying systems.
+                            ideas are here, but the project is still being
+                            shaped, and a lot of the work ahead is about making
+                            those ideas sturdier, clearer, and easier to use.
                         </p>
                         <p>
-                            The direction is broader than one interface. The aim
-                            is to make AI behavior more inspectable, leave more
-                            room for user choice, and rely less on opaque
-                            defaults that ask people to accept too much on
-                            faith.
+                            It is not just a web page or a demo. There is a
+                            broader effort underneath it: more checkable
+                            answers, more visible rules and defaults, more room
+                            for user choice, and more practical paths for
+                            self-hosting and provider choice.
                         </p>
                         <p>
                             You can run it from the repository and self-host it
@@ -207,24 +171,19 @@ const AboutPage = (): JSX.Element => (
 
                     <section
                         className="page-section"
-                        id="contributing"
-                        aria-labelledby="contributing-title"
+                        id="contribute"
+                        aria-labelledby="contribute-title"
                     >
-                        <h2 id="contributing-title">Contributing</h2>
+                        <h2 id="contribute-title">Contribute</h2>
                         <p>
-                            Useful contributions are not limited to model or
-                            backend work. Clearer docs, better trace UX,
-                            stronger review flows, and sharper product writing
-                            all matter here.
+                            There is room here for more than one kind of
+                            contributor. Backend work matters. Frontend work
+                            matters. Writing, diagrams, documentation, and the
+                            hard job of making complicated ideas understandable
+                            matter too.
                         </p>
                         <p>
-                            The project also benefits from people who care about
-                            accountability, legibility, and how trust is earned
-                            in real interfaces, not just from people who want to
-                            tune models or ship features quickly.
-                        </p>
-                        <p>
-                            If the project feels aligned with the questions you
+                            If the project lines up with the questions you
                             already have about AI, start with the{' '}
                             <Link to="/onboarding">Onboarding page</Link> and
                             the project on{' '}

--- a/packages/web/src/pages/AboutPage.tsx
+++ b/packages/web/src/pages/AboutPage.tsx
@@ -75,8 +75,16 @@ const AboutPage = (): JSX.Element => (
                             get stuck with one company just because it was the
                             default. If you want to use a different kind of AI
                             later, you should not have to rebuild everything.
-                            And if you want to run it yourself, that should be
-                            doable without a weekend of frustration.
+                            And if you want to{' '}
+                            <a
+                                href="https://github.com/footnote-ai/footnote#quickstart"
+                                target="_blank"
+                                rel="noreferrer"
+                            >
+                                run it yourself
+                            </a>
+                            , that should be doable without a weekend of
+                            frustration.
                         </p>
                         <p>
                             And trust is not about how smooth the writing is. A

--- a/packages/web/src/pages/AboutPage.tsx
+++ b/packages/web/src/pages/AboutPage.tsx
@@ -78,19 +78,21 @@ const AboutPage = (): JSX.Element => (
                         <h2 id="the-mission-title">The mission</h2>
 
                         <p>
-                            This is also about control. It&apos;s about keeping
-                            your data private when you need to, choosing how the
-                            system runs, and being able to change things later
-                            without the whole setup falling apart.
+                            Footnote is meant to make answers easier to understand
+                            and check. You shouldn&apos;t have to guess where
+                            something came from.
                         </p>
 
                         <p>
-                            A lot of tools make it easy to start and hard to
-                            leave. We&apos;re trying to avoid that. You
-                            shouldn&apos;t get stuck with one company just
-                            because it was the default. If you want to use a
-                            different kind of AI later, you shouldn&apos;t have
-                            to rebuild everything. And if you want to{' '}
+                            It's also about control—keeping your data private, 
+                            choosing how the system runs, and being able to change 
+                            things later without everything falling apart.
+                        </p>
+
+                        <p>
+                            Choice matters, so we try not to make it painful. Footnote 
+                            is designed to let you switch models or providers without 
+                            reworking the whole system. And if you want to{" "}
                             <a
                                 href="https://github.com/footnote-ai/footnote#quickstart"
                                 target="_blank"
@@ -98,18 +100,7 @@ const AboutPage = (): JSX.Element => (
                             >
                                 run it yourself
                             </a>
-                            , that should be doable without a weekend of
-                            frustration.
-                        </p>
-
-                        <p>
-                            Trust also isn&apos;t about how smooth the writing
-                            is. A clean, well-written answer can still be wrong
-                            or leave out something important. Footnote tries to
-                            give you a way to check it: where claims came from,
-                            what the system relied on, and when extra caution is
-                            worth it. If it&apos;s doing its job, you can dig in
-                            when you care and skim when you don&apos;t.
+                            , it should be doable without a weekend of frustration.
                         </p>
                     </section>
 
@@ -122,10 +113,8 @@ const AboutPage = (): JSX.Element => (
                             Reading a response
                         </h2>
                         <p>
-                            A Footnote response is not just the paragraph. It
-                            comes with handles: small, visible clues you can
-                            grab when you want to verify something, slow down,
-                            or dig deeper.
+                            A Footnote response comes with visible clues that can
+                            help when you want to slow down and dig deeper.
                         </p>
                         <div
                             className="card"
@@ -138,20 +127,11 @@ const AboutPage = (): JSX.Element => (
                             </p>
                         </div>
                         <p>
-                            Sources are the obvious one. Open them and see what
-                            a claim is anchored to. Safety notes are there for
-                            the moments when &ldquo;sounds fine&rdquo; is not
-                            good enough. TRACE is a quick posture snapshot of
-                            the response. The trace link opens the longer
-                            record.
-                        </p>
-                        <p>
-                            The trace page is the paper trail: which model ran,
-                            what steps happened, what tools were used, and what
-                            supporting material showed up along the way. It is
-                            not proof. It is accountability, something you can
-                            open and verify, instead of a polished answer with
-                            nothing behind it.
+                            Sources let you see what a claim is anchored to.
+                            Safety notes are there for the moments when 
+                            &ldquo;sounds fine&rdquo; is not good enough.
+                            TRACE is a snapshot of the response's posture.
+                            The trace link opens the longer, more detailed record.
                         </p>
                         <div
                             className="card"
@@ -163,6 +143,12 @@ const AboutPage = (): JSX.Element => (
                                 main sections worth explaining.
                             </p>
                         </div>
+                        <p>
+                            The trace page is the paper trail: which model ran,
+                            what steps happened, what tools were used, and what
+                            supporting material showed up along the way. It's not 
+                            proof, but a record you can open and verify for yourself.
+                        </p>
                     </section>
 
                     <section
@@ -194,9 +180,9 @@ const AboutPage = (): JSX.Element => (
                         <h2 id="contribute-title">Contribute</h2>
                         <p>
                             If this lines up with the concerns you already have
-                            about AI, jump in. There is real work across the
-                            stack: backend, frontend, UX, docs, diagrams, and
-                            the job of making complicated things understandable.
+                            about AI, we'd love to have your help in realizing Footnote. 
+                            There is real work to do across the frontend, backend, UX, docs, 
+                            diagrams—and making it legible to normal people (including grandma).
                         </p>
                         <p>
                             Start with the{' '}

--- a/packages/web/src/pages/AboutPage.tsx
+++ b/packages/web/src/pages/AboutPage.tsx
@@ -36,17 +36,30 @@ const AboutPage = (): JSX.Element => (
         <main className="page-content" id="main-content">
             <header className="page-hero" aria-labelledby="about-title">
                 <h1 id="about-title">AI that carries receipts.</h1>
+
                 <p className="page-hero__summary">
                     Footnote is an attempt to build something better.
                 </p>
+
                 <p>
-                    Most AI answers show up fast, confident, and polished, and
-                    you are still left guessing what is real. That is not a
-                    fluke. The industry gets rewarded for speed, lock-in, and
-                    persuasion, not for being checkable. Footnote gives you
-                    receipts: sources you can open, notes about uncertainty and
-                    safety when they matter, and a trace you can follow when you
-                    want the full story.
+                    Most AI answers show up fast, confident, and polished, but
+                    you&apos;re left guessing what&apos;s real. That&apos;s the
+                    predictable result of the incentives: the industry is
+                    rewarded for speed and persuasion, not for making answers
+                    easy to verify.
+                </p>
+
+                <p>
+                    Footnote isn&apos;t trying to be the flashiest AI. We care
+                    about giving you receipts: clear links to sources, notes
+                    about uncertainty and safety when they matter, and a paper
+                    trail you can follow when you want the full story.
+                </p>
+
+                <p>
+                    We believe AI that serves real people starts with being{' '}
+                    <strong>accessible</strong>, <strong>open</strong>, and{' '}
+                    <strong>honest</strong>.
                 </p>
             </header>
 
@@ -63,19 +76,21 @@ const AboutPage = (): JSX.Element => (
                         aria-labelledby="the-mission-title"
                     >
                         <h2 id="the-mission-title">The mission</h2>
+
                         <p>
-                            This is also about control. Keeping your data
-                            private when you need to. Choosing how it runs. And
-                            being able to change things later without the whole
-                            thing falling apart.
+                            This is also about control. It&apos;s about keeping
+                            your data private when you need to, choosing how the
+                            system runs, and being able to change things later
+                            without the whole setup falling apart.
                         </p>
+
                         <p>
                             A lot of tools make it easy to start and hard to
-                            leave. We are trying to avoid that. You should not
-                            get stuck with one company just because it was the
-                            default. If you want to use a different kind of AI
-                            later, you should not have to rebuild everything.
-                            And if you want to{' '}
+                            leave. We&apos;re trying to avoid that. You
+                            shouldn&apos;t get stuck with one company just
+                            because it was the default. If you want to use a
+                            different kind of AI later, you shouldn&apos;t have
+                            to rebuild everything. And if you want to{' '}
                             <a
                                 href="https://github.com/footnote-ai/footnote#quickstart"
                                 target="_blank"
@@ -86,14 +101,15 @@ const AboutPage = (): JSX.Element => (
                             , that should be doable without a weekend of
                             frustration.
                         </p>
+
                         <p>
-                            And trust is not about how smooth the writing is. A
-                            clean, well-written answer can still be wrong, or
-                            leave out something important. Footnote tries to
+                            Trust also isn&apos;t about how smooth the writing
+                            is. A clean, well-written answer can still be wrong
+                            or leave out something important. Footnote tries to
                             give you a way to check it: where claims came from,
                             what the system relied on, and when extra caution is
-                            worth it. If it is doing its job, you can dig in
-                            when you care and skim when you do not.
+                            worth it. If it&apos;s doing its job, you can dig in
+                            when you care and skim when you don&apos;t.
                         </p>
                     </section>
 
@@ -157,16 +173,16 @@ const AboutPage = (): JSX.Element => (
                         <h2 id="project-state-title">Project state</h2>
                         <p>
                             Footnote is open source and in early development.
-                            The core idea is here, but the hard part now is making 
-                            it sturdy, clear, and genuinely usable.
+                            The core idea is here, but the hard part now is
+                            making it sturdy, clear, and genuinely usable.
                         </p>
                         <p>
                             You can run it from the repository and self-host it
                             on your own infrastructure, with the model and
-                            provider choices you prefer. If you use hosted
+                            provider choices you prefer (e.g., OpenAI,
+                            Anthropic, Google, or others). If you use hosted
                             providers, their privacy and retention policies
-                            still apply. Footnote cannot hand-wave that away, so
-                            this page should not pretend otherwise.
+                            still apply.
                         </p>
                     </section>
 
@@ -177,11 +193,10 @@ const AboutPage = (): JSX.Element => (
                     >
                         <h2 id="contribute-title">Contribute</h2>
                         <p>
-                            If this lines up with the questions you already have
+                            If this lines up with the concerns you already have
                             about AI, jump in. There is real work across the
                             stack: backend, frontend, UX, docs, diagrams, and
-                            the unglamorous job of making complicated things
-                            understandable.
+                            the job of making complicated things understandable.
                         </p>
                         <p>
                             Start with the{' '}

--- a/packages/web/src/pages/AboutPage.tsx
+++ b/packages/web/src/pages/AboutPage.tsx
@@ -64,29 +64,28 @@ const AboutPage = (): JSX.Element => (
                     >
                         <h2 id="the-mission-title">The mission</h2>
                         <p>
-                            Footnote is for people who do not want to trust
-                            vibes. If an answer cannot show what it is leaning
-                            on, you are stuck taking it on faith. We are
-                            building responses you can interrogate: where claims
-                            came from, what shaped the answer, and what happened
-                            on the way there.
+                            This is also about control. Keeping your data
+                            private when you need to. Choosing how it runs. And
+                            being able to change things later without the whole
+                            thing falling apart.
                         </p>
                         <p>
-                            This is also about control over data, defaults, and
-                            dependencies. Your provider should not be a trap.
-                            Your model choice should not mean rewriting the
-                            whole system. Self-hosting should not be a weekend
-                            project. If you want stricter privacy boundaries,
-                            different infrastructure, lower costs, or a setup
-                            that better matches your values, that should be a
-                            practical choice.
+                            A lot of tools make it easy to start and hard to
+                            leave. We are trying to avoid that. You should not
+                            get stuck with one company just because it was the
+                            default. If you want to use a different kind of AI
+                            later, you should not have to rebuild everything.
+                            And if you want to run it yourself, that should be
+                            doable without a weekend of frustration.
                         </p>
                         <p>
-                            Trust is not a tone. It is a paper trail. If
-                            Footnote is doing its job, you end up with more
-                            leverage: more places to look, more ways to
-                            question, and fewer reasons to accept a confident
-                            paragraph at face value.
+                            And trust is not about how smooth the writing is. A
+                            clean, well-written answer can still be wrong, or
+                            leave out something important. Footnote tries to
+                            give you a way to check it: where claims came from,
+                            what the system relied on, and when extra caution is
+                            worth it. If it is doing its job, you can dig in
+                            when you care and skim when you do not.
                         </p>
                     </section>
 

--- a/packages/web/src/pages/AboutPage.tsx
+++ b/packages/web/src/pages/AboutPage.tsx
@@ -77,6 +77,14 @@ const AboutPage = (): JSX.Element => (
                             answer you got back.
                         </p>
                         <p>
+                            That uncertainty is not just a technical flaw. It
+                            changes the relationship between the person and the
+                            answer. A system that sounds sure of itself can make
+                            it easy to slide from usefulness into unearned
+                            trust, especially when there is very little for the
+                            reader to inspect.
+                        </p>
+                        <p>
                             Footnote starts from the idea that this uncertainty
                             matters. The goal is not to make AI feel magical. It
                             is to make it easier to look at a response and ask:
@@ -100,6 +108,14 @@ const AboutPage = (): JSX.Element => (
                             to the trace for that response.
                         </p>
                         <p>
+                            Each of those pieces is there for a reason. Sources
+                            help you follow specific claims back to something
+                            outside the assistant. A safety tier is a signal
+                            about the posture of the response, not a stamp of
+                            truth. The trace is where you go when the surface
+                            answer is not enough.
+                        </p>
+                        <p>
                             Those details are there to slow the experience down
                             in a useful way. Instead of treating the response as
                             a finished product, the page gives you a few handles
@@ -121,6 +137,13 @@ const AboutPage = (): JSX.Element => (
                             than the surface answer. It can show what model ran,
                             which workflow steps happened, and which outside
                             sources were used when they were part of the run.
+                        </p>
+                        <p>
+                            That matters because it replaces some of the usual
+                            black-box feeling with a visible record. Instead of
+                            being asked to trust the answer because it arrived
+                            fluently, you have something to examine when you
+                            need to understand how it came together.
                         </p>
                         <p>
                             That record does not prove the answer is correct.
@@ -167,6 +190,13 @@ const AboutPage = (): JSX.Element => (
                             underlying systems.
                         </p>
                         <p>
+                            The direction is broader than one interface. The aim
+                            is to make AI behavior more inspectable, leave more
+                            room for user choice, and rely less on opaque
+                            defaults that ask people to accept too much on
+                            faith.
+                        </p>
+                        <p>
                             You can run it from the repository and self-host it
                             with your own provider and infrastructure choices.
                             If you use hosted providers, their privacy and
@@ -186,6 +216,12 @@ const AboutPage = (): JSX.Element => (
                             backend work. Clearer docs, better trace UX,
                             stronger review flows, and sharper product writing
                             all matter here.
+                        </p>
+                        <p>
+                            The project also benefits from people who care about
+                            accountability, legibility, and how trust is earned
+                            in real interfaces, not just from people who want to
+                            tune models or ship features quickly.
                         </p>
                         <p>
                             If the project feels aligned with the questions you

--- a/packages/web/src/pages/AboutPage.tsx
+++ b/packages/web/src/pages/AboutPage.tsx
@@ -125,18 +125,17 @@ const AboutPage = (): JSX.Element => (
                             Sources are the obvious one. Open them and see what
                             a claim is anchored to. Safety notes are there for
                             the moments when &ldquo;sounds fine&rdquo; is not
-                            good enough. TRACE is the quick snapshot: what ran,
-                            what mattered, what shaped the answer. The trace
-                            link opens the longer record.
+                            good enough. TRACE is a quick posture snapshot of
+                            the response. The trace link opens the longer
+                            record.
                         </p>
                         <p>
-                            Open the trace page and you can look at the fuller
-                            trail: what model ran, which steps happened, what
-                            tools were used, and what supporting material showed
-                            up along the way. None of this guarantees the answer
-                            is correct. That is the point. It gives you
-                            something concrete to inspect instead of a smooth
-                            answer with no way to audit it.
+                            The trace page is the paper trail: which model ran,
+                            what steps happened, what tools were used, and what
+                            supporting material showed up along the way. It is
+                            not proof. It is accountability, something you can
+                            open and verify, instead of a polished answer with
+                            nothing behind it.
                         </p>
                         <div
                             className="card"
@@ -157,10 +156,9 @@ const AboutPage = (): JSX.Element => (
                     >
                         <h2 id="project-state-title">Project state</h2>
                         <p>
-                            Footnote is open source, and it is early. The core
-                            idea is here. The hard part now is making it
-                            sturdier, clearer, and genuinely usable, not just
-                            impressive in a demo.
+                            Footnote is open source and in early development.
+                            The core idea is here, but the hard part now is making 
+                            it sturdy, clear, and genuinely usable.
                         </p>
                         <p>
                             You can run it from the repository and self-host it

--- a/packages/web/src/pages/AboutPage.tsx
+++ b/packages/web/src/pages/AboutPage.tsx
@@ -37,13 +37,16 @@ const AboutPage = (): JSX.Element => (
             <header className="page-hero" aria-labelledby="about-title">
                 <h1 id="about-title">AI that carries receipts.</h1>
                 <p className="page-hero__summary">
-                    Footnote is a project about making AI easier to question.
+                    Footnote is an attempt to build something better.
                 </p>
                 <p>
-                    A lot of people have had the same experience with AI:
-                    something answers quickly, sounds sure of itself, and still
-                    leaves you with no clear way to tell what to trust. Footnote
-                    is one attempt to build something better.
+                    Most AI answers show up fast, confident, and polished, and
+                    you are still left guessing what is real. That is not a
+                    fluke. The industry gets rewarded for speed, lock-in, and
+                    persuasion, not for being checkable. Footnote gives you
+                    receipts: sources you can open, notes about uncertainty and
+                    safety when they matter, and a trace you can follow when you
+                    want the full story.
                 </p>
             </header>
 
@@ -61,28 +64,29 @@ const AboutPage = (): JSX.Element => (
                     >
                         <h2 id="the-mission-title">The mission</h2>
                         <p>
-                            Footnote is not trying to make AI feel smoother,
-                            faster, or more impressive than it already does. It
-                            is trying to make it less of a black box. That
-                            starts with answers you can examine, but it does not
-                            end there.
+                            Footnote is for people who do not want to trust
+                            vibes. If an answer cannot show what it is leaning
+                            on, you are stuck taking it on faith. We are
+                            building responses you can interrogate: where claims
+                            came from, what shaped the answer, and what happened
+                            on the way there.
                         </p>
                         <p>
-                            The project is also about privacy, ownership, and
-                            choice. People should have more say in how a system
-                            is run, where their data goes, which model or
-                            provider they rely on, and what trade-offs they are
-                            being asked to accept. If a person cares about
-                            hosting something themselves, using a different
-                            provider, or avoiding a setup that feels wrong to
-                            them, that should be a practical option.
+                            This is also about control over data, defaults, and
+                            dependencies. Your provider should not be a trap.
+                            Your model choice should not mean rewriting the
+                            whole system. Self-hosting should not be a weekend
+                            project. If you want stricter privacy boundaries,
+                            different infrastructure, lower costs, or a setup
+                            that better matches your values, that should be a
+                            practical choice.
                         </p>
                         <p>
-                            Under all of that is a simple idea: trust should be
-                            earned. Not by tone, not by polish, and not by
-                            pretending the system is wiser than it is. If
-                            Footnote is doing its job, it should leave people
-                            with more room to inspect, question, and choose.
+                            Trust is not a tone. It is a paper trail. If
+                            Footnote is doing its job, you end up with more
+                            leverage: more places to look, more ways to
+                            question, and fewer reasons to accept a confident
+                            paragraph at face value.
                         </p>
                     </section>
 
@@ -95,11 +99,10 @@ const AboutPage = (): JSX.Element => (
                             Reading a response
                         </h2>
                         <p>
-                            The easiest way to explain Footnote is to show what
-                            sits around an answer. The response itself is only
-                            one part. Around it, you may see sources, a safety
-                            label, TRACE information, and a link to open the
-                            full trace page.
+                            A Footnote response is not just the paragraph. It
+                            comes with handles: small, visible clues you can
+                            grab when you want to verify something, slow down,
+                            or dig deeper.
                         </p>
                         <div
                             className="card"
@@ -112,22 +115,21 @@ const AboutPage = (): JSX.Element => (
                             </p>
                         </div>
                         <p>
-                            The point of those pieces is not to decorate the
-                            answer. They give you places to look when you want
-                            to understand what the answer is leaning on. A
-                            source link can show where a claim came from. A
-                            safety label can tell you that extra care may be
-                            needed. TRACE is a compact picture of how the answer
-                            was shaped. The trace link opens the fuller record.
+                            Sources are the obvious one. Open them and see what
+                            a claim is anchored to. Safety notes are there for
+                            the moments when &ldquo;sounds fine&rdquo; is not
+                            good enough. TRACE is the quick snapshot: what ran,
+                            what mattered, what shaped the answer. The trace
+                            link opens the longer record.
                         </p>
                         <p>
-                            If you open the trace page, you get more than a
-                            short summary. You can see what ran, which steps
-                            happened, and what sources were involved when they
-                            were part of the answer. That still does not prove
-                            the answer is right. What it gives you is something
-                            real to inspect instead of a polished answer with no
-                            paper trail.
+                            Open the trace page and you can look at the fuller
+                            trail: what model ran, which steps happened, what
+                            tools were used, and what supporting material showed
+                            up along the way. None of this guarantees the answer
+                            is correct. That is the point. It gives you
+                            something concrete to inspect instead of a smooth
+                            answer with no way to audit it.
                         </p>
                         <div
                             className="card"
@@ -148,24 +150,18 @@ const AboutPage = (): JSX.Element => (
                     >
                         <h2 id="project-state-title">Project state</h2>
                         <p>
-                            Footnote is open source and still early. The core
-                            ideas are here, but the project is still being
-                            shaped, and a lot of the work ahead is about making
-                            those ideas sturdier, clearer, and easier to use.
-                        </p>
-                        <p>
-                            It is not just a web page or a demo. There is a
-                            broader effort underneath it: more checkable
-                            answers, more visible rules and defaults, more room
-                            for user choice, and more practical paths for
-                            self-hosting and provider choice.
+                            Footnote is open source, and it is early. The core
+                            idea is here. The hard part now is making it
+                            sturdier, clearer, and genuinely usable, not just
+                            impressive in a demo.
                         </p>
                         <p>
                             You can run it from the repository and self-host it
-                            with your own provider and infrastructure choices.
-                            If you use hosted providers, their privacy and
-                            retention rules still matter and should be reviewed
-                            on their own terms.
+                            on your own infrastructure, with the model and
+                            provider choices you prefer. If you use hosted
+                            providers, their privacy and retention policies
+                            still apply. Footnote cannot hand-wave that away, so
+                            this page should not pretend otherwise.
                         </p>
                     </section>
 
@@ -176,15 +172,14 @@ const AboutPage = (): JSX.Element => (
                     >
                         <h2 id="contribute-title">Contribute</h2>
                         <p>
-                            There is room here for more than one kind of
-                            contributor. Backend work matters. Frontend work
-                            matters. Writing, diagrams, documentation, and the
-                            hard job of making complicated ideas understandable
-                            matter too.
+                            If this lines up with the questions you already have
+                            about AI, jump in. There is real work across the
+                            stack: backend, frontend, UX, docs, diagrams, and
+                            the unglamorous job of making complicated things
+                            understandable.
                         </p>
                         <p>
-                            If the project lines up with the questions you
-                            already have about AI, start with the{' '}
+                            Start with the{' '}
                             <Link to="/onboarding">Onboarding page</Link> and
                             the project on{' '}
                             <a

--- a/packages/web/src/pages/OnboardingPage.tsx
+++ b/packages/web/src/pages/OnboardingPage.tsx
@@ -10,7 +10,6 @@
 import Header from '@components/Header';
 import Footer from '@components/Footer';
 import StickySectionToc from '@components/StickySectionToc';
-import { Link } from 'react-router-dom';
 
 type OnboardingSectionId =
     | 'status'
@@ -186,8 +185,8 @@ const OnboardingPage = (): JSX.Element => {
                         >
                             <h2 id="status-title">Status</h2>
                             <p>
-                                Onboarding reflects architecture as of May 2026.
-                                If you spot stale guidance, open an issue or PR.
+                                Onboarding reflects current architecture. If you
+                                spot stale guidance, open an issue or PR.
                             </p>
                         </section>
 
@@ -205,8 +204,15 @@ const OnboardingPage = (): JSX.Element => {
                                     dependencies with <code>pnpm</code>.
                                 </li>
                                 <li>
-                                    Follow <Link to="/setup">Setup</Link> to
-                                    configure one model provider.
+                                    Follow{' '}
+                                    <a
+                                        href="https://github.com/footnote-ai/footnote#quickstart"
+                                        target="_blank"
+                                        rel="noreferrer"
+                                    >
+                                        Quickstart
+                                    </a>{' '}
+                                    to configure one model provider.
                                 </li>
                                 <li>Run backend and web locally.</li>
                                 <li>Send one chat message in the web app.</li>

--- a/packages/web/src/pages/OnboardingPage.tsx
+++ b/packages/web/src/pages/OnboardingPage.tsx
@@ -1,25 +1,27 @@
 /**
- * @description: Contributor onboarding page for the web package that explains
- * current workflow architecture, key seams, and rendering responsibilities.
+ * @description: Contributor onboarding page that provides a first-run path,
+ * architecture orientation, and practical entry points by contributor type.
  * @footnote-scope: web
  * @footnote-module: OnboardingPage
- * @footnote-risk: medium - Incorrect onboarding details can mislead contributors during architecture changes.
- * @footnote-ethics: medium - Clear, accurate docs support transparency and reduce overclaiming of trust signals.
+ * @footnote-risk: medium - Incorrect onboarding guidance can cause contributor confusion and incorrect edits.
+ * @footnote-ethics: medium - Clear docs reduce misrepresentation of trust and provenance behavior.
  */
 
 import Header from '@components/Header';
 import Footer from '@components/Footer';
 import StickySectionToc from '@components/StickySectionToc';
+import { Link } from 'react-router-dom';
 
 type OnboardingSectionId =
+    | 'status'
+    | 'first-30-minutes'
     | 'repo-shape'
     | 'request-lifecycle'
-    | 'architectural-themes'
+    | 'architecture-rules'
     | 'workflow-boundaries'
     | 'symbols'
-    | 'web-rendering'
-    | 'gotchas'
-    | 'where-next';
+    | 'contributor-paths'
+    | 'gotchas';
 
 type SectionLink = {
     id: OnboardingSectionId;
@@ -28,15 +30,14 @@ type SectionLink = {
 
 type SymbolKind = 'type' | 'function' | 'seam' | 'module' | 'concept';
 
+type SymbolGroup = 'workflow execution' | 'planning' | 'context integrations';
+
 type SymbolReferenceEntry = {
     name: string;
     kind: SymbolKind;
+    group: SymbolGroup;
     filePath: string;
     explanation: string;
-};
-
-type WhereToReadNextEntry = {
-    filePath: string;
 };
 
 const REPOSITORY_BASE_URL = 'https://github.com/footnote-ai/footnote/blob/main';
@@ -44,145 +45,107 @@ const REPOSITORY_BASE_URL = 'https://github.com/footnote-ai/footnote/blob/main';
 const getRepositoryFileUrl = (filePath: string): string =>
     `${REPOSITORY_BASE_URL}/${filePath}`;
 
-const getRepositoryPathUrl = (filePath: string): string =>
-    `${REPOSITORY_BASE_URL}/${filePath}`;
-
 const sectionLinks: SectionLink[] = [
+    { id: 'status', label: 'Status' },
+    { id: 'first-30-minutes', label: 'First 30 minutes' },
     { id: 'repo-shape', label: 'Repo and package shape' },
     { id: 'request-lifecycle', label: 'Request lifecycle' },
-    { id: 'architectural-themes', label: 'Architectural themes' },
+    { id: 'architecture-rules', label: 'Architecture rules' },
     { id: 'workflow-boundaries', label: 'Workflow boundaries' },
     { id: 'symbols', label: 'Important symbols' },
-    { id: 'web-rendering', label: 'What web owns' },
+    { id: 'contributor-paths', label: 'Paths by contributor type' },
     { id: 'gotchas', label: 'Gotchas' },
-    { id: 'where-next', label: 'Where to read next' },
 ];
 
 const symbolReferences: SymbolReferenceEntry[] = [
     {
         name: 'workflowEngine',
         kind: 'module',
+        group: 'workflow execution',
         filePath: 'packages/backend/src/services/workflowEngine.ts',
         explanation:
-            'Runs step ordering, timing, limits, termination, and workflow lineage.',
-    },
-    {
-        name: 'chatOrchestrator',
-        kind: 'module',
-        filePath: 'packages/backend/src/services/chatOrchestrator.ts',
-        explanation:
-            'Assembles request context, planner seams, and runtime dependencies before chat execution.',
-    },
-    {
-        name: 'chatService',
-        kind: 'module',
-        filePath: 'packages/backend/src/services/chatService.ts',
-        explanation:
-            'Runs chat generation flow, workflow execution handoff, metadata assembly, and trace persistence.',
-    },
-    {
-        name: 'PlannerStepExecutor',
-        kind: 'type',
-        filePath: 'packages/backend/src/services/plannerWorkflowSeams.ts',
-        explanation:
-            'Injected executor interface that lets workflow run the planner as a timed plan step.',
-    },
-    {
-        name: 'PlannerResultApplier',
-        kind: 'seam',
-        filePath:
-            'packages/backend/src/services/chatOrchestrator/plannerResultApplier.ts',
-        explanation:
-            'Policy seam that applies backend rules to planner output before execution continues.',
-    },
-    {
-        name: 'AppliedPlanState',
-        kind: 'type',
-        filePath: 'packages/backend/src/services/plannerWorkflowSeams.ts',
-        explanation:
-            'Canonical post-policy plan snapshot carried into generation and metadata.',
-    },
-    {
-        name: 'PlanContinuationBuilder',
-        kind: 'seam',
-        filePath: 'packages/backend/src/services/plannerWorkflowSeams.ts',
-        explanation:
-            'Builds the post-plan continuation result: continue message flow or end with terminal action.',
-    },
-    {
-        name: 'PlanContinuation',
-        kind: 'type',
-        filePath: 'packages/backend/src/services/plannerWorkflowSeams.ts',
-        explanation:
-            'Union representing either continue_message or terminal_action after plan application.',
-    },
-    {
-        name: 'PlanTerminalAction',
-        kind: 'type',
-        filePath: 'packages/backend/src/services/plannerWorkflowSeams.ts',
-        explanation:
-            'Typed terminal outcomes: ignore, react, or image request without text generation.',
-    },
-    {
-        name: 'assemblePlanGenerationInput',
-        kind: 'function',
-        filePath:
-            'packages/backend/src/services/chatService/planGenerationInput.ts',
-        explanation:
-            'Builds generation-ready conversation payload after planner policy and prompt assembly.',
-    },
-    {
-        name: 'classifyPlanContinuation',
-        kind: 'function',
-        filePath:
-            'packages/backend/src/services/chatService/planContinuation.ts',
-        explanation:
-            'Classifies an applied execution plan into continue_message or terminal_action.',
+            'Owns step ordering, timing, limits, termination, and lineage records.',
     },
     {
         name: 'ContextStepExecutor',
         kind: 'type',
+        group: 'workflow execution',
         filePath: 'packages/backend/src/services/workflowEngine.ts',
         explanation:
-            'Executor contract for pre-generation context integrations inside workflow.',
-    },
-    {
-        name: 'ContextStepRequest',
-        kind: 'type',
-        filePath: 'packages/backend/src/services/workflowEngine.ts',
-        explanation:
-            'Structured request describing whether an integration was requested and eligible.',
+            'Contract for running context integrations before generation.',
     },
     {
         name: 'ContextStepResult',
         kind: 'type',
+        group: 'workflow execution',
         filePath: 'packages/backend/src/services/workflowEngine.ts',
         explanation:
-            'Structured context-step outcome with execution context, optional messages, and clarification.',
+            'Context-step outcome shape: execution context, optional messages, and sources.',
+    },
+    {
+        name: 'chatOrchestrator',
+        kind: 'module',
+        group: 'planning',
+        filePath: 'packages/backend/src/services/chatOrchestrator.ts',
+        explanation:
+            'Builds request context, planner seams, and runtime dependencies before chat execution.',
+    },
+    {
+        name: 'PlannerStepExecutor',
+        kind: 'type',
+        group: 'planning',
+        filePath: 'packages/backend/src/services/plannerWorkflowSeams.ts',
+        explanation:
+            'Injected plan-step executor used by workflow timing boundaries.',
+    },
+    {
+        name: 'PlanContinuationBuilder',
+        kind: 'seam',
+        group: 'planning',
+        filePath: 'packages/backend/src/services/plannerWorkflowSeams.ts',
+        explanation:
+            'Policy seam that decides continue_message vs terminal_action after plan application.',
     },
     {
         name: 'trace_target',
         kind: 'concept',
+        group: 'planning',
         filePath: 'packages/contracts/src/policy/types.ts',
         explanation:
-            'TRACE target posture recorded from planner/runtime temperament at response time.',
+            'TRACE target posture captured from planner/runtime temperament at response time.',
     },
     {
         name: 'trace_final',
         kind: 'concept',
+        group: 'planning',
         filePath: 'packages/contracts/src/policy/types.ts',
         explanation:
-            'TRACE final posture delivered in metadata for rendering and trace review.',
+            'TRACE final posture surfaced in metadata for rendering and trace review.',
+    },
+    {
+        name: 'createWeatherForecastContextStepExecutor',
+        kind: 'function',
+        group: 'context integrations',
+        filePath:
+            'packages/backend/src/services/contextIntegrations/weather/index.ts',
+        explanation:
+            'Weather context integration path used before generation and designed to fail open.',
+    },
+    {
+        name: 'createWebSearchContextStepExecutor',
+        kind: 'function',
+        group: 'context integrations',
+        filePath:
+            'packages/backend/src/services/contextIntegrations/webSearch/index.ts',
+        explanation:
+            'Current web-search context integration seam with provider fail-open behavior.',
     },
 ];
 
-const whereToReadNextEntries: WhereToReadNextEntry[] = [
-    { filePath: 'docs/architecture/context-integrations/weather-forecast.md' },
-    { filePath: 'packages/backend/src/services/workflowEngine.ts' },
-    { filePath: 'packages/backend/src/services/chatOrchestrator.ts' },
-    { filePath: 'packages/backend/src/services/plannerWorkflowSeams.ts' },
-    { filePath: 'packages/contracts/src/policy/types.ts' },
-    { filePath: 'packages/web/src/pages/TracePage.tsx' },
+const symbolGroups: SymbolGroup[] = [
+    'workflow execution',
+    'planning',
+    'context integrations',
 ];
 
 const SymbolBadge = ({ kind }: { kind: SymbolKind }): JSX.Element => (
@@ -204,24 +167,10 @@ const OnboardingPage = (): JSX.Element => {
                 >
                     <h1 id="onboarding-title">Contributor onboarding</h1>
                     <p className="page-hero__summary">
-                        Footnote is open source and built with community
-                        involvement in mind. This page is to help onboard
-                        contributors to the project.
+                        This page is a practical start path for contributors
+                        across backend, web, and docs work.
                     </p>
                 </header>
-
-                <section
-                    className="page-notice-banner"
-                    aria-label="Contribute page status"
-                >
-                    <p className="page-notice-banner__eyebrow">
-                        Under construction
-                    </p>
-                    <p className="page-notice-banner__copy">
-                        We are actively refining this page - Content subject to
-                        change.
-                    </p>
-                </section>
 
                 <div className="page-layout">
                     <StickySectionToc
@@ -232,41 +181,78 @@ const OnboardingPage = (): JSX.Element => {
                     <article className="page-content__main">
                         <section
                             className="page-section"
+                            id="status"
+                            aria-labelledby="status-title"
+                        >
+                            <h2 id="status-title">Status</h2>
+                            <p>
+                                Onboarding reflects architecture as of May 2026.
+                                If you spot stale guidance, open an issue or PR.
+                            </p>
+                        </section>
+
+                        <section
+                            className="page-section"
+                            id="first-30-minutes"
+                            aria-labelledby="first-30-minutes-title"
+                        >
+                            <h2 id="first-30-minutes-title">
+                                First 30 minutes
+                            </h2>
+                            <ol>
+                                <li>
+                                    Clone the repository and install
+                                    dependencies with <code>pnpm</code>.
+                                </li>
+                                <li>
+                                    Follow <Link to="/setup">Setup</Link> to
+                                    configure one model provider.
+                                </li>
+                                <li>Run backend and web locally.</li>
+                                <li>Send one chat message in the web app.</li>
+                                <li>Open the trace link from that response.</li>
+                                <li>
+                                    Confirm you can identify workflow steps,
+                                    safety tier, TRACE posture, and any source
+                                    links.
+                                </li>
+                            </ol>
+                            <p>
+                                After this loop, you have seen the full request
+                                path end-to-end.
+                            </p>
+                        </section>
+
+                        <section
+                            className="page-section"
                             id="repo-shape"
                             aria-labelledby="repo-shape-title"
                         >
                             <h2 id="repo-shape-title">
                                 Repo and package shape
                             </h2>
-                            <p>
-                                Main packages contributors usually touch
-                                together:
-                            </p>
                             <ul>
                                 <li>
-                                    <code>packages/backend</code>: runtime
-                                    authority for chat workflow, policy,
-                                    metadata, and trace storage.
+                                    <code>packages/backend</code>: execution
+                                    authority for workflow, policy, metadata,
+                                    and trace storage.
                                 </li>
                                 <li>
-                                    <code>packages/web</code>: browser surface
-                                    that renders chat output, traces, and
-                                    contributor-facing docs pages.
+                                    <code>packages/web</code>: browser rendering
+                                    of backend-owned output and docs pages.
                                 </li>
                                 <li>
                                     <code>packages/contracts</code>: shared
-                                    transport and metadata schema contracts used
-                                    across surfaces.
+                                    transport and metadata schema contracts.
                                 </li>
                                 <li>
                                     <code>packages/discord-bot</code>: Discord
-                                    transport and UI surface for the same
-                                    backend output.
+                                    transport/UI for backend-owned outputs.
                                 </li>
                                 <li>
                                     <code>packages/agent-runtime</code> and{' '}
-                                    <code>packages/prompts</code>: generation
-                                    runtime and prompt-layer dependencies.
+                                    <code>packages/prompts</code>: runtime and
+                                    prompt-layer dependencies.
                                 </li>
                             </ul>
                         </section>
@@ -281,81 +267,63 @@ const OnboardingPage = (): JSX.Element => {
                             </h2>
                             <ol>
                                 <li>
-                                    <code>/api/chat</code> enters backend
-                                    handlers and builds normalized request
-                                    context.
+                                    <code>/api/chat</code> normalizes request
+                                    input and conversation context.
                                 </li>
                                 <li>
-                                    <code>chatOrchestrator</code> resolves
-                                    execution mode and profile, then constructs
-                                    planner and context seams.
+                                    <code>chatOrchestrator</code> resolves mode
+                                    and profile context, then wires planner and
+                                    context seams.
                                 </li>
                                 <li>
-                                    <code>
-                                        chatService.runChatMessagesWithOutcome
-                                    </code>{' '}
-                                    resolves workflow runtime config and invokes{' '}
-                                    <code>workflowEngine</code>.
+                                    <code>workflowEngine</code> runs plan first,
+                                    then optional context integrations, then
+                                    generation/review flow.
                                 </li>
                                 <li>
-                                    Workflow runs <code>plan</code> first via{' '}
-                                    <code>PlannerStepExecutor</code>, then
-                                    applies policy via{' '}
-                                    <code>PlannerResultApplier</code>, then
-                                    branches through{' '}
-                                    <code>PlanContinuation</code>.
+                                    Planner output is policy-applied before
+                                    continuation. This keeps planner advisory
+                                    and backend policy authoritative.
                                 </li>
                                 <li>
-                                    If tool context is requested and eligible,
-                                    the context step runs before generation.
-                                    Weather currently uses this path.
-                                </li>
-                                <li>
-                                    Workflow continues with generation, optional
-                                    assess/revise loops, and bounded termination
-                                    based on limits and policy.
-                                </li>
-                                <li>
-                                    Metadata is assembled, including citations,
-                                    safety, TRACE, workflow lineage, and timing,
-                                    then stored in trace persistence.
+                                    Metadata is assembled and persisted with
+                                    citations, safety, TRACE, lineage, and
+                                    timing.
                                 </li>
                             </ol>
                         </section>
 
                         <section
                             className="page-section"
-                            id="architectural-themes"
-                            aria-labelledby="architectural-themes-title"
+                            id="architecture-rules"
+                            aria-labelledby="architecture-rules-title"
                         >
-                            <h2 id="architectural-themes-title">
-                                Architectural themes
+                            <h2 id="architecture-rules-title">
+                                Architecture rules
                             </h2>
                             <ul>
                                 <li>
-                                    Backend is the runtime boundary. Web and
-                                    Discord render backend-owned execution
-                                    truth.
+                                    If a decision changes runtime behavior, it
+                                    belongs in backend policy/orchestration, not
+                                    in web or Discord adapters.
                                 </li>
                                 <li>
-                                    Planner output is advisory. Policy
-                                    application is explicit and recorded after
-                                    planning.
+                                    Web and Discord render backend-owned truth.
+                                    They do not invent workflow history or mode
+                                    semantics.
                                 </li>
                                 <li>
-                                    Workflow lineage is canonical. If a step
-                                    happened, it should appear in workflow step
-                                    records.
+                                    Planner output is advisory. Keep policy
+                                    application explicit and inspectable.
                                 </li>
                                 <li>
-                                    Fail-open defaults are intentional. Runtime
-                                    should continue safely instead of blocking
-                                    on uncertain integration paths.
+                                    Public interfaces must stay serializable so
+                                    every surface can consume the same payload.
                                 </li>
                                 <li>
-                                    Public interfaces stay serializable, so
-                                    transport surfaces can render without
-                                    backend-only assumptions.
+                                    Fail-open behavior is intentional: uncertain
+                                    integrations should degrade safely, not
+                                    block execution.
                                 </li>
                             </ul>
                         </section>
@@ -366,27 +334,19 @@ const OnboardingPage = (): JSX.Element => {
                             aria-labelledby="workflow-boundaries-title"
                         >
                             <h2 id="workflow-boundaries-title">
-                                Workflow boundaries and ownership
+                                Workflow boundaries
                             </h2>
                             <p>
-                                <code>workflowEngine</code> owns timing, step
-                                ordering, limit enforcement, termination
-                                classification, and lineage records.
+                                <code>workflowEngine</code> owns execution
+                                control flow: step ordering, timing, limits, and
+                                termination lineage.
                             </p>
                             <p>
-                                It does not own planner policy semantics,
-                                provider behavior, transport rendering, or UI
-                                labeling decisions. Those stay in
-                                orchestrator/policy layers and rendering
-                                surfaces.
+                                Common boundary mistakes are routing logic in
+                                the engine that should live in
+                                policy/orchestrator, or policy decisions in UI
+                                adapters.
                             </p>
-                            <div className="onboarding-callout onboarding-callout--warn">
-                                <p>
-                                    Keep this boundary intact: engine is
-                                    execution control flow; policy and
-                                    presentation stay outside the engine.
-                                </p>
-                            </div>
                         </section>
 
                         <section
@@ -395,89 +355,99 @@ const OnboardingPage = (): JSX.Element => {
                             aria-labelledby="symbols-title"
                         >
                             <h2 id="symbols-title">Important symbols</h2>
-                            <div className="onboarding-symbol-table-wrap">
-                                <table className="onboarding-symbol-table">
-                                    <thead>
-                                        <tr>
-                                            <th scope="col">Symbol</th>
-                                            <th scope="col">Explanation</th>
-                                        </tr>
-                                    </thead>
-                                    <tbody>
-                                        {symbolReferences.map((entry) => (
-                                            <tr key={entry.name}>
-                                                <td className="onboarding-symbol-table__symbol-cell">
-                                                    <a
-                                                        className="onboarding-symbol-table__symbol-link"
-                                                        href={getRepositoryFileUrl(
-                                                            entry.filePath
-                                                        )}
-                                                        target="_blank"
-                                                        rel="noreferrer"
-                                                        aria-label={`Open ${entry.name} in repository`}
-                                                    >
-                                                        <code className="onboarding-symbol-table__inline-code">
-                                                            {entry.name}
-                                                        </code>
-                                                    </a>
-                                                    <div className="onboarding-symbol-table__kind">
-                                                        <SymbolBadge
-                                                            kind={entry.kind}
-                                                        />
-                                                    </div>
-                                                </td>
-                                                <td>{entry.explanation}</td>
-                                            </tr>
-                                        ))}
-                                    </tbody>
-                                </table>
-                            </div>
+                            {symbolGroups.map((group) => (
+                                <section
+                                    key={group}
+                                    className="onboarding-symbol-group"
+                                    aria-labelledby={`symbol-group-${group.replace(/\s+/g, '-')}`}
+                                >
+                                    <h3
+                                        id={`symbol-group-${group.replace(/\s+/g, '-')}`}
+                                    >
+                                        {group}
+                                    </h3>
+                                    <div className="onboarding-symbol-table-wrap">
+                                        <table className="onboarding-symbol-table">
+                                            <thead>
+                                                <tr>
+                                                    <th scope="col">Symbol</th>
+                                                    <th scope="col">
+                                                        Explanation
+                                                    </th>
+                                                </tr>
+                                            </thead>
+                                            <tbody>
+                                                {symbolReferences
+                                                    .filter(
+                                                        (entry) =>
+                                                            entry.group ===
+                                                            group
+                                                    )
+                                                    .map((entry) => (
+                                                        <tr key={entry.name}>
+                                                            <td className="onboarding-symbol-table__symbol-cell">
+                                                                <a
+                                                                    className="onboarding-symbol-table__symbol-link"
+                                                                    href={getRepositoryFileUrl(
+                                                                        entry.filePath
+                                                                    )}
+                                                                    target="_blank"
+                                                                    rel="noreferrer"
+                                                                    aria-label={`Open ${entry.name} in repository`}
+                                                                >
+                                                                    <code className="onboarding-symbol-table__inline-code">
+                                                                        {
+                                                                            entry.name
+                                                                        }
+                                                                    </code>
+                                                                </a>
+                                                                <div className="onboarding-symbol-table__kind">
+                                                                    <SymbolBadge
+                                                                        kind={
+                                                                            entry.kind
+                                                                        }
+                                                                    />
+                                                                </div>
+                                                            </td>
+                                                            <td>
+                                                                {
+                                                                    entry.explanation
+                                                                }
+                                                            </td>
+                                                        </tr>
+                                                    ))}
+                                            </tbody>
+                                        </table>
+                                    </div>
+                                </section>
+                            ))}
                         </section>
 
                         <section
                             className="page-section"
-                            id="web-rendering"
-                            aria-labelledby="web-rendering-title"
+                            id="contributor-paths"
+                            aria-labelledby="contributor-paths-title"
                         >
-                            <h2 id="web-rendering-title">What web owns</h2>
+                            <h2 id="contributor-paths-title">
+                                Paths by contributor type
+                            </h2>
                             <ul>
                                 <li>
-                                    Render workflow lineage as recorded by
-                                    backend; do not infer missing step history.
+                                    Backend contributor: start with
+                                    <code>workflowEngine</code>,{' '}
+                                    <code>chatOrchestrator</code>, and related
+                                    tests in <code>packages/backend/test</code>.
                                 </li>
                                 <li>
-                                    Show workflow <code>plan</code> steps in
-                                    trace timelines when present.
+                                    Web contributor: start with
+                                    <code>TracePage</code> and provenance
+                                    rendering components in
+                                    <code>packages/web/src</code>.
                                 </li>
                                 <li>
-                                    Keep citations and source links clear and
-                                    visible.
-                                </li>
-                                <li>
-                                    Render TRACE axes as posture indicators, not
-                                    accuracy scores.
-                                </li>
-                                <li>
-                                    Do not imply <code>web_search</code> is
-                                    already migrated into context-step flow.
-                                </li>
-                                <li>
-                                    Do not claim a user selected a mode unless
-                                    request or backend metadata says so.
-                                </li>
-                                <li>
-                                    Explain mode labels in plain language:
-                                    <code>fast</code> is short-path planning
-                                    without review;
-                                    <code>balanced</code> includes a lighter
-                                    review pass;
-                                    <code>grounded</code> keeps stricter
-                                    evidence posture and review depth.
-                                </li>
-                                <li>
-                                    Keep safety tier and citations visible as
-                                    trust surfaces in page summaries and detail
-                                    views.
+                                    Docs/design contributor: start with
+                                    <code>docs/architecture/README.md</code> and
+                                    context integration architecture docs.
                                 </li>
                             </ul>
                         </section>
@@ -491,53 +461,31 @@ const OnboardingPage = (): JSX.Element => {
                             <ul>
                                 <li>
                                     Planner output is advisory. Backend policy
-                                    can adjust or reject parts of it before
-                                    execution.
+                                    can adjust or reject planner fields before
+                                    execution continues.
                                 </li>
                                 <li>
-                                    Fast mode does not bypass planning. If
-                                    behavior changes, verify profile limits
-                                    before assuming a planner bug.
+                                    Balanced and grounded modes both plan; do
+                                    not assume planning was skipped from mode
+                                    alone.
                                 </li>
                                 <li>
-                                    Weather context integration is implemented
-                                    and fail-open. Tool failure should not block
-                                    message completion.
+                                    TRACE target and TRACE final should both be
+                                    populated for message paths. Verify both
+                                    fields when changing planner or metadata
+                                    assembly code.
                                 </li>
                                 <li>
-                                    TRACE target/final are required rendering
-                                    inputs for message outcomes; verify both
-                                    when editing planner or metadata assembly
-                                    paths.
+                                    Weather context integration is fail-open.
+                                    Tool failure should degrade safely rather
+                                    than block message completion.
                                 </li>
                                 <li>
-                                    TrustGraph metadata exists, but user-facing
-                                    trust claims should stay tied to fields
-                                    actually present in the trace payload.
+                                    <code>web_search</code> remains a legacy
+                                    integration path in parts of the stack; do
+                                    not assume parity with every context-step
+                                    integration flow.
                                 </li>
-                            </ul>
-                        </section>
-
-                        <section
-                            className="page-section"
-                            id="where-next"
-                            aria-labelledby="where-next-title"
-                        >
-                            <h2 id="where-next-title">Where to read next</h2>
-                            <ul>
-                                {whereToReadNextEntries.map((entry) => (
-                                    <li key={entry.filePath}>
-                                        <a
-                                            href={getRepositoryPathUrl(
-                                                entry.filePath
-                                            )}
-                                            target="_blank"
-                                            rel="noreferrer"
-                                        >
-                                            <code>{entry.filePath}</code>
-                                        </a>
-                                    </li>
-                                ))}
                             </ul>
                         </section>
                     </article>


### PR DESCRIPTION
## Summary
This PR resolves two correctness issues and then refines contributor/user-facing docs copy for clarity and trust.

1. Fixes a TRACE propagation gap so planner temperament is preserved on short-circuit message paths.
2. Removes stale `fast` user-facing mode references and updates onboarding structure/content.
3. Rewrites the About page into a clearer, less AI-coded, more plainspoken narrative with diagram placeholders.

## What Changed
- Backend correctness fix:
  - `chatService` now passes `plannerTemperament` through context-step short-circuit metadata assembly.
  - Added regression coverage to ensure short-circuit message metadata preserves planner temperament.
- Onboarding page updates:
  - Replaced stale `fast` mode language with current balanced/grounded framing.
  - Reworked onboarding flow to be more contributor-actionable (first-30-min path, grouped symbols, contributor paths, updated gotchas).
  - Replaced the old status banner pattern with a dated status note.
- About page rewrite:
  - Multiple iterative copy passes to remove AI-sounding cadence and improve readability for non-technical readers.
  - Collapsed to 4 sections: `The mission`, `Reading a response`, `Project state`, `Contribute`.
  - Added explicit placeholders for response and trace diagrams.
  - Clarified TRACE semantics vs trace-page semantics:
    - TRACE = posture metadata snapshot
    - Trace page = execution/provenance paper trail
  - Added a direct Quickstart link for “run it yourself.”

## Why
- New contributors were seeing stale mode semantics (`fast`) in onboarding copy.
- TRACE fields could be underpopulated on short-circuit paths, creating a credibility gap in trace/provenance surfaces.
- About/onboarding copy was too abstract and “AI-coded,” which made the project mission harder to understand for skeptical or non-technical readers.

## Implementation Notes
- Backend behavior change is intentionally narrow:
  - It only threads existing `plannerTemperament` into short-circuit metadata context.
  - It does not alter policy routing, workflow ownership boundaries, or external API contracts.
- Web changes are content/structure-focused and keep existing routing/layout patterns.
- Diagram placeholders are intentionally left as explicit insertion points for upcoming labeled visuals.

## Validation
- Lint and formatting checks were run after edits (`pnpm lint:fix`, `pnpm lint`).
- Backend regression test for short-circuit temperament propagation was added and verified.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Restructured About page with new sections covering project mission, response reading, project status, and contribution guidelines.
  * Enhanced contributor onboarding documentation with reorganized architecture guides, workflow guidance, and reference materials.
  * Improved symbol documentation with better organization and grouping for easier navigation.

* **Tests**
  * Added test coverage for response metadata handling in chat workflow scenarios.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/footnote-ai/footnote/pull/358)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->