### PR TITLE
fix(workflow): grounded workflow trace-card reliability and raise grounded step budgets

### DIFF
--- a/packages/backend/src/services/executionContract.ts
+++ b/packages/backend/src/services/executionContract.ts
@@ -365,7 +365,7 @@ export const EXECUTION_CONTRACT_PRESETS: Readonly<
             limits: {
                 maxWorkflowSteps: 8,
                 maxToolCalls: 3,
-                maxDeliberationCalls: 2,
+                maxDeliberationCalls: 3,
                 maxTokensTotal: 14_000,
                 maxDurationMs: 70_000,
             },

--- a/packages/backend/src/services/workflowEngine/reviewDecision.ts
+++ b/packages/backend/src/services/workflowEngine/reviewDecision.ts
@@ -6,12 +6,20 @@
  * @footnote-risk: medium - Invalid parsing can trigger incorrect fail-open behavior.
  * @footnote-ethics: high - Assess decisions control bounded revision/finalize paths.
  */
+import type {
+    PartialResponseTemperament,
+    TraceAxisScore,
+} from '@footnote/contracts/policy';
+import { z } from 'zod';
 import { sanitizeReviewModuleIds } from '../reviewModules.js';
 
 export type ReviewDecision = {
     reviewDecision: 'finalize' | 'revise';
     reviewReason: string;
     revisionInstruction?: string;
+    traceAlignment?: 'aligned' | 'misaligned';
+    traceAlignmentReason?: string;
+    finalTemperament?: PartialResponseTemperament;
     moduleHints?: string[];
     concerns?: {
         length?: 'too_long' | 'ok';
@@ -26,6 +34,15 @@ Schema:
   "reviewDecision": "finalize" | "revise",
   "reviewReason": "one short sentence",
   "revisionInstruction": "required when reviewDecision is revise",
+  "traceAlignment": "aligned" | "misaligned",
+  "traceAlignmentReason": "required when traceAlignment is misaligned",
+  "finalTemperament": {
+    "tightness": 1 | 2 | 3 | 4 | 5,
+    "rationale": 1 | 2 | 3 | 4 | 5,
+    "attribution": 1 | 2 | 3 | 4 | 5,
+    "caution": 1 | 2 | 3 | 4 | 5,
+    "extent": 1 | 2 | 3 | 4 | 5
+  },
   "moduleHints": ["optional review module ids"],
   "concerns": {
     "length": "too_long" | "ok",
@@ -41,6 +58,86 @@ Do not include markdown or extra keys.`;
 export const DEFAULT_REVISION_PROMPT_PREFIX =
     'Revise the prior draft using the review guidance while preserving factual grounding and provenance boundaries.';
 
+const TraceAxisScoreSchema: z.ZodType<TraceAxisScore> = z.union([
+    z.literal(1),
+    z.literal(2),
+    z.literal(3),
+    z.literal(4),
+    z.literal(5),
+]);
+
+const PartialResponseTemperamentSchema = z
+    .object({
+        tightness: TraceAxisScoreSchema.optional(),
+        rationale: TraceAxisScoreSchema.optional(),
+        attribution: TraceAxisScoreSchema.optional(),
+        caution: TraceAxisScoreSchema.optional(),
+        extent: TraceAxisScoreSchema.optional(),
+    })
+    .strict();
+
+const ReviewDecisionSchema = z
+    .object({
+        reviewDecision: z.enum(['finalize', 'revise']),
+        reviewReason: z.string().min(1),
+        revisionInstruction: z.string().optional(),
+        traceAlignment: z.enum(['aligned', 'misaligned']).optional(),
+        traceAlignmentReason: z.string().optional(),
+        finalTemperament: PartialResponseTemperamentSchema.optional(),
+        moduleHints: z.array(z.string()).optional(),
+        concerns: z
+            .object({
+                length: z.enum(['too_long', 'ok']).optional(),
+                style: z.enum(['too_stiff', 'ok']).optional(),
+                evidence: z.enum(['needs_caution', 'ok']).optional(),
+            })
+            .strict()
+            .optional(),
+    })
+    .passthrough()
+    .superRefine((value, context) => {
+        const normalizedRevisionInstruction = value.revisionInstruction?.trim();
+        if (
+            value.reviewDecision === 'revise' &&
+            (!normalizedRevisionInstruction ||
+                normalizedRevisionInstruction.length === 0)
+        ) {
+            context.addIssue({
+                code: z.ZodIssueCode.custom,
+                path: ['revisionInstruction'],
+                message:
+                    'revisionInstruction is required when reviewDecision is "revise".',
+            });
+        }
+
+        const normalizedTraceAlignmentReason =
+            value.traceAlignmentReason?.trim();
+        const hasFinalTemperamentAxes =
+            value.finalTemperament !== undefined &&
+            Object.keys(value.finalTemperament).length > 0;
+        if (value.traceAlignment === 'misaligned') {
+            if (
+                !normalizedTraceAlignmentReason ||
+                normalizedTraceAlignmentReason.length === 0
+            ) {
+                context.addIssue({
+                    code: z.ZodIssueCode.custom,
+                    path: ['traceAlignmentReason'],
+                    message:
+                        'traceAlignmentReason is required when traceAlignment is "misaligned".',
+                });
+            }
+            if (!hasFinalTemperamentAxes) {
+                context.addIssue({
+                    code: z.ZodIssueCode.custom,
+                    path: ['finalTemperament'],
+                    message:
+                        'finalTemperament must include at least one axis when traceAlignment is "misaligned".',
+                });
+            }
+        }
+    });
+
 export const parseReviewDecisionOutput = (
     text: string
 ): ReviewDecision | null => {
@@ -50,66 +147,44 @@ export const parseReviewDecisionOutput = (
     }
 
     try {
-        const parsed = JSON.parse(trimmed) as {
-            reviewDecision?: unknown;
-            reviewReason?: unknown;
-            revisionInstruction?: unknown;
-            moduleHints?: unknown;
-            concerns?: unknown;
-        };
-        if (
-            parsed.reviewDecision !== 'finalize' &&
-            parsed.reviewDecision !== 'revise'
-        ) {
+        const parsedPayload = JSON.parse(trimmed) as unknown;
+        const parsedDecision = ReviewDecisionSchema.safeParse(parsedPayload);
+        if (!parsedDecision.success) {
             return null;
         }
-        if (
-            typeof parsed.reviewReason !== 'string' ||
-            parsed.reviewReason.trim().length === 0
-        ) {
-            return null;
-        }
-        const rawRevisionInstruction =
-            typeof parsed.revisionInstruction === 'string'
-                ? parsed.revisionInstruction.trim()
-                : undefined;
-        if (
-            parsed.reviewDecision === 'revise' &&
-            (!rawRevisionInstruction || rawRevisionInstruction.length === 0)
-        ) {
-            return null;
-        }
-        const moduleHints = Array.isArray(parsed.moduleHints)
-            ? sanitizeReviewModuleIds(
-                  parsed.moduleHints.filter(
-                      (hint): hint is string => typeof hint === 'string'
-                  )
-              )
+
+        const normalizedRevisionInstruction =
+            parsedDecision.data.revisionInstruction?.trim();
+        const moduleHints = parsedDecision.data.moduleHints
+            ? sanitizeReviewModuleIds(parsedDecision.data.moduleHints)
             : undefined;
-        const concerns =
-            parsed.concerns && typeof parsed.concerns === 'object'
-                ? (parsed.concerns as Record<string, unknown>)
-                : undefined;
         const normalizedConcerns: NonNullable<ReviewDecision['concerns']> = {
-            ...(concerns?.length === 'too_long' || concerns?.length === 'ok'
-                ? { length: concerns.length as 'too_long' | 'ok' }
-                : {}),
-            ...(concerns?.style === 'too_stiff' || concerns?.style === 'ok'
-                ? { style: concerns.style as 'too_stiff' | 'ok' }
-                : {}),
-            ...(concerns?.evidence === 'needs_caution' ||
-            concerns?.evidence === 'ok'
-                ? {
-                      evidence: concerns.evidence as 'needs_caution' | 'ok',
-                  }
-                : {}),
+            ...(parsedDecision.data.concerns?.length !== undefined && {
+                length: parsedDecision.data.concerns.length,
+            }),
+            ...(parsedDecision.data.concerns?.style !== undefined && {
+                style: parsedDecision.data.concerns.style,
+            }),
+            ...(parsedDecision.data.concerns?.evidence !== undefined && {
+                evidence: parsedDecision.data.concerns.evidence,
+            }),
         };
 
         return {
-            reviewDecision: parsed.reviewDecision,
-            reviewReason: parsed.reviewReason.trim(),
-            ...(rawRevisionInstruction !== undefined && {
-                revisionInstruction: rawRevisionInstruction,
+            reviewDecision: parsedDecision.data.reviewDecision,
+            reviewReason: parsedDecision.data.reviewReason.trim(),
+            ...(normalizedRevisionInstruction !== undefined && {
+                revisionInstruction: normalizedRevisionInstruction,
+            }),
+            ...(parsedDecision.data.traceAlignment !== undefined && {
+                traceAlignment: parsedDecision.data.traceAlignment,
+            }),
+            ...(parsedDecision.data.traceAlignmentReason !== undefined && {
+                traceAlignmentReason:
+                    parsedDecision.data.traceAlignmentReason.trim(),
+            }),
+            ...(parsedDecision.data.finalTemperament !== undefined && {
+                finalTemperament: parsedDecision.data.finalTemperament,
             }),
             ...(moduleHints !== undefined && { moduleHints }),
             ...(Object.keys(normalizedConcerns).length > 0 && {

--- a/packages/backend/src/services/workflowEngine/reviewLoopSignals.ts
+++ b/packages/backend/src/services/workflowEngine/reviewLoopSignals.ts
@@ -7,14 +7,25 @@
  */
 import type { BoundedReviewAssessSignals } from '@footnote/contracts/policy';
 import type { ReviewDecision } from './reviewDecision.js';
+import { toAssessFinalTemperamentSignals } from '../traceAlignmentSignals.js';
 
 export const buildAssessSignals = (
     decision: ReviewDecision
 ): BoundedReviewAssessSignals => ({
     reviewDecision: decision.reviewDecision,
     reviewReason: decision.reviewReason,
+    // Keep assess signals schema-compatible even when model output omits TRACE
+    // alignment details so trace retrieval remains fail-open.
+    traceAlignment: decision.traceAlignment ?? 'aligned',
+    ...(decision.traceAlignmentReason !== undefined && {
+        traceAlignmentReason: decision.traceAlignmentReason,
+    }),
+    ...toAssessFinalTemperamentSignals(decision.finalTemperament),
     ...(decision.reviewDecision === 'revise' && {
         refinementRequested: true,
+        ...(decision.revisionInstruction !== undefined && {
+            revisionInstruction: decision.revisionInstruction,
+        }),
     }),
     ...(decision.concerns?.length !== undefined && {
         lengthConcern: decision.concerns.length,

--- a/packages/backend/src/services/workflowProfileRegistry.ts
+++ b/packages/backend/src/services/workflowProfileRegistry.ts
@@ -55,13 +55,13 @@ const EXECUTION_CONTRACT_QUALITY_GROUNDED_WORKFLOW_POLICY_PRESET: Readonly<
 const QUALITY_GROUNDED_DEFAULT_LIMITS: Readonly<
     WorkflowProfileRuntime['defaultLimits']
 > = {
-    maxWorkflowSteps: 4,
-    maxToolCalls: 1,
+    maxWorkflowSteps: 8,
+    maxToolCalls: 3,
     maxPlanCycles: 1,
     maxReviewCycles: 3,
     maxDeliberationCalls: 4,
     maxTokensTotal: Number.MAX_SAFE_INTEGER,
-    maxDurationMs: 15000,
+    maxDurationMs: 70000,
 };
 
 const REVIEWED_WORKFLOW_PROFILE: WorkflowProfileRuntime = {

--- a/packages/backend/src/storage/traces/sqliteTraceStore.ts
+++ b/packages/backend/src/storage/traces/sqliteTraceStore.ts
@@ -5,15 +5,17 @@
  * @footnote-risk: medium - Storage errors can drop trace records or corrupt metadata.
  * @footnote-ethics: medium - Trace accuracy underpins transparency and auditability.
  */
-import type { Citation, ResponseMetadata } from '@footnote/contracts/policy';
+import {
+    TRACE_ASSESS_FINAL_TEMPERAMENT_SIGNAL_KEYS,
+    type Citation,
+    type ResponseMetadata,
+} from '@footnote/contracts/policy';
+import { ResponseMetadataSchema } from '@footnote/contracts/web/schemas';
 import Database from 'better-sqlite3';
 import fs from 'fs';
 import path from 'path';
 import { logger } from '../../utils/logger.js';
-import {
-    assertValidResponseMetadata,
-    traceStoreJsonReplacer,
-} from './traceStoreUtils.js';
+import { traceStoreJsonReplacer } from './traceStoreUtils.js';
 
 const BUSY_MAX_ATTEMPTS = 5;
 const BUSY_RETRY_DELAY_MS = 50;
@@ -23,6 +25,120 @@ const traceLogger =
     typeof logger.child === 'function'
         ? logger.child({ module: 'sqliteTraceStore' })
         : logger;
+const TRACE_ASSESS_FINAL_AXIS_SIGNAL_KEYS = Object.values(
+    TRACE_ASSESS_FINAL_TEMPERAMENT_SIGNAL_KEYS
+);
+
+const isPlainObject = (value: unknown): value is Record<string, unknown> =>
+    !!value &&
+    typeof value === 'object' &&
+    !Array.isArray(value) &&
+    Object.getPrototypeOf(value) === Object.prototype;
+
+const hasFinalTemperamentAxisSignals = (
+    signals: Record<string, unknown>
+): boolean =>
+    TRACE_ASSESS_FINAL_AXIS_SIGNAL_KEYS.some((axisKey) => {
+        const score = signals[axisKey];
+        return (
+            typeof score === 'number' &&
+            Number.isInteger(score) &&
+            score >= 1 &&
+            score <= 5
+        );
+    });
+
+const normalizeAssessSignalsForCompatibility = (
+    signals: Record<string, unknown>
+): Record<string, unknown> => {
+    const normalizedSignals: Record<string, unknown> = { ...signals };
+    const reviewDecision = normalizedSignals.reviewDecision;
+    const reviewReason = normalizedSignals.reviewReason;
+    if (
+        (reviewDecision === 'finalize' || reviewDecision === 'revise') &&
+        (typeof reviewReason !== 'string' || reviewReason.trim().length === 0)
+    ) {
+        normalizedSignals.reviewReason =
+            'Compatibility fallback: assess reason unavailable.';
+    }
+    if (reviewDecision === 'revise') {
+        const revisionInstruction = normalizedSignals.revisionInstruction;
+        if (
+            typeof revisionInstruction !== 'string' ||
+            revisionInstruction.trim().length === 0
+        ) {
+            normalizedSignals.revisionInstruction =
+                'Compatibility fallback: revision instruction unavailable.';
+        }
+    }
+
+    const traceAlignment = normalizedSignals.traceAlignment;
+    const hasTraceAlignment =
+        traceAlignment === 'aligned' || traceAlignment === 'misaligned';
+    if (!hasTraceAlignment) {
+        normalizedSignals.traceAlignment = 'aligned';
+        return normalizedSignals;
+    }
+
+    if (traceAlignment === 'misaligned') {
+        const traceAlignmentReason = normalizedSignals.traceAlignmentReason;
+        const hasReason =
+            typeof traceAlignmentReason === 'string' &&
+            traceAlignmentReason.trim().length > 0;
+        if (!hasReason || !hasFinalTemperamentAxisSignals(normalizedSignals)) {
+            normalizedSignals.traceAlignment = 'aligned';
+            delete normalizedSignals.traceAlignmentReason;
+        }
+    }
+
+    return normalizedSignals;
+};
+
+const repairTraceMetadataForCompatibility = (metadata: unknown): unknown => {
+    if (!isPlainObject(metadata)) {
+        return metadata;
+    }
+
+    const root = { ...metadata };
+    if (!isPlainObject(root.workflow)) {
+        return root;
+    }
+
+    const workflow = { ...root.workflow };
+    if (!Array.isArray(workflow.steps)) {
+        root.workflow = workflow;
+        return root;
+    }
+
+    workflow.steps = workflow.steps.map((step): unknown => {
+        if (!isPlainObject(step)) {
+            return step;
+        }
+        if (step.stepKind !== 'assess') {
+            return step;
+        }
+        if (!isPlainObject(step.outcome)) {
+            return step;
+        }
+        if (step.outcome.status !== 'executed') {
+            return step;
+        }
+        const outcome = { ...step.outcome };
+        const existingSignals = isPlainObject(outcome.signals)
+            ? outcome.signals
+            : {};
+        outcome.signals =
+            normalizeAssessSignalsForCompatibility(existingSignals);
+
+        return {
+            ...step,
+            outcome,
+        };
+    });
+
+    root.workflow = workflow;
+    return root;
+};
 
 export interface SqliteTraceStoreConfig {
     dbPath: string;
@@ -232,43 +348,60 @@ export class SqliteTraceStore {
             return null;
         }
 
-        const filePath = `sqlite:${responseId}`;
-        const parsed = JSON.parse(row.metadata_json) as unknown;
-
-        if (
-            !parsed ||
-            typeof parsed !== 'object' ||
-            !Array.isArray((parsed as { citations?: unknown }).citations)
-        ) {
-            throw new Error(
-                `Trace record "${responseId}" is invalid: missing citations array.`
+        let parsedJson: unknown;
+        try {
+            parsedJson = JSON.parse(row.metadata_json) as unknown;
+        } catch (error) {
+            traceLogger.warn(
+                `Trace record "${responseId}" failed JSON parsing; returning null fail-open.`,
+                {
+                    responseId,
+                    reasonCode: 'trace_json_parse_error',
+                    error:
+                        error instanceof Error ? error.message : String(error),
+                }
             );
+            return null;
         }
 
-        const citations = (parsed as { citations: unknown[] }).citations;
-        for (const citation of citations) {
-            if (!citation || typeof citation !== 'object') {
-                throw new Error(
-                    `Trace record "${responseId}" is invalid: citation entry is invalid.`
+        const strictParsed = ResponseMetadataSchema.safeParse(parsedJson);
+        if (strictParsed.success) {
+            if (strictParsed.data.responseId !== responseId) {
+                traceLogger.warn(
+                    `Trace record "${responseId}" has mismatched responseId "${strictParsed.data.responseId}"; returning null fail-open.`
                 );
+                return null;
             }
-
-            const citationRecord = citation as Record<string, unknown>;
-            if (typeof citationRecord.url !== 'string') {
-                throw new Error(
-                    `Trace record "${responseId}" is invalid: citation URL missing or malformed.`
-                );
-            }
+            return strictParsed.data;
         }
 
-        assertValidResponseMetadata(parsed, filePath, responseId);
-        if ((parsed as ResponseMetadata).responseId !== responseId) {
-            throw new Error(
-                `Trace record "${responseId}" is corrupted: responseId mismatch (expected "${responseId}" but found "${(parsed as ResponseMetadata).responseId}").`
+        const repairedPayload = repairTraceMetadataForCompatibility(parsedJson);
+        const repairedParsed =
+            ResponseMetadataSchema.safeParse(repairedPayload);
+        if (repairedParsed.success) {
+            if (repairedParsed.data.responseId !== responseId) {
+                traceLogger.warn(
+                    `Compatibility-repaired trace "${responseId}" still has mismatched responseId "${repairedParsed.data.responseId}"; returning null fail-open.`
+                );
+                return null;
+            }
+            traceLogger.warn(
+                `Trace record "${responseId}" required compatibility repair to satisfy metadata schema.`
             );
+            return repairedParsed.data;
         }
 
-        return parsed as ResponseMetadata;
+        const firstIssue = repairedParsed.error.issues[0];
+        const issuePath =
+            firstIssue && firstIssue.path.length > 0
+                ? firstIssue.path.join('.')
+                : 'root';
+        const issueMessage =
+            firstIssue?.message ?? 'Invalid trace metadata payload.';
+        traceLogger.warn(
+            `Trace record "${responseId}" remains invalid after compatibility repair (${issuePath}: ${issueMessage}); returning null fail-open.`
+        );
+        return null;
     }
 
     async delete(responseId: string): Promise<void> {

--- a/packages/backend/test/executionContractResolver.test.ts
+++ b/packages/backend/test/executionContractResolver.test.ts
@@ -26,6 +26,9 @@ test('resolveExecutionContract maps known preset ids deterministically', () => {
         qualityGrounded.policyContract.response.responseMode,
         'quality_grounded'
     );
+    assert.equal(qualityGrounded.policyContract.limits.maxWorkflowSteps, 8);
+    assert.equal(qualityGrounded.policyContract.limits.maxToolCalls, 3);
+    assert.equal(qualityGrounded.policyContract.limits.maxDeliberationCalls, 3);
     assert.equal(
         qualityGrounded.policyContract.response.stoppingRule,
         'bounded_sufficient_answer'

--- a/packages/backend/test/traceStore.test.ts
+++ b/packages/backend/test/traceStore.test.ts
@@ -152,3 +152,65 @@ test('TraceStore delete removes both trace metadata and trace-card SVG', async (
         await fs.rm(tempRoot, { recursive: true, force: true });
     }
 });
+
+test('TraceStore retrieve repairs missing assess TRACE alignment fail-open', async () => {
+    const tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'trace-repair-'));
+    const dbPath = path.join(tempRoot, 'provenance.db');
+    const store = new SqliteTraceStore({ dbPath });
+    const responseId = 'trace_repair_alignment_123';
+
+    const metadata: ResponseMetadata = {
+        responseId,
+        provenance: 'Inferred',
+        safetyTier: 'Low',
+        tradeoffCount: 1,
+        chainHash: 'repair_hash',
+        licenseContext: 'MIT + HL3',
+        modelVersion: 'gpt-5-mini',
+        staleAfter: new Date(Date.now() + 60000).toISOString(),
+        citations: [],
+        trace_target: {},
+        trace_final: {},
+        workflow: {
+            workflowId: 'wf_repair_123',
+            workflowName: 'message_reviewed',
+            status: 'completed',
+            terminationReason: 'goal_satisfied',
+            stepCount: 1,
+            maxSteps: 4,
+            maxDurationMs: 15000,
+            steps: [
+                {
+                    stepId: 'step_1',
+                    attempt: 1,
+                    stepKind: 'assess',
+                    startedAt: new Date().toISOString(),
+                    finishedAt: new Date().toISOString(),
+                    durationMs: 1,
+                    outcome: {
+                        status: 'executed',
+                        summary: 'Assess completed.',
+                        signals: {
+                            reviewDecision: 'finalize',
+                            reviewReason: 'Ready.',
+                        },
+                    },
+                },
+            ],
+        },
+    };
+
+    try {
+        await store.upsert(metadata);
+        const repaired = await store.retrieve(responseId);
+        assert.ok(repaired, 'trace should be retrievable with compatibility');
+        const assessStep = repaired.workflow?.steps.find(
+            (step) => step.stepKind === 'assess'
+        );
+        assert.ok(assessStep);
+        assert.equal(assessStep.outcome.signals?.traceAlignment, 'aligned');
+    } finally {
+        store.close();
+        await fs.rm(tempRoot, { recursive: true, force: true });
+    }
+});

--- a/packages/backend/test/workflowEngine/review-loop.test.ts
+++ b/packages/backend/test/workflowEngine/review-loop.test.ts
@@ -462,6 +462,7 @@ test('runBoundedReviewWorkflow persists assess machine decision and reason in li
         assessStep.outcome.signals?.reviewReason,
         'Draft is complete and clear.'
     );
+    assert.equal(assessStep.outcome.signals?.traceAlignment, 'aligned');
     assert.equal(generationCalls, 2);
 });
 
@@ -575,6 +576,11 @@ test('runBoundedReviewWorkflow executes engine-bounded refinement path without r
     );
     assert.ok(assessReviseStep);
     assert.equal(assessReviseStep.outcome.signals?.refinementRequested, true);
+    assert.equal(
+        assessReviseStep.outcome.signals?.revisionInstruction,
+        'Trim and soften the phrasing.'
+    );
+    assert.equal(assessReviseStep.outcome.signals?.traceAlignment, 'aligned');
     assert.equal(assessReviseStep.outcome.signals?.moduleHintCount, 1);
     assert.equal(
         assessReviseStep.outcome.signals?.moduleHintIdsCsv,
@@ -778,4 +784,86 @@ test('runBoundedReviewWorkflow fail-opens when assess revise omits required revi
         ),
         false
     );
+});
+
+test('runBoundedReviewWorkflow persists assess TRACE alignment signals when provided', async () => {
+    let generationCalls = 0;
+    const generationRuntime: GenerationRuntime = {
+        kind: 'test-runtime',
+        async generate() {
+            generationCalls += 1;
+            if (generationCalls === 1) {
+                return {
+                    text: 'initial draft',
+                    model: 'gpt-5-mini',
+                    usage: {
+                        promptTokens: 10,
+                        completionTokens: 10,
+                        totalTokens: 20,
+                    },
+                    provenance: 'Inferred',
+                    citations: [],
+                };
+            }
+
+            return {
+                text: '{"reviewDecision":"finalize","reviewReason":"Ready to ship.","traceAlignment":"misaligned","traceAlignmentReason":"Need tighter caution tone.","finalTemperament":{"caution":4}}',
+                model: 'gpt-5-mini',
+                usage: {
+                    promptTokens: 5,
+                    completionTokens: 5,
+                    totalTokens: 10,
+                },
+                provenance: 'Inferred',
+                citations: [],
+            };
+        },
+    };
+
+    const result = await runBoundedReviewWorkflowForTest({
+        generationRuntime,
+        generationRequest: {
+            model: 'gpt-5-mini',
+            messages: [{ role: 'user', content: 'Draft answer' }],
+        },
+        messagesWithHints: [{ role: 'user', content: 'Draft answer' }],
+        generationStartedAtMs: Date.now(),
+        workflowConfig: {
+            workflowName: 'message_reviewed',
+            maxIterations: 2,
+            maxDurationMs: 15000,
+        },
+        workflowPolicy: {
+            enablePlanning: false,
+            enableToolUse: false,
+            enableReplanning: false,
+            enableGeneration: true,
+            enableAssessment: true,
+            enableRevision: true,
+        },
+        captureUsage: (generationResult) => ({
+            model: generationResult.model ?? 'gpt-5-mini',
+            promptTokens: generationResult.usage?.promptTokens ?? 0,
+            completionTokens: generationResult.usage?.completionTokens ?? 0,
+            totalTokens: generationResult.usage?.totalTokens ?? 0,
+            estimatedCost: {
+                inputCostUsd: 0,
+                outputCostUsd: 0,
+                totalCostUsd: 0,
+            },
+        }),
+    });
+
+    assert.equal(result.outcome, 'generated');
+    const assessStep = result.workflowLineage.steps.find(
+        (step) => step.stepKind === 'assess'
+    );
+    assert.ok(assessStep);
+    assert.equal(assessStep.outcome.status, 'executed');
+    assert.equal(assessStep.outcome.signals?.traceAlignment, 'misaligned');
+    assert.equal(
+        assessStep.outcome.signals?.traceAlignmentReason,
+        'Need tighter caution tone.'
+    );
+    assert.equal(assessStep.outcome.signals?.finalTemperamentCaution, 4);
 });

--- a/packages/backend/test/workflowProfileRegistry.test.ts
+++ b/packages/backend/test/workflowProfileRegistry.test.ts
@@ -377,3 +377,40 @@ test('resolveWorkflowRuntimeConfig keeps maxDeliberationCalls compatibility mapp
             (balanced.workflowExecutionLimits.maxReviewCycles ?? 0)
     );
 });
+
+test('resolveWorkflowRuntimeConfig allows grounded contract defaults to run at least one refinement cycle', () => {
+    const groundedWithContract = resolveWorkflowRuntimeConfig({
+        modeId: 'grounded',
+        reviewLoopEnabled: false,
+        maxIterations: 5,
+        maxDurationMs: 9000,
+        ExecutionContract: {
+            response: {
+                responseMode: 'quality_grounded',
+                stoppingRule: 'bounded_sufficient_answer',
+            },
+            limits: {
+                maxWorkflowSteps: 8,
+                maxToolCalls: 3,
+                maxDeliberationCalls: 3,
+                maxTokensTotal: 14000,
+                maxDurationMs: 70000,
+            },
+        },
+    });
+
+    assert.equal(groundedWithContract.workflowExecutionEnabled, true);
+    assert.equal(
+        groundedWithContract.workflowExecutionLimits.maxWorkflowSteps,
+        8
+    );
+    assert.equal(groundedWithContract.workflowExecutionLimits.maxPlanCycles, 1);
+    assert.equal(
+        groundedWithContract.workflowExecutionLimits.maxReviewCycles,
+        2
+    );
+    assert.equal(
+        groundedWithContract.workflowExecutionLimits.maxDeliberationCalls,
+        3
+    );
+});


### PR DESCRIPTION
This PR fixes two regressions introduced during recent workflow refactoring:

1. Trace metadata/card generation could fail hard when assess step signals were partially missing (traceAlignment), causing:
- metadata_unavailable on cards
- /traces/:id returning 500
- Trace viewer “Trace Unavailable”


2. Grounded default runtime limits were too tight, so normal grounded flow (planner -> trustgraph attempt -> generate -> assess) could exhaust budget before refinement.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced workflow capabilities with increased execution limits for deliberation and refinement cycles.
  * Added trace alignment tracking to review decisions for improved transparency.

* **Bug Fixes**
  * Improved robustness of trace data storage with automatic repair for compatibility issues.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/footnote-ai/footnote/pull/368?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->