### PR TITLE
fix(backend): stop scheduling trustgraph context step when runtime is disabled

### DIFF
--- a/packages/backend/src/services/chatService.ts
+++ b/packages/backend/src/services/chatService.ts
@@ -593,11 +593,17 @@ const mergeContextStepRequests = (input: {
  * execution-contract context.
  */
 const buildTrustGraphContextStepRequest = (
+    executionContractTrustGraph:
+        | ExecutionContractTrustGraphRuntimeOptions
+        | undefined,
     executionContractTrustGraphContext:
         | ExecutionContractTrustGraphContext
         | undefined
 ): ContextStepRequest | undefined => {
-    if (executionContractTrustGraphContext === undefined) {
+    if (
+        executionContractTrustGraph === undefined ||
+        executionContractTrustGraphContext === undefined
+    ) {
         return undefined;
     }
     return {
@@ -980,6 +986,7 @@ export const createChatService = ({
             );
             const trustGraphContextStepRequest =
                 buildTrustGraphContextStepRequest(
+                    executionContractTrustGraph,
                     executionContractTrustGraphContext
                 );
             const effectiveContextStepRequests = mergeContextStepRequests({


### PR DESCRIPTION
This PR fixes a trace-noise bug where TrustGraph was still being scheduled as a workflow context step even when TrustGraph runtime wiring was disabled, which produced confusing `tool:trustgraph(skipped, tool_unavailable)` events.