### PR TITLE
Normalize execution timeline ordering in contracts

### DIFF
--- a/packages/contracts/src/policy/executionFormatting.ts
+++ b/packages/contracts/src/policy/executionFormatting.ts
@@ -7,6 +7,12 @@
  */
 import type { ExecutionEvent, StepRecord, WorkflowRecord } from './types.js';
 
+type TimelineEntry = {
+    segment: string;
+    phaseOrder: 0 | 1 | 2;
+    index: number;
+};
+
 const formatEvaluatorSummary = (event: ExecutionEvent): string => {
     if (event.kind !== 'evaluator') {
         return 'decision';
@@ -87,7 +93,11 @@ const formatExecutionEvent = (event: ExecutionEvent): string => {
     return `${event.kind}:${modelOrProfile}(${event.status}${reasonSuffix}${durationSuffix})`;
 };
 
-const formatWorkflowPlannerStep = (step: StepRecord): string => {
+const formatWorkflowStep = (
+    label: string,
+    step: StepRecord,
+    defaultModelOrProfile: string
+): string => {
     const durationSuffix =
         step.durationMs !== undefined ? `, ${step.durationMs}ms` : '';
     const reasonSuffix =
@@ -100,8 +110,52 @@ const formatWorkflowPlannerStep = (step: StepRecord): string => {
         (typeof profileIdSignal === 'string' &&
         profileIdSignal.trim().length > 0
             ? profileIdSignal
-            : 'workflow');
-    return `planner:${modelOrProfile}(${step.outcome.status}${reasonSuffix}${durationSuffix})`;
+            : defaultModelOrProfile);
+    return `${label}:${modelOrProfile}(${step.outcome.status}${reasonSuffix}${durationSuffix})`;
+};
+
+const isIncludedWorkflowStep = (step: StepRecord): boolean =>
+    step.stepKind === 'plan' ||
+    step.stepKind === 'assess' ||
+    (step.stepKind === 'generate' &&
+        step.outcome.signals?.refinementApplied === true);
+
+const normalizeWorkflowStepEntry = (
+    step: StepRecord,
+    index: number
+): TimelineEntry | null => {
+    if (!isIncludedWorkflowStep(step)) {
+        return null;
+    }
+
+    if (step.stepKind === 'plan') {
+        return {
+            segment: formatWorkflowStep('planner', step, 'workflow'),
+            phaseOrder: 0,
+            index,
+        };
+    }
+
+    return {
+        segment: formatWorkflowStep(step.stepKind, step, 'workflow'),
+        phaseOrder: 2,
+        index,
+    };
+};
+
+const normalizeExecutionEventEntry = (
+    event: ExecutionEvent,
+    index: number
+): TimelineEntry | null => {
+    if (event.kind === 'planner') {
+        return null;
+    }
+
+    return {
+        segment: formatExecutionEvent(event),
+        phaseOrder: 1,
+        index,
+    };
 };
 
 /**
@@ -111,18 +165,21 @@ export const formatExecutionTimelineSummary = (
     execution: ExecutionEvent[] | undefined,
     workflow?: WorkflowRecord
 ): string | null => {
-    const executionEvents = execution ?? [];
-    const workflowPlannerSummaries =
+    const workflowEntries =
         workflow?.steps
-            .filter((step) => step.stepKind === 'plan')
-            .map(formatWorkflowPlannerStep) ?? [];
-    const executionSummaries = executionEvents
-        .filter((event) => event.kind !== 'planner')
-        .map(formatExecutionEvent);
-    const timelineSegments = [
-        ...workflowPlannerSummaries,
-        ...executionSummaries,
-    ];
+            .map((step, index) => normalizeWorkflowStepEntry(step, index))
+            .filter((entry): entry is TimelineEntry => entry !== null) ?? [];
+    const executionEntries =
+        (execution ?? [])
+            .map((event, index) => normalizeExecutionEventEntry(event, index))
+            .filter((entry): entry is TimelineEntry => entry !== null) ?? [];
+    const timelineSegments = [...workflowEntries, ...executionEntries]
+        .sort((left, right) =>
+            left.phaseOrder === right.phaseOrder
+                ? left.index - right.index
+                : left.phaseOrder - right.phaseOrder
+        )
+        .map((entry) => entry.segment);
 
     if (timelineSegments.length === 0) {
         return null;

--- a/packages/contracts/test/executionFormatting.test.ts
+++ b/packages/contracts/test/executionFormatting.test.ts
@@ -269,3 +269,94 @@ test('formatExecutionTimelineSummary surfaces planner lineage from workflow plan
         'planner:openai-text-fast(executed, 10ms) -> generation:gpt-5-mini(executed)'
     );
 });
+
+test('formatExecutionTimelineSummary appends workflow assess and refinement steps for reviewed loops', () => {
+    const summary = formatExecutionTimelineSummary(
+        [
+            {
+                kind: 'planner',
+                status: 'executed',
+                purpose: 'chat_orchestrator_action_selection',
+                contractType: 'text_json',
+                applyOutcome: 'applied',
+                mattered: false,
+                matteredControlIds: [],
+                model: 'gpt-5-nano',
+            },
+            {
+                kind: 'generation',
+                status: 'executed',
+                model: 'gpt-5-mini',
+                durationMs: 120,
+            },
+        ],
+        {
+            workflowId: 'wf_3',
+            workflowName: 'message_reviewed',
+            status: 'degraded',
+            terminationReason: 'executor_error_fail_open',
+            stepCount: 4,
+            maxSteps: 8,
+            maxDurationMs: 70000,
+            steps: [
+                {
+                    stepId: 'step_plan_1',
+                    attempt: 1,
+                    stepKind: 'plan',
+                    startedAt: '2026-04-01T00:00:00.000Z',
+                    finishedAt: '2026-04-01T00:00:00.010Z',
+                    durationMs: 10,
+                    outcome: {
+                        status: 'executed',
+                        summary: 'Planner step emitted bounded summary.',
+                    },
+                },
+                {
+                    stepId: 'step_generate_1',
+                    attempt: 1,
+                    stepKind: 'generate',
+                    startedAt: '2026-04-01T00:00:00.010Z',
+                    finishedAt: '2026-04-01T00:00:00.130Z',
+                    durationMs: 120,
+                    outcome: {
+                        status: 'executed',
+                        summary: 'Generated initial draft response.',
+                    },
+                },
+                {
+                    stepId: 'step_assess_1',
+                    attempt: 1,
+                    stepKind: 'assess',
+                    startedAt: '2026-04-01T00:00:00.130Z',
+                    finishedAt: '2026-04-01T00:00:00.150Z',
+                    durationMs: 20,
+                    outcome: {
+                        status: 'executed',
+                        summary: 'Assessment step evaluated draft quality.',
+                    },
+                },
+                {
+                    stepId: 'step_generate_2',
+                    attempt: 1,
+                    stepKind: 'generate',
+                    startedAt: '2026-04-01T00:00:00.150Z',
+                    finishedAt: '2026-04-01T00:00:00.190Z',
+                    durationMs: 40,
+                    reasonCode: 'generation_runtime_error',
+                    outcome: {
+                        status: 'failed',
+                        summary: 'Refinement generation failed.',
+                        signals: {
+                            refinementApplied: true,
+                        },
+                    },
+                },
+            ],
+        }
+    );
+
+    assert.equal(
+        summary,
+        'planner:workflow(executed, 10ms) -> generation:gpt-5-mini(executed, 120ms) -> assess:workflow(executed, 20ms) -> generate:workflow(failed, generation_runtime_error, 40ms)'
+    );
+});


### PR DESCRIPTION
## Summary
- Normalize execution timeline summaries so workflow steps and execution events are ordered by phase instead of concatenation order.
- Include reviewed workflow loops by surfacing `assess` steps and refinement `generate` steps in the timeline summary.
- Keep planner workflow steps labeled consistently while preserving existing formatting for status, reason, and duration.

## Testing
- Added coverage for reviewed-loop timeline formatting in `packages/contracts/test/executionFormatting.test.ts`.
- Not run: `pnpm lint:fix`
- Not run: `pnpm lint`