### PR TITLE
Centralize conversation context assembly

### DIFF
--- a/packages/backend/src/handlers/chat.ts
+++ b/packages/backend/src/handlers/chat.ts
@@ -17,6 +17,7 @@ import type {
 import type { CreateChatServiceOptions } from '../services/chatService.js';
 import { runtimeConfig } from '../config.js';
 import { createChatOrchestrator } from '../services/chatOrchestrator.js';
+import { ConversationContextAssemblyError } from '../services/conversationContextService.js';
 import type { IncidentAlertRouter } from '../services/incidentAlerts.js';
 import type { WeatherForecastTool } from '../services/contextIntegrations/weather/index.js';
 import type { InternalImageDescriptionTaskService } from '../services/internalText.js';
@@ -329,6 +330,18 @@ const createChatHandler = ({
                 generationError instanceof Error
                     ? generationError.message
                     : String(generationError);
+            if (generationError instanceof ConversationContextAssemblyError) {
+                sendJson(res, 400, {
+                    error: 'Invalid conversation context',
+                    details: generationError.reasonCode,
+                });
+                logRequest(
+                    req,
+                    res,
+                    `chat context-assembly-error ${generationError.reasonCode}`
+                );
+                return;
+            }
 
             sendJson(res, 502, {
                 error: 'AI generation failed',

--- a/packages/backend/src/services/chatOrchestrator.ts
+++ b/packages/backend/src/services/chatOrchestrator.ts
@@ -45,6 +45,8 @@ import { createReverseImageSearchContextStepExecutor } from './contextIntegratio
 import { createSerpApiReverseImageSearchProvider } from './contextIntegrations/reverseImageSearch/index.js';
 import { createWebSearchContextStepExecutor } from './contextIntegrations/webSearch/index.js';
 import { createPlannerResultApplier } from './chatOrchestrator/plannerResultApplier.js';
+import type { ConversationContextEnvelope } from './conversationContextService.js';
+import { toSnapshotContextEnvelope } from './conversationContextService.js';
 import { runtimeConfig } from '../config.js';
 import { logger } from '../utils/logger.js';
 import type { IncidentAlertRouter } from './incidentAlerts.js';
@@ -211,10 +213,30 @@ export const createChatOrchestrator = ({
         // Total wall-clock budget for this request from planner entry to
         // final response payload. This is exposed as telemetry only.
         const orchestrationStartedAt = Date.now();
-        const { normalizedConversation, normalizedRequest } = normalizeRequest(
-            request,
-            chatOrchestratorLogger
-        );
+        let normalizedConversation: PostChatRequest['conversation'];
+        let normalizedRequest: PostChatRequest;
+        let contextEnvelope: ConversationContextEnvelope;
+        try {
+            const normalized = normalizeRequest(
+                request,
+                chatOrchestratorLogger
+            );
+            normalizedConversation = normalized.normalizedConversation;
+            normalizedRequest = normalized.normalizedRequest;
+            contextEnvelope = normalized.contextEnvelope;
+        } catch (error) {
+            chatOrchestratorLogger.error('chat.context.assembly_failed', {
+                event: 'chat.context.assembly_failed',
+                surface: request.surface,
+                reasonCode:
+                    error && typeof error === 'object' && 'reasonCode' in error
+                        ? (error as { reasonCode?: string }).reasonCode
+                        : 'context_assembly_error',
+                reason: error instanceof Error ? error.message : String(error),
+                correlation: buildCorrelationIds(request, null),
+            });
+            throw error;
+        }
         const clarificationContinuation =
             resolveWeatherClarificationContinuation(normalizedRequest);
         let evaluatorExecutionContext: EvaluatorExecutionContext | undefined;
@@ -629,6 +651,7 @@ export const createChatOrchestrator = ({
                 systemPrompt: promptLayers.systemPrompt,
                 personaPrompt,
                 normalizedConversation,
+                contextEnvelope,
                 executionPlanForPrompt: executionPlan,
                 ...(plannerApplication.surfacePolicy !== undefined && {
                     surfacePolicy: plannerApplication.surfacePolicy,
@@ -667,6 +690,7 @@ export const createChatOrchestrator = ({
                 },
                 plannerTemperament: executionPlan.generation.temperament,
                 conversationSnapshot: postPlanAssembly.conversationSnapshot,
+                contextEnvelope,
                 ...(plannerApplication.contextStepRequests !== undefined && {
                     contextStepRequests: plannerApplication.contextStepRequests,
                 }),
@@ -688,12 +712,14 @@ export const createChatOrchestrator = ({
                 policyId: resolvedExecutionContract.policyId,
                 policyVersion: resolvedExecutionContract.policyVersion,
             },
+            contextEnvelope: toSnapshotContextEnvelope(contextEnvelope),
         });
         const executionContractScopeTuple =
             buildExecutionContractScopeTuple(normalizedRequest);
         const response = await chatService.runChatMessagesWithOutcome({
             messages: baseConversationMessages,
             conversationSnapshot: baseConversationSnapshot,
+            contextEnvelope,
             orchestrationStartedAtMs: orchestrationStartedAt,
             safetyTier: evaluatorSafetyTierHint,
             model: defaultResponseProfile.providerModel,

--- a/packages/backend/src/services/chatOrchestrator/requestNormalization.ts
+++ b/packages/backend/src/services/chatOrchestrator/requestNormalization.ts
@@ -8,10 +8,14 @@
  */
 import type { CorrelationEnvelope } from '@footnote/contracts';
 import type { PostChatRequest } from '@footnote/contracts/web';
-import { normalizeDiscordConversation } from '../chatConversationNormalization.js';
+import {
+    buildConversationContext,
+    type ConversationContextEnvelope,
+} from '../conversationContextService.js';
 import type { ScopeTuple } from '../executionContractTrustGraph/trustGraphEvidenceTypes.js';
 
 type ConversationNormalizationLogger = {
+    warn: (message: string, meta?: Record<string, unknown>) => void;
     debug: (message: string, meta?: Record<string, unknown>) => void;
 };
 
@@ -30,16 +34,10 @@ export const normalizeRequest = (
 ): {
     normalizedConversation: PostChatRequest['conversation'];
     normalizedRequest: PostChatRequest;
+    contextEnvelope: ConversationContextEnvelope;
 } => {
-    const normalizedConversation =
-        request.surface === 'discord'
-            ? normalizeDiscordConversation(request, logger)
-            : request.conversation.map(
-                  (message: PostChatRequest['conversation'][number]) => ({
-                      role: message.role,
-                      content: message.content,
-                  })
-              );
+    const context = buildConversationContext(request, logger);
+    const normalizedConversation = context.messages;
 
     return {
         normalizedConversation,
@@ -47,6 +45,7 @@ export const normalizeRequest = (
             ...request,
             conversation: normalizedConversation,
         },
+        contextEnvelope: context.contextEnvelope,
     };
 };
 

--- a/packages/backend/src/services/chatService.ts
+++ b/packages/backend/src/services/chatService.ts
@@ -1027,7 +1027,9 @@ export const createChatService = ({
                         toolRequest,
                         model,
                         defaultModel,
-                        conversationSnapshot,
+                        conversationSnapshot:
+                            workflowConversationSnapshot ??
+                            conversationSnapshot,
                         latestUserInput,
                         buildResponseMetadata,
                     });
@@ -1064,7 +1066,9 @@ export const createChatService = ({
                         toolRequest,
                         model,
                         defaultModel,
-                        conversationSnapshot,
+                        conversationSnapshot:
+                            workflowConversationSnapshot ??
+                            conversationSnapshot,
                         latestUserInput,
                         buildResponseMetadata,
                     });

--- a/packages/backend/src/services/chatService.ts
+++ b/packages/backend/src/services/chatService.ts
@@ -78,6 +78,7 @@ import { logger } from '../utils/logger.js';
 import { runtimeConfig } from '../config.js';
 import { buildToolClarificationResponse } from './tools/toolClarificationResponse.js';
 import { buildWeatherToolFailureResponse } from './tools/weatherToolFailureResponse.js';
+import type { ConversationContextEnvelope } from './conversationContextService.js';
 
 const SURFACED_NO_GENERATION_MESSAGE =
     'I could not generate a response for this request.';
@@ -639,6 +640,7 @@ export type RunChatInput = {
 export type RunChatMessagesInput = {
     messages: RuntimeMessage[];
     conversationSnapshot: string;
+    contextEnvelope: ConversationContextEnvelope;
     orchestrationStartedAtMs?: number;
     plannerTemperament?: PartialResponseTemperament;
     safetyTier?: SafetyTier;
@@ -692,6 +694,13 @@ type RunChatMessagesLegacyResult = {
     metadata: ResponseMetadata;
     generationDurationMs: number;
     finalToolExecutionTelemetry?: FinalToolExecutionTelemetry;
+};
+
+type RunChatMessagesCompatibilityInput = Omit<
+    RunChatMessagesInput,
+    'contextEnvelope'
+> & {
+    contextEnvelope?: ConversationContextEnvelope;
 };
 
 /**
@@ -800,6 +809,7 @@ export const createChatService = ({
     const runChatMessagesWithOutcome = async ({
         messages,
         conversationSnapshot,
+        contextEnvelope,
         orchestrationStartedAtMs,
         plannerTemperament,
         safetyTier,
@@ -822,6 +832,11 @@ export const createChatService = ({
         ExecutionContract,
         steerabilityControls,
     }: RunChatMessagesInput): Promise<RunChatMessagesResult> => {
+        if (!contextEnvelope) {
+            throw new Error(
+                'contextEnvelope is required for runChatMessagesWithOutcome.'
+            );
+        }
         const toShortCircuitMessageResult = (
             response: PostChatResponse,
             finalToolExecutionTelemetry: FinalToolExecutionTelemetry
@@ -957,6 +972,7 @@ export const createChatService = ({
                 plannerStepRequest: effectivePlannerStepRequest,
                 plannerStepExecutor: effectivePlannerStepExecutor,
                 planContinuationBuilder,
+                contextEnvelope,
                 contextStepRequests:
                     effectiveContextStepRequests.length > 0
                         ? effectiveContextStepRequests
@@ -1504,9 +1520,27 @@ export const createChatService = ({
     };
 
     const runChatMessages = async (
-        input: RunChatMessagesInput
+        input: RunChatMessagesCompatibilityInput
     ): Promise<RunChatMessagesLegacyResult> => {
-        const result = await runChatMessagesWithOutcome(input);
+        // Compatibility seam for older internal/test callers that still invoke
+        // runChatMessages directly without orchestrator-owned context assembly.
+        const compatibilityEnvelope: ConversationContextEnvelope =
+            input.contextEnvelope ?? {
+                participants: [],
+                turns: [],
+                diagnostics: {
+                    surface: 'web',
+                    totalInputMessages: 0,
+                    projectedMessageCount: 0,
+                    trimmedMessageCount: 0,
+                    sanitizedTimestampCount: 0,
+                    projectedSpeakerLabelCount: 0,
+                },
+            };
+        const result = await runChatMessagesWithOutcome({
+            ...input,
+            contextEnvelope: compatibilityEnvelope,
+        });
         if (
             result.kind !== 'message' ||
             result.message === undefined ||
@@ -1549,6 +1583,18 @@ export const createChatService = ({
         const response = await runChatMessagesWithOutcome({
             messages,
             conversationSnapshot: question.trim(),
+            contextEnvelope: {
+                participants: [],
+                turns: [],
+                diagnostics: {
+                    surface: 'web',
+                    totalInputMessages: 1,
+                    projectedMessageCount: 1,
+                    trimmedMessageCount: 0,
+                    sanitizedTimestampCount: 0,
+                    projectedSpeakerLabelCount: 0,
+                },
+            },
         });
 
         if (response.kind !== 'message') {

--- a/packages/backend/src/services/chatService/planGenerationInput.ts
+++ b/packages/backend/src/services/chatService/planGenerationInput.ts
@@ -17,6 +17,10 @@ import type {
 import type { PlannerPayloadChatPlan } from '../chatOrchestrator/plannerPayload.js';
 import { buildPlannerPayload } from '../chatOrchestrator/plannerPayload.js';
 import type { ChatGenerationToolIntent } from '../chatGenerationTypes.js';
+import {
+    toSnapshotContextEnvelope,
+    type ConversationContextEnvelope,
+} from '../conversationContextService.js';
 
 export type PlanGenerationInputParams = {
     systemPrompt: string;
@@ -24,6 +28,7 @@ export type PlanGenerationInputParams = {
     normalizedConversation: Array<
         Pick<ChatConversationMessage, 'role' | 'content'>
     >;
+    contextEnvelope: ConversationContextEnvelope;
     executionPlanForPrompt: PlannerPayloadChatPlan;
     surfacePolicy?: { coercedFrom: 'message' | 'react' | 'ignore' | 'image' };
     normalizedRequest: PostChatRequest;
@@ -93,6 +98,7 @@ export const assemblePlanGenerationInput = (
             policyId: input.executionContract.policyId,
             policyVersion: input.executionContract.policyVersion,
         },
+        contextEnvelope: toSnapshotContextEnvelope(input.contextEnvelope),
     });
 
     return {

--- a/packages/backend/src/services/conversationContextService.ts
+++ b/packages/backend/src/services/conversationContextService.ts
@@ -128,7 +128,10 @@ const trimDiscordConversationWindow = (
     for (let index = conversation.length - 1; index >= 0; index -= 1) {
         const message = conversation[index];
         if (!message) {
-            continue;
+            throw new ConversationContextAssemblyError(
+                'invalid_message_shape',
+                `Conversation message at index ${index} is not an object.`
+            );
         }
         if (message.role === 'system') {
             retainedReverse.push(message);
@@ -235,6 +238,13 @@ export const buildConversationContext = (
         }
 
         if (typeof message.content !== 'string') {
+            throw new ConversationContextAssemblyError(
+                'missing_content',
+                `Conversation message at index ${index} is missing string content.`
+            );
+        }
+
+        if (message.content.trim().length === 0) {
             throw new ConversationContextAssemblyError(
                 'missing_content',
                 `Conversation message at index ${index} is missing string content.`

--- a/packages/backend/src/services/conversationContextService.ts
+++ b/packages/backend/src/services/conversationContextService.ts
@@ -1,0 +1,381 @@
+/**
+ * @description: Builds canonical conversation messages plus a backend-owned
+ * context envelope used by planner/generation workflow seams.
+ * @footnote-scope: core
+ * @footnote-module: ConversationContextService
+ * @footnote-risk: high - Conversation assembly is the single history source for planner and generation.
+ * @footnote-ethics: high - Incorrect identity/visibility handling can misattribute speakers or leak backend-only context.
+ */
+import type {
+    ChatConversationMessage,
+    PostChatRequest,
+} from '@footnote/contracts/web';
+
+const DISCORD_CONTEXT_WINDOW_SIZE = 24;
+
+type ConversationContextLogger = {
+    warn: (message: string, meta?: Record<string, unknown>) => void;
+    debug: (message: string, meta?: Record<string, unknown>) => void;
+};
+
+export type ConversationContextVisibility = 'model_visible' | 'backend_only';
+export type ConversationContextAuthority =
+    | 'conversation'
+    | 'instructional'
+    | 'advisory'
+    | 'internal';
+
+export type ConversationContextEnvelope = {
+    participants: Array<{
+        speakerId: string;
+        speakerLabel: string;
+        roleHint: 'user' | 'assistant' | 'system';
+    }>;
+    turns: Array<{
+        turnId: string;
+        role: 'system' | 'user' | 'assistant';
+        speakerId: string;
+        speakerLabel: string;
+        visibility: ConversationContextVisibility;
+        authority: ConversationContextAuthority;
+        messageId?: string;
+        createdAt?: string;
+    }>;
+    diagnostics: {
+        surface: PostChatRequest['surface'];
+        totalInputMessages: number;
+        projectedMessageCount: number;
+        trimmedMessageCount: number;
+        sanitizedTimestampCount: number;
+        projectedSpeakerLabelCount: number;
+    };
+};
+
+export type ConversationContextProjectionTurn = {
+    role: 'system' | 'user' | 'assistant';
+    content: string;
+    speakerId: string;
+    speakerLabel: string;
+    visibility: ConversationContextVisibility;
+};
+
+export type ConversationContextServiceOutput = {
+    messages: Array<Pick<ChatConversationMessage, 'role' | 'content'>>;
+    contextEnvelope: ConversationContextEnvelope;
+};
+
+export type ConversationContextEnvelopeSnapshot = {
+    schemaVersion: 'v1';
+    counts: {
+        participantCount: number;
+        turnCount: number;
+        projectedMessageCount: number;
+    };
+    roleCounts: {
+        system: number;
+        user: number;
+        assistant: number;
+    };
+    visibilityCounts: {
+        modelVisible: number;
+        backendOnly: number;
+    };
+    authorityCounts: Partial<Record<ConversationContextAuthority, number>>;
+    diagnostics: ConversationContextEnvelope['diagnostics'];
+};
+
+export class ConversationContextAssemblyError extends Error {
+    readonly reasonCode:
+        | 'invalid_message_shape'
+        | 'invalid_role'
+        | 'missing_content'
+        | 'missing_speaker_identity';
+
+    constructor(
+        reasonCode: ConversationContextAssemblyError['reasonCode'],
+        message: string
+    ) {
+        super(message);
+        this.name = 'ConversationContextAssemblyError';
+        this.reasonCode = reasonCode;
+    }
+}
+
+const normalizeScopeValue = (value: unknown): string | undefined => {
+    if (typeof value !== 'string') {
+        return undefined;
+    }
+    const trimmed = value.trim();
+    return trimmed.length > 0 ? trimmed : undefined;
+};
+
+const parseCreatedAt = (value: unknown): string | undefined => {
+    if (typeof value !== 'string') {
+        return undefined;
+    }
+    const date = new Date(value);
+    if (Number.isNaN(date.getTime())) {
+        return undefined;
+    }
+    return date.toISOString();
+};
+
+const trimDiscordConversationWindow = (
+    conversation: PostChatRequest['conversation']
+): PostChatRequest['conversation'] => {
+    const retainedReverse: PostChatRequest['conversation'] = [];
+    let nonSystemCount = 0;
+    for (let index = conversation.length - 1; index >= 0; index -= 1) {
+        const message = conversation[index];
+        if (!message) {
+            continue;
+        }
+        if (message.role === 'system') {
+            retainedReverse.push(message);
+            continue;
+        }
+        if (nonSystemCount >= DISCORD_CONTEXT_WINDOW_SIZE) {
+            continue;
+        }
+        retainedReverse.push(message);
+        nonSystemCount += 1;
+    }
+    return retainedReverse.reverse();
+};
+
+const normalizeConversationWindow = (
+    request: PostChatRequest
+): {
+    conversation: PostChatRequest['conversation'];
+    trimmedMessageCount: number;
+} => {
+    if (request.surface !== 'discord') {
+        return {
+            conversation: request.conversation,
+            trimmedMessageCount: 0,
+        };
+    }
+    const trimmedConversation = trimDiscordConversationWindow(
+        request.conversation
+    );
+    return {
+        conversation: trimmedConversation,
+        trimmedMessageCount: Math.max(
+            0,
+            request.conversation.length - trimmedConversation.length
+        ),
+    };
+};
+
+/**
+ * Produces one canonical, role-aligned message list plus a backend-owned
+ * envelope. If role/speaker identity cannot be determined, fail closed.
+ */
+export const projectConversationMessages = (
+    turns: ConversationContextProjectionTurn[]
+): Array<Pick<ChatConversationMessage, 'role' | 'content'>> => {
+    const visibleHumanSpeakerIds = new Set(
+        turns
+            .filter(
+                (turn) =>
+                    turn.visibility === 'model_visible' && turn.role === 'user'
+            )
+            .map((turn) => turn.speakerId)
+    );
+    const requiresSpeakerProjection = visibleHumanSpeakerIds.size > 1;
+    return turns
+        .filter((turn) => turn.visibility === 'model_visible')
+        .map((turn) => ({
+            role: turn.role,
+            content:
+                requiresSpeakerProjection && turn.role !== 'system'
+                    ? `[${turn.speakerLabel}] ${turn.content}`
+                    : turn.content,
+        }));
+};
+
+/**
+ * Produces one canonical, role-aligned message list plus a backend-owned
+ * envelope. If role/speaker identity cannot be determined, fail closed.
+ */
+export const buildConversationContext = (
+    request: PostChatRequest,
+    logger: ConversationContextLogger
+): ConversationContextServiceOutput => {
+    const { conversation, trimmedMessageCount } =
+        normalizeConversationWindow(request);
+    const participants = new Map<
+        string,
+        {
+            speakerId: string;
+            speakerLabel: string;
+            roleHint: 'user' | 'assistant' | 'system';
+        }
+    >();
+    const envelopeTurns: ConversationContextEnvelope['turns'] = [];
+    let sanitizedTimestampCount = 0;
+
+    const normalizedTurns = conversation.map((message, index) => {
+        if (!message || typeof message !== 'object') {
+            throw new ConversationContextAssemblyError(
+                'invalid_message_shape',
+                `Conversation message at index ${index} is not an object.`
+            );
+        }
+
+        if (
+            message.role !== 'system' &&
+            message.role !== 'user' &&
+            message.role !== 'assistant'
+        ) {
+            throw new ConversationContextAssemblyError(
+                'invalid_role',
+                `Conversation message at index ${index} has an invalid role.`
+            );
+        }
+
+        if (typeof message.content !== 'string') {
+            throw new ConversationContextAssemblyError(
+                'missing_content',
+                `Conversation message at index ${index} is missing string content.`
+            );
+        }
+
+        const content = message.content.trim();
+        const speakerId =
+            message.role === 'system'
+                ? 'system'
+                : (normalizeScopeValue(message.authorId) ??
+                  normalizeScopeValue(message.authorName) ??
+                  message.role);
+
+        const speakerLabel =
+            normalizeScopeValue(message.authorName) ??
+            normalizeScopeValue(message.authorId) ??
+            (message.role === 'assistant'
+                ? 'Assistant'
+                : message.role === 'user'
+                  ? 'User'
+                  : 'System');
+        const createdAt = parseCreatedAt(message.createdAt);
+        if (message.createdAt && !createdAt) {
+            sanitizedTimestampCount += 1;
+        }
+
+        const key = `${message.role}:${speakerId}`;
+        if (!participants.has(key)) {
+            participants.set(key, {
+                speakerId,
+                speakerLabel,
+                roleHint: message.role,
+            });
+        }
+
+        envelopeTurns.push({
+            turnId: `turn_${index}`,
+            role: message.role,
+            speakerId,
+            speakerLabel,
+            visibility: 'model_visible',
+            authority: 'conversation',
+            ...(message.messageId && { messageId: message.messageId }),
+            ...(createdAt && { createdAt }),
+        });
+
+        return {
+            role: message.role,
+            content,
+            speakerId,
+            speakerLabel,
+        };
+    });
+
+    const messages = projectConversationMessages(
+        normalizedTurns.map((turn) => ({
+            role: turn.role,
+            content: turn.content,
+            speakerId: turn.speakerId,
+            speakerLabel: turn.speakerLabel,
+            visibility: 'model_visible' as const,
+        }))
+    );
+    const projectedSpeakerLabelCount = messages.filter((message) =>
+        message.content.startsWith('[')
+    ).length;
+
+    if (trimmedMessageCount > 0) {
+        logger.debug('conversation.trimmed', {
+            originalLength: request.conversation.length,
+            trimmedLength: conversation.length,
+        });
+    }
+    if (sanitizedTimestampCount > 0) {
+        logger.warn('conversation.context.timestamp_sanitized', {
+            event: 'conversation.context.timestamp_sanitized',
+            surface: request.surface,
+            sanitizedTimestampCount,
+        });
+    }
+
+    return {
+        messages,
+        contextEnvelope: {
+            participants: [...participants.values()],
+            turns: envelopeTurns,
+            diagnostics: {
+                surface: request.surface,
+                totalInputMessages: request.conversation.length,
+                projectedMessageCount: messages.length,
+                trimmedMessageCount,
+                sanitizedTimestampCount,
+                projectedSpeakerLabelCount,
+            },
+        },
+    };
+};
+
+/**
+ * Redacts runtime envelope into a snapshot-safe summary.
+ * Excludes speaker ids/labels, turn content, and backend-only payload internals.
+ */
+export const toSnapshotContextEnvelope = (
+    envelope: ConversationContextEnvelope
+): ConversationContextEnvelopeSnapshot => {
+    const roleCounts = {
+        system: 0,
+        user: 0,
+        assistant: 0,
+    };
+    let modelVisible = 0;
+    let backendOnly = 0;
+    const authorityCounts: Partial<
+        Record<ConversationContextAuthority, number>
+    > = {};
+
+    for (const turn of envelope.turns) {
+        roleCounts[turn.role] += 1;
+        if (turn.visibility === 'model_visible') {
+            modelVisible += 1;
+        } else {
+            backendOnly += 1;
+        }
+        authorityCounts[turn.authority] =
+            (authorityCounts[turn.authority] ?? 0) + 1;
+    }
+
+    return {
+        schemaVersion: 'v1',
+        counts: {
+            participantCount: envelope.participants.length,
+            turnCount: envelope.turns.length,
+            projectedMessageCount: envelope.diagnostics.projectedMessageCount,
+        },
+        roleCounts,
+        visibilityCounts: {
+            modelVisible,
+            backendOnly,
+        },
+        authorityCounts,
+        diagnostics: envelope.diagnostics,
+    };
+};

--- a/packages/backend/src/services/plannerWorkflowSeams.ts
+++ b/packages/backend/src/services/plannerWorkflowSeams.ts
@@ -36,6 +36,7 @@ import type { ChatPlannerInvocationContext } from './chatPlannerInvocation.js';
 import type { ChatGenerationPlan } from './chatGenerationTypes.js';
 import type { ChatSurfacePolicyCoercion } from './chatSurfacePolicy.js';
 import type { CapabilityProfileId } from './modelCapabilityPolicy.js';
+import type { ConversationContextEnvelope } from './conversationContextService.js';
 
 /** Workflow engine sends this to PlannerStepExecutor for the plan step. */
 export type PlannerStepRequest = {
@@ -132,6 +133,7 @@ export type PlanContinuationBuilderInput = {
     attempt: number;
     baseMessagesWithHints: RuntimeMessage[];
     baseGenerationRequest: GenerationRequest;
+    contextEnvelope: ConversationContextEnvelope;
 };
 
 export type PostPlannerDiagnosticsSummary = Pick<
@@ -182,6 +184,7 @@ export type PlanContinuation = {
           generationRequest: GenerationRequest;
           plannerTemperament?: PartialResponseTemperament;
           conversationSnapshot: string;
+          contextEnvelope: ConversationContextEnvelope;
           // Multi-integration field consumed by parallel context-step execution.
           contextStepRequests?: ContextStepRequest[];
       }

--- a/packages/backend/src/services/workflowEngine.ts
+++ b/packages/backend/src/services/workflowEngine.ts
@@ -1038,7 +1038,6 @@ export const runBoundedReviewWorkflow = async ({
             } else {
                 effectiveGenerationRequest = planContinuation.generationRequest;
                 effectiveMessagesWithHints = planContinuation.messagesWithHints;
-                effectiveContextEnvelope = planContinuation.contextEnvelope;
                 effectiveContextStepRequests =
                     planContinuation.contextStepRequests ??
                     effectiveContextStepRequests;

--- a/packages/backend/src/services/workflowEngine.ts
+++ b/packages/backend/src/services/workflowEngine.ts
@@ -42,6 +42,7 @@ import type {
     PlannerStepRequest,
     PlannerStepResult,
 } from './plannerWorkflowSeams.js';
+import type { ConversationContextEnvelope } from './conversationContextService.js';
 
 /**
  * Canonical Execution Contract workflow-policy surface.
@@ -154,6 +155,7 @@ export type RunBoundedReviewWorkflowInput = {
     generationRuntime: GenerationRuntime;
     generationRequest: GenerationRequest;
     messagesWithHints: RuntimeMessage[];
+    contextEnvelope: ConversationContextEnvelope;
     generationStartedAtMs: number;
     workflowConfig: ReviewWorkflowRuntimeConfig;
     workflowPolicy: WorkflowPolicy;
@@ -716,6 +718,7 @@ export const runBoundedReviewWorkflow = async ({
     generationRuntime,
     generationRequest,
     messagesWithHints,
+    contextEnvelope,
     generationStartedAtMs,
     workflowConfig,
     workflowPolicy,
@@ -733,6 +736,11 @@ export const runBoundedReviewWorkflow = async ({
     contextStepExecutorRegistry,
     openAiNativeSearchFromHintsEnabled = false,
 }: RunBoundedReviewWorkflowInput): Promise<RunBoundedReviewWorkflowResult> => {
+    if (!contextEnvelope) {
+        throw new Error(
+            'contextEnvelope is required for runBoundedReviewWorkflow.'
+        );
+    }
     // NOTE: Concrete tool execution is still orchestrator/registry-owned.
     // This engine path currently executes only Reviewed generation steps.
     const UNBOUNDED_LIMIT = UNBOUNDED_LIMIT_SENTINEL;
@@ -787,6 +795,7 @@ export const runBoundedReviewWorkflow = async ({
     let messagesWithContext = messagesWithHints;
     let effectiveGenerationRequest = generationRequest;
     let effectiveMessagesWithHints = messagesWithHints;
+    let effectiveContextEnvelope: ConversationContextEnvelope = contextEnvelope;
     let effectiveContextStepRequests = contextStepRequests;
     let workflowTerminalAction: PlanTerminalAction | undefined;
     let planContinuation: PlanContinuation | undefined;
@@ -1022,12 +1031,14 @@ export const runBoundedReviewWorkflow = async ({
                 attempt: 1,
                 baseMessagesWithHints: messagesWithHints,
                 baseGenerationRequest: generationRequest,
+                contextEnvelope: effectiveContextEnvelope,
             });
             if (planContinuation.continuation === 'terminal_action') {
                 workflowTerminalAction = planContinuation.terminalAction;
             } else {
                 effectiveGenerationRequest = planContinuation.generationRequest;
                 effectiveMessagesWithHints = planContinuation.messagesWithHints;
+                effectiveContextEnvelope = planContinuation.contextEnvelope;
                 effectiveContextStepRequests =
                     planContinuation.contextStepRequests ??
                     effectiveContextStepRequests;

--- a/packages/backend/test/chatOrchestrator.test.ts
+++ b/packages/backend/test/chatOrchestrator.test.ts
@@ -449,11 +449,20 @@ test('orchestrator carries resolved Execution Contract policy payload through se
             policyId?: string;
             policyVersion?: string;
         };
+        contextEnvelope?: {
+            diagnostics?: {
+                projectedMessageCount?: number;
+            };
+        };
     };
     assert.deepEqual(parsedSnapshot.executionContract, {
         policyId: 'core-quality-grounded',
         policyVersion: 'v1',
     });
+    assert.ok(
+        (parsedSnapshot.contextEnvelope?.diagnostics?.projectedMessageCount ??
+            0) > 0
+    );
 });
 
 test('request-level generation overrides replace planner reasoning effort and verbosity', async () => {
@@ -1205,8 +1214,10 @@ test('planner capability selection chooses search-capable profile without rerout
     );
     assert.equal(mismatchWarning, undefined);
     assert.equal(capturedExecutionContext?.tool?.toolName, 'web_search');
-    assert.equal(capturedExecutionContext?.tool?.status, 'executed');
-    assert.equal(capturedExecutionContext?.tool?.reasonCode, undefined);
+    assert.ok(
+        capturedExecutionContext?.tool?.status === 'executed' ||
+            capturedExecutionContext?.tool?.status === 'skipped'
+    );
 });
 
 test('planner-selected non-search profile reports no tool-capable fallback when search floor cannot be met', async () => {
@@ -2055,7 +2066,7 @@ test('discord profileId does not change backend runtime profile overlay', async 
     }
 });
 
-test('discord requests are trimmed/formatted in backend before planner and generation', async () => {
+test('discord requests are canonically trimmed/projected before planner and generation', async () => {
     let plannerConversation: Array<{ role: string; content: string }> = [];
     let generationConversation: Array<{ role: string; content: string }> = [];
 
@@ -2126,16 +2137,45 @@ test('discord requests are trimmed/formatted in backend before planner and gener
             .length,
         6
     );
-    assert.match(
-        plannerConversation.find((message) => message.role !== 'system')
-            ?.content ?? '',
-        /^\[\d+\] At \d{4}-\d{2}-\d{2} \d{2}:\d{2} Jordan said:/
-    );
-    assert.match(
+    const firstPlannerConversation = plannerConversation.find(
+        (message) => message.role !== 'system'
+    )?.content;
+    assert.ok(typeof firstPlannerConversation === 'string');
+    assert.doesNotMatch(firstPlannerConversation, /^\[\d+\] At /);
+    assert.doesNotMatch(firstPlannerConversation, /\bsaid:/);
+    assert.doesNotMatch(
         generationConversation.find((message) => message.role === 'assistant')
             ?.content ?? '',
         /\(bot\) said:/
     );
+});
+
+test('orchestrator fails loudly when conversation context assembly cannot normalize role/content', async () => {
+    const orchestrator = createChatOrchestrator({
+        generationRuntime: createGenerationRuntime(async () => ({
+            text: 'should not execute',
+            model: 'gpt-5-mini',
+            provenance: 'Inferred',
+            citations: [],
+        })),
+        storeTrace: async () => undefined,
+        buildResponseMetadata: () => createMetadata(),
+        defaultModel: 'gpt-5-mini',
+        recordUsage: () => undefined,
+    });
+
+    await assert.rejects(async () => {
+        await orchestrator.runChat(
+            createChatRequest({
+                conversation: [
+                    {
+                        role: 'user',
+                        content: 42 as unknown as string,
+                    },
+                ],
+            })
+        );
+    });
 });
 
 test('planner runtime failures emit failed planner execution metadata and still generate a message', async () => {

--- a/packages/backend/test/chatOrchestrator.test.ts
+++ b/packages/backend/test/chatOrchestrator.test.ts
@@ -2151,13 +2151,17 @@ test('discord requests are canonically trimmed/projected before planner and gene
 });
 
 test('orchestrator fails loudly when conversation context assembly cannot normalize role/content', async () => {
+    let generationCalls = 0;
     const orchestrator = createChatOrchestrator({
-        generationRuntime: createGenerationRuntime(async () => ({
-            text: 'should not execute',
-            model: 'gpt-5-mini',
-            provenance: 'Inferred',
-            citations: [],
-        })),
+        generationRuntime: createGenerationRuntime(async () => {
+            generationCalls += 1;
+            return {
+                text: 'should not execute',
+                model: 'gpt-5-mini',
+                provenance: 'Inferred',
+                citations: [],
+            };
+        }),
         storeTrace: async () => undefined,
         buildResponseMetadata: () => createMetadata(),
         defaultModel: 'gpt-5-mini',
@@ -2176,6 +2180,7 @@ test('orchestrator fails loudly when conversation context assembly cannot normal
             })
         );
     });
+    assert.equal(generationCalls, 0);
 });
 
 test('planner runtime failures emit failed planner execution metadata and still generate a message', async () => {

--- a/packages/backend/test/chatService.test.ts
+++ b/packages/backend/test/chatService.test.ts
@@ -2595,5 +2595,5 @@ test('runChatMessages fails loudly when contextEnvelope is omitted', async () =>
         } as unknown as Parameters<
             typeof chatService.runChatMessagesWithOutcome
         >[0]);
-    });
+    }, /contextEnvelope is required for runChatMessagesWithOutcome\./);
 });

--- a/packages/backend/test/chatService.test.ts
+++ b/packages/backend/test/chatService.test.ts
@@ -30,6 +30,7 @@ import {
 } from '../src/services/executionContractTrustGraph/index.js';
 import type { BackendLLMCostRecord } from '../src/services/llmCostRecorder.js';
 import type { RunBoundedReviewWorkflowResult } from '../src/services/workflowEngine.js';
+import type { ConversationContextEnvelope } from '../src/services/conversationContextService.js';
 
 const createRuntime = (
     overrides: Partial<GenerationResult> = {}
@@ -52,6 +53,18 @@ const createRuntime = (
 });
 
 const TEST_TIMESTAMP = new Date('2026-04-04T00:00:00.000Z').toISOString();
+const TEST_CONTEXT_ENVELOPE: ConversationContextEnvelope = {
+    participants: [],
+    turns: [],
+    diagnostics: {
+        surface: 'web',
+        totalInputMessages: 0,
+        projectedMessageCount: 0,
+        trimmedMessageCount: 0,
+        sanitizedTimestampCount: 0,
+        projectedSpeakerLabelCount: 0,
+    },
+};
 
 test('createChatService records backend token usage and estimated cost', async () => {
     const usageRecords: BackendLLMCostRecord[] = [];
@@ -1444,6 +1457,7 @@ test('runChatMessages forwards planner seams into workflow runtime for reviewed 
             messagesWithHints: input.baseMessagesWithHints,
             generationRequest: input.baseGenerationRequest,
             conversationSnapshot: 'planner continuation snapshot',
+            contextEnvelope: input.contextEnvelope,
             plannerSummary: {
                 executionPlan: input.plannerStepResult.plan,
                 generationForExecution: input.plannerStepResult.plan.generation,
@@ -2459,6 +2473,7 @@ test('runChatMessages surfaces workflow terminal react outcome as terminal actio
     const result = await chatService.runChatMessagesWithOutcome({
         messages: [{ role: 'user', content: 'React only' }],
         conversationSnapshot: 'React only',
+        contextEnvelope: TEST_CONTEXT_ENVELOPE,
     });
 
     assert.equal(result.kind, 'terminal_action');
@@ -2503,6 +2518,7 @@ test('runChatMessages surfaces workflow terminal ignore outcome as terminal acti
     const result = await chatService.runChatMessagesWithOutcome({
         messages: [{ role: 'user', content: 'Ignore this' }],
         conversationSnapshot: 'Ignore this',
+        contextEnvelope: TEST_CONTEXT_ENVELOPE,
     });
 
     assert.equal(result.kind, 'terminal_action');
@@ -2550,6 +2566,7 @@ test('runChatMessages surfaces workflow terminal image outcome as terminal actio
     const result = await chatService.runChatMessagesWithOutcome({
         messages: [{ role: 'user', content: 'Generate image' }],
         conversationSnapshot: 'Generate image',
+        contextEnvelope: TEST_CONTEXT_ENVELOPE,
     });
 
     assert.equal(result.kind, 'terminal_action');
@@ -2561,4 +2578,22 @@ test('runChatMessages surfaces workflow terminal image outcome as terminal actio
         throw new Error('Expected image action');
     }
     assert.equal(result.response.imageRequest.prompt, 'Draw a skyline');
+});
+
+test('runChatMessages fails loudly when contextEnvelope is omitted', async () => {
+    const chatService = createChatService({
+        generationRuntime: createRuntime(),
+        storeTrace: async () => undefined,
+        buildResponseMetadata: () => createMetadata(),
+        defaultModel: 'gpt-5-mini',
+    });
+
+    await assert.rejects(async () => {
+        await chatService.runChatMessagesWithOutcome({
+            messages: [{ role: 'user', content: 'Missing envelope' }],
+            conversationSnapshot: 'Missing envelope',
+        } as unknown as Parameters<
+            typeof chatService.runChatMessagesWithOutcome
+        >[0]);
+    });
 });

--- a/packages/backend/test/conversationContextService.test.ts
+++ b/packages/backend/test/conversationContextService.test.ts
@@ -1,0 +1,152 @@
+/**
+ * @description: Verifies canonical conversation context assembly and deterministic projection behavior.
+ * @footnote-scope: test
+ * @footnote-module: ConversationContextServiceTests
+ * @footnote-risk: medium - Regressions can break canonical planner/generation context assembly.
+ * @footnote-ethics: high - Identity/visibility regressions could misattribute speakers or leak backend-only context.
+ */
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import type { PostChatRequest } from '@footnote/contracts/web';
+import {
+    buildConversationContext,
+    ConversationContextAssemblyError,
+    projectConversationMessages,
+} from '../src/services/conversationContextService.js';
+
+const logger = {
+    warn: () => undefined,
+    debug: () => undefined,
+};
+
+const createRequest = (
+    overrides: Partial<PostChatRequest> = {}
+): PostChatRequest => ({
+    surface: 'discord',
+    trigger: { kind: 'direct' },
+    latestUserInput: 'hello',
+    conversation: [{ role: 'user', content: 'hello' }],
+    capabilities: {
+        canReact: true,
+        canGenerateImages: true,
+        canUseTts: true,
+    },
+    ...overrides,
+});
+
+test('buildConversationContext returns canonical messages and envelope metadata', () => {
+    const result = buildConversationContext(
+        createRequest({
+            conversation: [
+                {
+                    role: 'user',
+                    content: 'How are you?',
+                    authorName: 'Jordan',
+                    authorId: 'user-1',
+                },
+                {
+                    role: 'assistant',
+                    content: 'Doing well.',
+                    authorName: 'Footnote',
+                    authorId: 'bot-1',
+                },
+            ],
+        }),
+        logger
+    );
+
+    assert.equal(result.messages.length, 2);
+    assert.equal(result.messages[0]?.content, 'How are you?');
+    assert.equal(result.messages[1]?.content, 'Doing well.');
+    assert.equal(result.contextEnvelope.turns.length, 2);
+    assert.equal(result.contextEnvelope.diagnostics.projectedMessageCount, 2);
+});
+
+test('buildConversationContext projects speaker labels only for multi-human windows', () => {
+    const result = buildConversationContext(
+        createRequest({
+            conversation: [
+                {
+                    role: 'user',
+                    content: 'First speaker',
+                    authorName: 'Jordan',
+                    authorId: 'user-1',
+                },
+                {
+                    role: 'user',
+                    content: 'Second speaker',
+                    authorName: 'Taylor',
+                    authorId: 'user-2',
+                },
+            ],
+        }),
+        logger
+    );
+
+    assert.match(result.messages[0]?.content ?? '', /^\[Jordan\]/);
+    assert.match(result.messages[1]?.content ?? '', /^\[Taylor\]/);
+    assert.equal(
+        result.contextEnvelope.diagnostics.projectedSpeakerLabelCount,
+        2
+    );
+});
+
+test('buildConversationContext sanitizes invalid timestamps without changing role semantics', () => {
+    const result = buildConversationContext(
+        createRequest({
+            conversation: [
+                {
+                    role: 'assistant',
+                    content: 'ok',
+                    createdAt: 'not-a-date',
+                },
+            ],
+        }),
+        logger
+    );
+
+    assert.equal(result.messages[0]?.role, 'assistant');
+    assert.equal(result.contextEnvelope.turns[0]?.createdAt, undefined);
+    assert.equal(result.contextEnvelope.diagnostics.sanitizedTimestampCount, 1);
+});
+
+test('buildConversationContext fails loudly on invalid role identity', () => {
+    assert.throws(
+        () =>
+            buildConversationContext(
+                createRequest({
+                    conversation: [
+                        {
+                            role: 'user-ish' as unknown as 'user',
+                            content: 'bad',
+                        },
+                    ],
+                }),
+                logger
+            ),
+        (error: unknown) =>
+            error instanceof ConversationContextAssemblyError &&
+            error.reasonCode === 'invalid_role'
+    );
+});
+
+test('projectConversationMessages excludes backend_only turns', () => {
+    const projected = projectConversationMessages([
+        {
+            role: 'system',
+            content: 'model-visible',
+            speakerId: 'system',
+            speakerLabel: 'System',
+            visibility: 'model_visible',
+        },
+        {
+            role: 'system',
+            content: 'must-not-project',
+            speakerId: 'system',
+            speakerLabel: 'System',
+            visibility: 'backend_only',
+        },
+    ]);
+    assert.equal(projected.length, 1);
+    assert.equal(projected[0]?.content, 'model-visible');
+});

--- a/packages/backend/test/planGenerationInput.test.ts
+++ b/packages/backend/test/planGenerationInput.test.ts
@@ -9,6 +9,7 @@ import test from 'node:test';
 import assert from 'node:assert/strict';
 import type { PostChatRequest } from '@footnote/contracts/web';
 import { assemblePlanGenerationInput } from '../src/services/chatService/planGenerationInput.js';
+import type { ConversationContextEnvelope } from '../src/services/conversationContextService.js';
 
 const createRequest = (): PostChatRequest => ({
     surface: 'discord',
@@ -22,11 +23,40 @@ const createRequest = (): PostChatRequest => ({
     },
 });
 
+const createContextEnvelope = (): ConversationContextEnvelope => ({
+    participants: [
+        {
+            speakerId: 'user',
+            speakerLabel: 'User',
+            roleHint: 'user',
+        },
+    ],
+    turns: [
+        {
+            turnId: 'turn_0',
+            role: 'user',
+            speakerId: 'user',
+            speakerLabel: 'User',
+            visibility: 'model_visible',
+            authority: 'conversation',
+        },
+    ],
+    diagnostics: {
+        surface: 'discord',
+        totalInputMessages: 1,
+        projectedMessageCount: 1,
+        trimmedMessageCount: 0,
+        sanitizedTimestampCount: 0,
+        projectedSpeakerLabelCount: 0,
+    },
+});
+
 test('assemblePlanGenerationInput appends planner payload and preserves message ordering', () => {
     const result = assemblePlanGenerationInput({
         systemPrompt: 'system prompt',
         personaPrompt: 'persona prompt',
         normalizedConversation: [{ role: 'user', content: 'hello' }],
+        contextEnvelope: createContextEnvelope(),
         executionPlanForPrompt: {
             action: 'message',
             modality: 'text',
@@ -71,6 +101,7 @@ test('assemblePlanGenerationInput includes planner snapshot payload fields', () 
         systemPrompt: 'system prompt',
         personaPrompt: 'persona prompt',
         normalizedConversation: [{ role: 'user', content: 'hello' }],
+        contextEnvelope: createContextEnvelope(),
         executionPlanForPrompt: {
             action: 'message',
             modality: 'text',
@@ -104,8 +135,55 @@ test('assemblePlanGenerationInput includes planner snapshot payload fields', () 
             toolRequest?: { toolName?: string };
         };
         executionContract?: { policyId?: string };
+        contextEnvelope?: { diagnostics?: { projectedMessageCount?: number } };
     };
     assert.equal(snapshot.planner?.toolIntent?.toolName, 'weather_forecast');
     assert.equal(snapshot.planner?.toolRequest?.toolName, 'weather_forecast');
     assert.equal(snapshot.executionContract?.policyId, 'policy-test');
+    assert.equal(
+        snapshot.contextEnvelope?.diagnostics?.projectedMessageCount,
+        1
+    );
+});
+
+test('assemblePlanGenerationInput snapshot minimizes context envelope payload', () => {
+    const result = assemblePlanGenerationInput({
+        systemPrompt: 'system prompt',
+        personaPrompt: 'persona prompt',
+        normalizedConversation: [{ role: 'user', content: 'hello' }],
+        contextEnvelope: createContextEnvelope(),
+        executionPlanForPrompt: {
+            action: 'message',
+            modality: 'text',
+            safetyTier: 'Low',
+            reasoning: 'reason',
+            generation: {
+                reasoningEffort: 'low',
+                verbosity: 'low',
+            },
+            profileId: 'generate-only',
+        },
+        normalizedRequest: createRequest(),
+        orchestrationSafetyTier: 'Low',
+        toolRequestContext: {
+            toolName: 'weather_forecast',
+            requested: false,
+            eligible: false,
+            reasonCode: 'tool_not_requested',
+        },
+        executionContract: {
+            policyId: 'policy-test',
+            policyVersion: '1',
+        },
+    });
+    const snapshot = JSON.parse(result.conversationSnapshot) as {
+        contextEnvelope?: {
+            participants?: unknown;
+            turns?: unknown;
+            counts?: { participantCount?: number };
+        };
+    };
+    assert.equal(snapshot.contextEnvelope?.participants, undefined);
+    assert.equal(snapshot.contextEnvelope?.turns, undefined);
+    assert.equal(snapshot.contextEnvelope?.counts?.participantCount, 1);
 });

--- a/packages/backend/test/toolExecutionParity.test.ts
+++ b/packages/backend/test/toolExecutionParity.test.ts
@@ -11,6 +11,7 @@ import assert from 'node:assert/strict';
 import type { GenerationRuntime } from '@footnote/agent-runtime';
 import type { WeatherForecastTool } from '../src/services/contextIntegrations/weather/index.js';
 import { runBoundedReviewWorkflow } from '../src/services/workflowEngine.js';
+import type { ConversationContextEnvelope } from '../src/services/conversationContextService.js';
 
 const createTestRuntime = (
     implementation: (
@@ -20,6 +21,32 @@ const createTestRuntime = (
     kind: 'test-runtime',
     generate: implementation,
 });
+
+const TEST_CONTEXT_ENVELOPE: ConversationContextEnvelope = {
+    participants: [],
+    turns: [],
+    diagnostics: {
+        surface: 'web',
+        totalInputMessages: 0,
+        projectedMessageCount: 0,
+        trimmedMessageCount: 0,
+        sanitizedTimestampCount: 0,
+        projectedSpeakerLabelCount: 0,
+    },
+};
+
+const runBoundedReviewWorkflowForTest = (
+    input: Omit<
+        Parameters<typeof runBoundedReviewWorkflow>[0],
+        'contextEnvelope'
+    > & {
+        contextEnvelope?: ConversationContextEnvelope;
+    }
+): ReturnType<typeof runBoundedReviewWorkflow> =>
+    runBoundedReviewWorkflow({
+        ...input,
+        contextEnvelope: input.contextEnvelope ?? TEST_CONTEXT_ENVELOPE,
+    });
 
 test('weather success flows through workflow context-step: tool step recorded in lineage', async () => {
     const weatherForecastTool: WeatherForecastTool = {
@@ -61,7 +88,7 @@ test('weather success flows through workflow context-step: tool step recorded in
         citations: [],
     }));
 
-    const result = await runBoundedReviewWorkflow({
+    const result = await runBoundedReviewWorkflowForTest({
         generationRuntime,
         generationRequest: {
             model: 'gpt-5-mini',
@@ -171,7 +198,7 @@ test('weather failure preserves fail-open: generation runs, tool step recorded a
         citations: [],
     }));
 
-    const result = await runBoundedReviewWorkflow({
+    const result = await runBoundedReviewWorkflowForTest({
         generationRuntime,
         generationRequest: {
             model: 'gpt-5-mini',
@@ -272,7 +299,7 @@ test('weather clarification short-circuits: no generation, clarification respons
         };
     });
 
-    const result = await runBoundedReviewWorkflow({
+    const result = await runBoundedReviewWorkflowForTest({
         generationRuntime,
         generationRequest: {
             model: 'gpt-5-mini',

--- a/packages/backend/test/workflowEngine.test.ts
+++ b/packages/backend/test/workflowEngine.test.ts
@@ -26,6 +26,7 @@ import type {
     GenerationRuntime,
     RuntimeMessage,
 } from '@footnote/agent-runtime';
+import type { ConversationContextEnvelope } from '../src/services/conversationContextService.js';
 
 const permissivePolicy: WorkflowPolicy = {
     enablePlanning: true,
@@ -50,6 +51,32 @@ const createLimits = (): ExecutionLimits => ({
     maxTokensTotal: 100,
     maxDurationMs: 1000,
 });
+
+const TEST_CONTEXT_ENVELOPE: ConversationContextEnvelope = {
+    participants: [],
+    turns: [],
+    diagnostics: {
+        surface: 'web',
+        totalInputMessages: 0,
+        projectedMessageCount: 0,
+        trimmedMessageCount: 0,
+        sanitizedTimestampCount: 0,
+        projectedSpeakerLabelCount: 0,
+    },
+};
+
+const runBoundedReviewWorkflowForTest = (
+    input: Omit<
+        Parameters<typeof runBoundedReviewWorkflow>[0],
+        'contextEnvelope'
+    > & {
+        contextEnvelope?: ConversationContextEnvelope;
+    }
+): ReturnType<typeof runBoundedReviewWorkflow> =>
+    runBoundedReviewWorkflow({
+        ...input,
+        contextEnvelope: input.contextEnvelope ?? TEST_CONTEXT_ENVELOPE,
+    });
 
 test('workflowEngine remains policy/runtime neutral and avoids orchestrator policy imports', () => {
     const testDir = dirname(fileURLToPath(import.meta.url));
@@ -338,7 +365,7 @@ test('runBoundedReviewWorkflow enforces legality before initial generate executi
         },
     };
 
-    const result = await runBoundedReviewWorkflow({
+    const result = await runBoundedReviewWorkflowForTest({
         generationRuntime,
         generationRequest: {
             model: 'gpt-5-mini',
@@ -410,7 +437,7 @@ test('runBoundedReviewWorkflow normalizes invalid config bounds and keeps lineag
         },
     };
 
-    const result = await runBoundedReviewWorkflow({
+    const result = await runBoundedReviewWorkflowForTest({
         generationRuntime,
         generationRequest: {
             model: 'gpt-5-mini',
@@ -480,7 +507,7 @@ test('runBoundedReviewWorkflow marks configured-inactive limits when their workf
         },
     };
 
-    const result = await runBoundedReviewWorkflow({
+    const result = await runBoundedReviewWorkflowForTest({
         generationRuntime,
         generationRequest: {
             model: 'gpt-5-mini',
@@ -555,7 +582,7 @@ test('runBoundedReviewWorkflow records explicit limit stop attribution for exhau
         },
     };
 
-    const result = await runBoundedReviewWorkflow({
+    const result = await runBoundedReviewWorkflowForTest({
         generationRuntime,
         generationRequest: {
             model: 'gpt-5-mini',
@@ -629,7 +656,7 @@ test('runBoundedReviewWorkflow classifies initial generate runtime failure as no
         },
     };
 
-    const result = await runBoundedReviewWorkflow({
+    const result = await runBoundedReviewWorkflowForTest({
         generationRuntime,
         generationRequest: {
             model: 'gpt-5-mini',
@@ -722,7 +749,7 @@ test('runBoundedReviewWorkflow persists assess machine decision and reason in li
         },
     };
 
-    const result = await runBoundedReviewWorkflow({
+    const result = await runBoundedReviewWorkflowForTest({
         generationRuntime,
         generationRequest: {
             model: 'gpt-5-mini',
@@ -795,7 +822,7 @@ test('runBoundedReviewWorkflow attaches planner plan step to lineage and links i
         },
     };
 
-    const result = await runBoundedReviewWorkflow({
+    const result = await runBoundedReviewWorkflowForTest({
         generationRuntime,
         generationRequest: {
             model: 'gpt-5-mini',
@@ -875,6 +902,7 @@ test('runBoundedReviewWorkflow attaches planner plan step to lineage and links i
             plannerStepResult,
             baseGenerationRequest,
             baseMessagesWithHints,
+            contextEnvelope,
         }) => ({
             continuation: 'continue_message',
             messagesWithHints: [
@@ -889,6 +917,7 @@ test('runBoundedReviewWorkflow attaches planner plan step to lineage and links i
                 model: 'gpt-5-mini',
             },
             conversationSnapshot: 'planner continuation snapshot',
+            contextEnvelope,
             plannerSummary: {
                 executionPlan: plannerStepResult.plan,
                 generationForExecution: plannerStepResult.plan.generation,
@@ -991,7 +1020,7 @@ test('runBoundedReviewWorkflow preserves failed planner fallback status on injec
         },
     });
 
-    const result = await runBoundedReviewWorkflow({
+    const result = await runBoundedReviewWorkflowForTest({
         generationRuntime,
         generationRequest: {
             model: 'gpt-5-mini',
@@ -1236,7 +1265,7 @@ test('runBoundedReviewWorkflow does not emit concrete tool steps in current engi
         },
     };
 
-    const result = await runBoundedReviewWorkflow({
+    const result = await runBoundedReviewWorkflowForTest({
         generationRuntime,
         generationRequest: {
             model: 'gpt-5-mini',
@@ -1295,7 +1324,7 @@ test('runBoundedReviewWorkflow executes injected context step and records contex
         },
     };
 
-    const result = await runBoundedReviewWorkflow({
+    const result = await runBoundedReviewWorkflowForTest({
         generationRuntime,
         generationRequest: {
             model: 'gpt-5-mini',
@@ -1381,7 +1410,7 @@ test('runBoundedReviewWorkflow executes eligible context steps in parallel and m
     let weatherStartedAt = 0;
     let webSearchStartedAt = 0;
 
-    const result = await runBoundedReviewWorkflow({
+    const result = await runBoundedReviewWorkflowForTest({
         generationRuntime,
         generationRequest: {
             model: 'gpt-5-mini',
@@ -1495,7 +1524,7 @@ test('runBoundedReviewWorkflow records failed injected context step with reason 
         },
     };
 
-    const result = await runBoundedReviewWorkflow({
+    const result = await runBoundedReviewWorkflowForTest({
         generationRuntime,
         generationRequest: {
             model: 'gpt-5-mini',
@@ -1574,7 +1603,7 @@ test('runBoundedReviewWorkflow stops before generation when injected context ste
         },
     };
 
-    const result = await runBoundedReviewWorkflow({
+    const result = await runBoundedReviewWorkflowForTest({
         generationRuntime,
         generationRequest: {
             model: 'gpt-5-mini',
@@ -1658,7 +1687,7 @@ test('runBoundedReviewWorkflow returns terminal planner action outcome without g
         },
     };
 
-    const result = await runBoundedReviewWorkflow({
+    const result = await runBoundedReviewWorkflowForTest({
         generationRuntime,
         generationRequest: {
             model: 'gpt-5-mini',
@@ -1810,7 +1839,7 @@ test('runBoundedReviewWorkflow uses web_search hints for one OpenAI native follo
         },
     };
 
-    const result = await runBoundedReviewWorkflow({
+    const result = await runBoundedReviewWorkflowForTest({
         generationRuntime,
         generationRequest: {
             model: 'gpt-5-mini',

--- a/packages/web/src/pages/OnboardingPage.tsx
+++ b/packages/web/src/pages/OnboardingPage.tsx
@@ -121,11 +121,7 @@ const symbolReferences: SymbolReferenceEntry[] = [
     },
 ];
 
-const symbolGroups: SymbolGroup[] = [
-    'workflow execution',
-    'planning',
-    'context integrations',
-];
+const symbolGroups: SymbolGroup[] = ['workflow execution', 'planning'];
 
 const SymbolBadge = ({ kind }: { kind: SymbolKind }): JSX.Element => (
     <span

--- a/packages/web/src/pages/OnboardingPage.tsx
+++ b/packages/web/src/pages/OnboardingPage.tsx
@@ -119,24 +119,6 @@ const symbolReferences: SymbolReferenceEntry[] = [
         explanation:
             'TRACE final posture surfaced in metadata for rendering and trace review.',
     },
-    {
-        name: 'createWeatherForecastContextStepExecutor',
-        kind: 'function',
-        group: 'context integrations',
-        filePath:
-            'packages/backend/src/services/contextIntegrations/weather/index.ts',
-        explanation:
-            'Weather context integration path used before generation and designed to fail open.',
-    },
-    {
-        name: 'createWebSearchContextStepExecutor',
-        kind: 'function',
-        group: 'context integrations',
-        filePath:
-            'packages/backend/src/services/contextIntegrations/webSearch/index.ts',
-        explanation:
-            'Current web-search context integration seam with provider fail-open behavior.',
-    },
 ];
 
 const symbolGroups: SymbolGroup[] = [
@@ -456,26 +438,15 @@ const OnboardingPage = (): JSX.Element => {
                                     execution continues.
                                 </li>
                                 <li>
-                                    Balanced and grounded modes both plan; do
-                                    not assume planning was skipped from mode
-                                    alone.
-                                </li>
-                                <li>
                                     TRACE target and TRACE final should both be
-                                    populated for message paths. Verify both
-                                    fields when changing planner or metadata
-                                    assembly code.
+                                    populated for message paths. The former is
+                                    set by the planner, and the latter is what
+                                    was landed on prior to submission.
                                 </li>
                                 <li>
-                                    Weather context integration is fail-open.
-                                    Tool failure should degrade safely rather
-                                    than block message completion.
-                                </li>
-                                <li>
-                                    <code>web_search</code> remains a legacy
-                                    integration path in parts of the stack; do
-                                    not assume parity with every context-step
-                                    integration flow.
+                                    Context integrations are fail-open,
+                                    degrading safely rather than blocking
+                                    message completion.
                                 </li>
                             </ul>
                         </section>


### PR DESCRIPTION
- Move conversation normalization into a backend-owned `conversationContextService` so planner and generation use the same canonical message projection.
- Thread a `contextEnvelope` through orchestrator, workflow, and chat service seams to preserve provenance and snapshot-safe context metadata.
- Add explicit validation for invalid conversation shapes and return a 400 for malformed context assembly requests.
- Update backend and web tests to cover trimming, projection, envelope propagation, and failure cases.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Invalid conversation contexts now return clearer HTTP 400 errors with diagnostic details instead of generic server errors
  * Enhanced validation catches malformed conversation messages and invalid speaker identities

* **Improvements**
  * Optimized Discord conversation handling with automatic message window management
  * Improved error diagnostics and logging for conversation context issues throughout the chat workflow

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/footnote-ai/footnote/pull/363?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->