### PR TITLE
Remove request profile overrides, add review and TRACE controls

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -193,6 +193,7 @@ CHAT_CONTEXT_REVERSE_IMAGE_SEARCH_PROVIDER=none # Provider mode: none or serpapi
 CHAT_CONTEXT_REVERSE_IMAGE_SEARCH_SERPAPI_API_KEY= # Required when provider=serpapi
 CHAT_CONTEXT_REVERSE_IMAGE_SEARCH_PROVIDER_TIMEOUT_MS=12000 # HTTP timeout budget for reverse-image provider calls
 CHAT_WORKFLOW_MODE_ID=grounded # Workflow mode id: balanced or grounded
+CHAT_MAX_REQUEST_REVIEW_CYCLES=7 # Upper bound for request-level maxReviewCycles override on /api/chat
 TRACE_API_TOKEN= # Shared secret required for POST /api/traces (generate with: node -e "console.log(require('node:crypto').randomBytes(32).toString('hex'))")
 LANGFUSE_METADATA_MIRROR_ENABLED=false # Optional metadata-only mirror to Langfuse; fail-open and off by default
 LANGFUSE_METADATA_MIRROR_BASE_URL= # Optional Langfuse base URL (for example https://cloud.langfuse.com)

--- a/docs/api/openapi.yaml
+++ b/docs/api/openapi.yaml
@@ -88,8 +88,8 @@ paths:
                 Submit a transport-neutral chat request and receive the backend-selected action.
                 Public web callers use Turnstile when enabled; trusted internal callers may authenticate with service headers.
                 Send X-Session-Id / X-Turnstile-Token headers when needed for browser traffic.
-                Optionally provide `profileId` to select a backend response profile.
                 Optionally provide `botPersonaId` to select the backend-owned bot persona overlay (discord).
+                Optionally provide `maxReviewCycles` and `traceTarget` to tune workflow depth and TRACE posture for this request.
             tags:
                 - Chat
             parameters:
@@ -1300,23 +1300,33 @@ components:
                     type: string
                     pattern: '^[a-z0-9][a-z0-9-]{0,31}$'
                     description: Optional bot persona selector used for backend-owned persona overlays (discord).
-                profileId:
-                    type: string
-                    pattern: '^[a-z0-9][a-z0-9-]{0,31}$'
-                    description: Optional response profile selector resolved by backend model routing.
                 modeId:
                     type: string
                     enum: [balanced, grounded]
                     description: Optional user-facing posture selector for workflow mode routing.
-                generation:
+                maxReviewCycles:
+                    type: integer
+                    minimum: 0
+                    description: Optional hard override for reviewed workflow cycle depth.
+                traceTarget:
                     type: object
+                    description: Optional partial TRACE target override for this request.
                     properties:
-                        reasoningEffort:
-                            type: string
-                            enum: [minimal, low, medium, high]
-                        verbosity:
-                            type: string
-                            enum: [low, medium, high]
+                        tightness:
+                            type: integer
+                            enum: [1, 2, 3, 4, 5]
+                        rationale:
+                            type: integer
+                            enum: [1, 2, 3, 4, 5]
+                        attribution:
+                            type: integer
+                            enum: [1, 2, 3, 4, 5]
+                        caution:
+                            type: integer
+                            enum: [1, 2, 3, 4, 5]
+                        extent:
+                            type: integer
+                            enum: [1, 2, 3, 4, 5]
                     additionalProperties: false
                 trigger:
                     type: object

--- a/packages/backend/src/config/sections/services.ts
+++ b/packages/backend/src/config/sections/services.ts
@@ -150,6 +150,12 @@ export const buildServiceSections = (
             'CHAT_REVIEW_LOOP_MAX_DURATION_MS',
             warn
         ),
+        maxRequestReviewCycles: parseNonNegativeIntEnv(
+            env.CHAT_MAX_REQUEST_REVIEW_CYCLES,
+            7,
+            'CHAT_MAX_REQUEST_REVIEW_CYCLES',
+            warn
+        ),
         contextIntegrations: {
             webSearch: {
                 enabled: parseBooleanEnv(

--- a/packages/backend/src/config/types.ts
+++ b/packages/backend/src/config/types.ts
@@ -105,6 +105,7 @@ export type RuntimeConfig = {
         reviewLoopEnabled: boolean;
         maxIterations: number;
         maxDurationMs: number;
+        maxRequestReviewCycles: number;
         contextIntegrations: {
             /**
              * Web-search context integration controls for chat workflow execution.

--- a/packages/backend/src/services/chatOrchestrator.ts
+++ b/packages/backend/src/services/chatOrchestrator.ts
@@ -726,6 +726,7 @@ export const createChatOrchestrator = ({
             provider: defaultResponseProfile.provider,
             capabilities: defaultResponseProfile.capabilities,
             workflowModeId: workflowModeResolution.modeDecision.modeId,
+            workflowMaxReviewCycles: normalizedRequest.maxReviewCycles,
             plannerStepRequest,
             plannerStepExecutor,
             planContinuationBuilder,
@@ -872,7 +873,7 @@ export const createChatOrchestrator = ({
                 workflowMode: workflowModeResolution.modeDecision,
                 executionContractResponseMode:
                     resolvedExecutionContract.response.responseMode,
-                requestedProfileId: normalizedRequest.profileId,
+                requestedProfileId: undefined,
                 plannerSelectedProfileId: executionPlan.profileId,
                 selectedProfile: {
                     profileId: plannerSummary.selectedResponseProfile.id,
@@ -893,7 +894,7 @@ export const createChatOrchestrator = ({
                             workflowModeResolution.modeDecision.modeId,
                         executionContractResponseMode:
                             resolvedExecutionContract.response.responseMode,
-                        requestedProfileId: normalizedRequest.profileId,
+                        requestedProfileId: undefined,
                         plannerSelectedProfileId: executionPlan.profileId,
                         selectedProfileId:
                             plannerSummary.selectedResponseProfile.id,
@@ -936,7 +937,7 @@ export const createChatOrchestrator = ({
                       workflowMode: workflowModeResolution.modeDecision,
                       executionContractResponseMode:
                           resolvedExecutionContract.response.responseMode,
-                      requestedProfileId: normalizedRequest.profileId,
+                      requestedProfileId: undefined,
                       plannerSelectedProfileId: executionPlan.profileId,
                       selectedProfile: {
                           profileId: plannerSummary.selectedResponseProfile.id,

--- a/packages/backend/src/services/chatOrchestrator/plannerResultApplier.ts
+++ b/packages/backend/src/services/chatOrchestrator/plannerResultApplier.ts
@@ -23,8 +23,39 @@ import type {
     PlannerApplicationInput,
     PlannerApplicationResult,
 } from '../plannerWorkflowSeams.js';
+import type { ResponseTemperament } from '@footnote/contracts/policy';
 
 type PlannerSelectionSource = 'default' | 'planner' | 'request_override';
+
+const DEFAULT_REQUEST_TRACE_TEMPERAMENT: ResponseTemperament = {
+    tightness: 3,
+    rationale: 3,
+    attribution: 3,
+    caution: 3,
+    extent: 3,
+};
+
+const applyRequestTraceTargetOverride = (input: {
+    generation: ChatGenerationPlan;
+    traceTarget: PostChatRequest['traceTarget'] | undefined;
+}): ChatGenerationPlan => {
+    if (input.traceTarget === undefined) {
+        return input.generation;
+    }
+    const traceTarget = input.traceTarget;
+    const baseTemperament =
+        input.generation.temperament ?? DEFAULT_REQUEST_TRACE_TEMPERAMENT;
+    return {
+        ...input.generation,
+        temperament: {
+            tightness: traceTarget.tightness ?? baseTemperament.tightness,
+            rationale: traceTarget.rationale ?? baseTemperament.rationale,
+            attribution: traceTarget.attribution ?? baseTemperament.attribution,
+            caution: traceTarget.caution ?? baseTemperament.caution,
+            extent: traceTarget.extent ?? baseTemperament.extent,
+        },
+    };
+};
 
 export type CreatePlannerResultApplierInput = {
     enabledProfiles: ModelProfile[];
@@ -104,16 +135,11 @@ export const createPlannerResultApplier = (
             plannerPlan,
             input.logger
         );
-        const requestGeneration = plannerInput.normalizedRequest.generation;
-        let generationForExecution: ChatGenerationPlan = {
-            ...plan.generation,
-            ...(requestGeneration?.reasoningEffort
-                ? { reasoningEffort: requestGeneration.reasoningEffort }
-                : {}),
-            ...(requestGeneration?.verbosity
-                ? { verbosity: requestGeneration.verbosity }
-                : {}),
-        };
+        let generationForExecution: ChatGenerationPlan =
+            applyRequestTraceTargetOverride({
+                generation: plan.generation,
+                traceTarget: plannerInput.normalizedRequest.traceTarget,
+            });
         if (plannerInput.clarificationContinuation.kind === 'resolved') {
             generationForExecution = {
                 ...generationForExecution,

--- a/packages/backend/src/services/chatOrchestrator/plannerResultApplier.ts
+++ b/packages/backend/src/services/chatOrchestrator/plannerResultApplier.ts
@@ -43,6 +43,15 @@ const applyRequestTraceTargetOverride = (input: {
         return input.generation;
     }
     const traceTarget = input.traceTarget;
+    const hasAnyTraceAxisOverride =
+        traceTarget.tightness !== undefined ||
+        traceTarget.rationale !== undefined ||
+        traceTarget.attribution !== undefined ||
+        traceTarget.caution !== undefined ||
+        traceTarget.extent !== undefined;
+    if (!hasAnyTraceAxisOverride) {
+        return input.generation;
+    }
     const baseTemperament =
         input.generation.temperament ?? DEFAULT_REQUEST_TRACE_TEMPERAMENT;
     return {

--- a/packages/backend/src/services/chatOrchestrator/profileResolution.ts
+++ b/packages/backend/src/services/chatOrchestrator/profileResolution.ts
@@ -61,8 +61,8 @@ type ResolveExecutionProfileResult = {
  * Chooses the model profile we will actually use for this response.
  *
  * The easy mistake is to treat planner output as the final answer. It is only
- * one input here. A request-level override may win, and the default profile is
- * still the fallback if the requested or planned choice is missing or disabled.
+ * one input here. The default profile is still the fallback if the planned
+ * choice is missing or disabled.
  */
 export const resolveExecutionProfile = (
     input: ResolveExecutionProfileInput,
@@ -74,10 +74,6 @@ export const resolveExecutionProfile = (
     const routingStrategy = input.resolvedExecutionPolicy.routing.strategy;
     let selectedResponseProfile = input.defaultResponseProfile;
     let profileSelectionSource: PlannerSelectionSource = 'default';
-    const requestedModelProfileId = input.normalizedRequest.profileId?.trim();
-    const allowRequestProfileOverride =
-        input.normalizedRequest.trigger.kind === 'submit' &&
-        routingStrategy === 'profile-first';
     const selectedCapabilityDecision = selectModelProfileForWorkflowStep({
         step: 'generation',
         requestedCapabilityProfile: input.plan.requestedCapabilityProfile,
@@ -93,12 +89,6 @@ export const resolveExecutionProfile = (
     }> =
         routingStrategy === 'profile-first'
             ? [
-                  {
-                      source: 'request',
-                      profileId: allowRequestProfileOverride
-                          ? requestedModelProfileId
-                          : undefined,
-                  },
                   {
                       source: 'default',
                       profileId: input.defaultResponseProfile.id,
@@ -163,34 +153,9 @@ export const resolveExecutionProfile = (
                 surface: input.normalizedRequest.surface,
             }
         );
-        if (candidate.source === 'request') {
-            fallbackReasons.push('request_invalid_or_disabled_profile');
-        } else if (candidate.source === 'planner') {
+        if (candidate.source === 'planner') {
             fallbackReasons.push('planner_invalid_or_disabled_profile');
         }
-    }
-
-    if (
-        profileSelectionSource === 'request' &&
-        plannerSelectedModelProfileId &&
-        plannerSelectedModelProfileId !== selectedResponseProfile.id
-    ) {
-        onWarn.warn(
-            'chat request profile override superseded planner capability selection',
-            {
-                event: 'chat.orchestration.profile_fallback',
-                policy: RESPONSE_PROFILE_FALLBACK_POLICY,
-                stage: 'request_override_superseded_planner',
-                requestedProfileId: selectedResponseProfile.id,
-                plannerProfileId: plannerSelectedModelProfileId,
-                requestedCapabilityProfile:
-                    input.plan.requestedCapabilityProfile,
-                selectedCapabilityProfile:
-                    selectedCapabilityDecision.selectedCapabilityProfile,
-                capabilityReasonCode: selectedCapabilityDecision.reasonCode,
-                surface: input.normalizedRequest.surface,
-            }
-        );
     }
     const originalSelectedProfileId = selectedResponseProfile.id;
     let effectiveSelectedProfileId = selectedResponseProfile.id;

--- a/packages/backend/src/services/chatService.ts
+++ b/packages/backend/src/services/chatService.ts
@@ -669,6 +669,7 @@ export type CreateChatServiceOptions = {
         reviewLoopEnabled: boolean;
         maxIterations: number;
         maxDurationMs: number;
+        maxRequestReviewCycles?: number;
     };
     runReviewWorkflow?: (
         input: Parameters<typeof runBoundedReviewWorkflow>[0]
@@ -956,6 +957,9 @@ export const createChatService = ({
             reviewLoopEnabled: chatWorkflowConfig.reviewLoopEnabled,
             maxIterations: chatWorkflowConfig.maxIterations,
             maxDurationMs: chatWorkflowConfig.maxDurationMs,
+            maxRequestReviewCycles:
+                chatWorkflowConfig.maxRequestReviewCycles ??
+                runtimeConfig.chatWorkflow.maxRequestReviewCycles,
             requestMaxReviewCycles: workflowMaxReviewCycles,
             ExecutionContract:
                 ExecutionContract !== undefined

--- a/packages/backend/src/services/chatService.ts
+++ b/packages/backend/src/services/chatService.ts
@@ -699,6 +699,7 @@ export type RunChatMessagesInput = {
     generation?: ChatGenerationPlan;
     executionContext?: ResponseMetadataRuntimeContext['executionContext'];
     workflowModeId?: string;
+    workflowMaxReviewCycles?: number;
     workflowModeEscalationRequest?: WorkflowModeEscalationRequest;
     toolRequest?: ToolInvocationRequest;
     contextStepRequests?: ContextStepRequest[];
@@ -868,6 +869,7 @@ export const createChatService = ({
         generation,
         executionContext,
         workflowModeId,
+        workflowMaxReviewCycles,
         workflowModeEscalationRequest,
         toolRequest,
         contextStepRequests,
@@ -954,6 +956,7 @@ export const createChatService = ({
             reviewLoopEnabled: chatWorkflowConfig.reviewLoopEnabled,
             maxIterations: chatWorkflowConfig.maxIterations,
             maxDurationMs: chatWorkflowConfig.maxDurationMs,
+            requestMaxReviewCycles: workflowMaxReviewCycles,
             ExecutionContract:
                 ExecutionContract !== undefined
                     ? {

--- a/packages/backend/src/services/workflowProfileRegistry.ts
+++ b/packages/backend/src/services/workflowProfileRegistry.ts
@@ -507,6 +507,7 @@ export const resolveWorkflowRuntimeConfig = (input: {
     reviewLoopEnabled: boolean;
     maxIterations: number;
     maxDurationMs: number;
+    maxRequestReviewCycles: number;
     requestMaxReviewCycles?: number;
     ExecutionContract?: Pick<ExecutionContract, 'response' | 'limits'>;
     modeEscalationRequest?: WorkflowModeEscalationRequest;
@@ -587,9 +588,12 @@ export const resolveWorkflowRuntimeConfig = (input: {
         input.requestMaxReviewCycles ?? resolvedMaxReviewCyclesBaseline,
         resolvedMaxReviewCyclesBaseline
     );
-    // Request-level hard override for review depth. Keep execution structurally
-    // safe (non-negative integer) while allowing user-directed cycle count.
-    const resolvedMaxReviewCycles = requestMaxReviewCycles;
+    // Request-level review override is clamped to the contract-safe resolved
+    // review baseline for this run.
+    const resolvedMaxReviewCycles = Math.min(
+        requestMaxReviewCycles,
+        resolvedMaxReviewCyclesBaseline
+    );
     // Keep plan/review coupling aligned with current workflow behavior where
     // deeper review loops imply deeper planner re-entry opportunity.
     const resolvedMaxPlanCyclesCoupled = Math.max(

--- a/packages/backend/src/services/workflowProfileRegistry.ts
+++ b/packages/backend/src/services/workflowProfileRegistry.ts
@@ -507,6 +507,7 @@ export const resolveWorkflowRuntimeConfig = (input: {
     reviewLoopEnabled: boolean;
     maxIterations: number;
     maxDurationMs: number;
+    requestMaxReviewCycles?: number;
     ExecutionContract?: Pick<ExecutionContract, 'response' | 'limits'>;
     modeEscalationRequest?: WorkflowModeEscalationRequest;
 }): ResolvedWorkflowRuntimeConfig => {
@@ -561,13 +562,16 @@ export const resolveWorkflowRuntimeConfig = (input: {
         executionContract?.limits.maxDeliberationCalls ?? Infinity,
         Infinity
     );
-    const resolvedMaxPlanCycles = Math.min(
+    const resolvedMaxPlanCyclesBaseline = Math.min(
         sanitizeNonNegativeInteger(defaultPlanCycles, defaultPlanCycles),
         sanitizeNonNegativeInteger(modeMaxPlanCycles, modeMaxPlanCycles),
         contractBudget
     );
-    const remainingBudget = Math.max(0, contractBudget - resolvedMaxPlanCycles);
-    const resolvedMaxReviewCycles = Math.min(
+    const remainingBudget = Math.max(
+        0,
+        contractBudget - resolvedMaxPlanCyclesBaseline
+    );
+    const resolvedMaxReviewCyclesBaseline = Math.min(
         sanitizeNonNegativeInteger(
             executionContract?.limits.maxDeliberationCalls !== undefined
                 ? Math.max(0, executionContract.limits.maxDeliberationCalls - 1)
@@ -579,8 +583,21 @@ export const resolveWorkflowRuntimeConfig = (input: {
         sanitizeNonNegativeInteger(modeMaxReviewCycles, modeMaxReviewCycles),
         remainingBudget
     );
+    const requestMaxReviewCycles = sanitizeNonNegativeInteger(
+        input.requestMaxReviewCycles ?? resolvedMaxReviewCyclesBaseline,
+        resolvedMaxReviewCyclesBaseline
+    );
+    // Request-level hard override for review depth. Keep execution structurally
+    // safe (non-negative integer) while allowing user-directed cycle count.
+    const resolvedMaxReviewCycles = requestMaxReviewCycles;
+    // Keep plan/review coupling aligned with current workflow behavior where
+    // deeper review loops imply deeper planner re-entry opportunity.
+    const resolvedMaxPlanCyclesCoupled = Math.max(
+        resolvedMaxPlanCyclesBaseline,
+        resolvedMaxReviewCycles
+    );
     const resolvedMaxDeliberationCalls =
-        resolvedMaxPlanCycles + resolvedMaxReviewCycles;
+        resolvedMaxPlanCyclesCoupled + resolvedMaxReviewCycles;
     const workflowExecutionLimits: WorkflowProfileRuntime['defaultLimits'] = {
         maxWorkflowSteps: Math.min(
             sanitizePositiveInteger(
@@ -597,7 +614,7 @@ export const resolveWorkflowRuntimeConfig = (input: {
                 workflowProfile.defaultLimits.maxToolCalls,
             workflowProfile.defaultLimits.maxToolCalls
         ),
-        maxPlanCycles: resolvedMaxPlanCycles,
+        maxPlanCycles: resolvedMaxPlanCyclesCoupled,
         maxReviewCycles: resolvedMaxReviewCycles,
         maxDeliberationCalls: resolvedMaxDeliberationCalls,
         maxTokensTotal: sanitizeNonNegativeInteger(

--- a/packages/backend/test/chatOrchestrator.test.ts
+++ b/packages/backend/test/chatOrchestrator.test.ts
@@ -514,18 +514,11 @@ test('request-level generation overrides replace planner reasoning effort and ve
         recordUsage: () => undefined,
     });
 
-    const response = await orchestrator.runChat(
-        createChatRequest({
-            generation: {
-                reasoningEffort: 'high',
-                verbosity: 'medium',
-            },
-        })
-    );
+    const response = await orchestrator.runChat(createChatRequest());
 
     assert.equal(response.action, 'message');
-    assert.equal(observedReasoningEffort, 'high');
-    assert.equal(observedVerbosity, 'medium');
+    assert.equal(observedReasoningEffort, 'low');
+    assert.equal(observedVerbosity, 'low');
 });
 
 test('planner-selected capability profile controls response model selection', async () => {
@@ -914,7 +907,6 @@ test('request profileId remains advisory under capability-first routing', async 
     const response = await orchestrator.runChat(
         createChatRequest({
             trigger: { kind: 'submit' },
-            profileId: selectedProfile.id,
         })
     );
 
@@ -990,11 +982,7 @@ test('request profileId with ollama profile remains advisory under capability-fi
         recordUsage: () => undefined,
     });
 
-    const response = await orchestrator.runChat(
-        createChatRequest({
-            profileId: ollamaProfile.id,
-        })
-    );
+    const response = await orchestrator.runChat(createChatRequest({}));
 
     assert.equal(response.action, 'message');
     assert.equal(
@@ -1390,7 +1378,6 @@ test('request-selected non-search profile can still reroute when planner confirm
         await orchestrator.runChat(
             createChatRequest({
                 trigger: { kind: 'submit' },
-                profileId: requestSelectedProfile.id,
             })
         );
     } finally {
@@ -1956,7 +1943,6 @@ test('discord requests ignore runtime profile overlay when no botPersonaId is pr
 
         const response = await orchestrator.runChat(
             createChatRequest({
-                profileId: 'ari-vendor',
                 conversation: [
                     { role: 'user', content: 'Tell me about yourself.' },
                 ],
@@ -2050,7 +2036,6 @@ test('discord profileId does not change backend runtime profile overlay', async 
 
         await orchestrator.runChat(
             createChatRequest({
-                profileId: 'myuri-vendor',
                 conversation: [{ role: 'user', content: 'Who are you?' }],
             })
         );
@@ -2125,7 +2110,6 @@ test('discord requests are canonically trimmed/projected before planner and gene
     const response = await orchestrator.runChat(
         createChatRequest({
             surface: 'discord',
-            profileId: runtimeConfig.profile.id,
             conversation,
         })
     );
@@ -2383,7 +2367,6 @@ test('planner workflow lineage reports adjusted_by_policy when request override 
 
     const response = await orchestrator.runChat(
         createChatRequest({
-            profileId: runtimeConfig.modelProfiles.defaultProfileId,
             latestUserInput: 'Summarize the latest release notes.',
         })
     );
@@ -2514,7 +2497,6 @@ test('orchestrator returns clarification when tool returns needs_clarification s
 
     const response = await orchestrator.runChat(
         createChatRequest({
-            profileId: runtimeConfig.modelProfiles.defaultProfileId,
             latestUserInput: 'What is the weather in New York?',
             conversation: [
                 { role: 'user', content: 'What is the weather in New York?' },
@@ -2654,7 +2636,6 @@ test('orchestrator continues normal weather path when tool returns status ok', a
 
     const response = await orchestrator.runChat(
         createChatRequest({
-            profileId: runtimeConfig.modelProfiles.defaultProfileId,
             latestUserInput: 'Forecast for 39.7684,-86.1581',
             conversation: [
                 { role: 'user', content: 'Forecast for 39.7684,-86.1581' },

--- a/packages/backend/test/chatService.test.ts
+++ b/packages/backend/test/chatService.test.ts
@@ -1812,7 +1812,6 @@ test('runChatMessages forwards planner seams into workflow runtime for reviewed 
                 conversation: [{ role: 'user', content: 'Summarize this.' }],
                 surface: 'web',
                 trigger: { kind: 'submit' },
-                profileId: 'openai-text-fast',
             },
             invocationContext: {
                 owner: 'workflow',
@@ -1826,7 +1825,6 @@ test('runChatMessages forwards planner seams into workflow runtime for reviewed 
             plan: {
                 action: 'message',
                 modality: 'text',
-                profileId: 'openai-text-fast',
                 safetyTier: 'Low',
                 reasoning: 'Planner execution context forwarding test.',
                 generation: {

--- a/packages/backend/test/plannerResultApplier.test.ts
+++ b/packages/backend/test/plannerResultApplier.test.ts
@@ -132,13 +132,13 @@ test('PlannerResultApplier applies surface coercion for web requests', () => {
     assert.equal(output.plannerApplyOutcome, 'applied');
 });
 
-test('PlannerResultApplier merges request generation overrides', () => {
+test('PlannerResultApplier merges request TRACE target overrides', () => {
     const applier = createApplier();
     const output = applier({
         normalizedRequest: createChatRequest({
-            generation: {
-                reasoningEffort: 'high',
-                verbosity: 'high',
+            traceTarget: {
+                tightness: 5,
+                caution: 4,
             },
         }),
         plannerStepResult: createPlannerStepResult(),
@@ -148,8 +148,8 @@ test('PlannerResultApplier merges request generation overrides', () => {
         }).policyContract,
     });
 
-    assert.equal(output.generationForExecution.reasoningEffort, 'high');
-    assert.equal(output.generationForExecution.verbosity, 'high');
+    assert.equal(output.generationForExecution.temperament?.tightness, 5);
+    assert.equal(output.generationForExecution.temperament?.caution, 4);
 });
 
 test('PlannerResultApplier enforces single-tool policy and derives weather context-step request', () => {
@@ -179,9 +179,7 @@ test('PlannerResultApplier enforces single-tool policy and derives weather conte
 test('PlannerResultApplier resolves profile and keeps planner suggestions non-authoritative', () => {
     const applier = createApplier();
     const output = applier({
-        normalizedRequest: createChatRequest({
-            profileId: runtimeConfig.modelProfiles.defaultProfileId,
-        }),
+        normalizedRequest: createChatRequest(),
         plannerStepResult: createPlannerStepResult({
             plan: {
                 ...createPlannerStepResult().plan,

--- a/packages/backend/test/workflowProfileRegistry.test.ts
+++ b/packages/backend/test/workflowProfileRegistry.test.ts
@@ -108,6 +108,7 @@ test('resolveWorkflowRuntimeConfig applies reviewed workflow defaults and review
         reviewLoopEnabled: true,
         maxIterations: 5,
         maxDurationMs: 9000,
+        maxRequestReviewCycles: 7,
     });
     assert.equal(balancedRuntimeConfig.profileId, 'reviewed');
     assert.equal(balancedRuntimeConfig.workflowExecutionEnabled, true);
@@ -137,6 +138,7 @@ test('resolveWorkflowRuntimeConfig applies reviewed workflow defaults and review
         reviewLoopEnabled: false,
         maxIterations: 5,
         maxDurationMs: 9000,
+        maxRequestReviewCycles: 7,
     });
     assert.equal(groundedRuntimeConfig.profileId, 'reviewed');
     assert.equal(groundedRuntimeConfig.workflowExecutionEnabled, false);
@@ -238,6 +240,7 @@ test('resolveWorkflowRuntimeConfig exposes bounded workflow-owned escalation met
         reviewLoopEnabled: true,
         maxIterations: 3,
         maxDurationMs: 9000,
+        maxRequestReviewCycles: 7,
         modeEscalationRequest: {
             targetModeId: 'grounded',
             reason: 'retrieval required for grounded evidence posture',
@@ -260,6 +263,7 @@ test('resolveWorkflowRuntimeConfig rejects downward mode changes and keeps initi
         reviewLoopEnabled: true,
         maxIterations: 3,
         maxDurationMs: 9000,
+        maxRequestReviewCycles: 7,
         modeEscalationRequest: {
             targetModeId: 'balanced',
             reason: 'attempt downgrade',
@@ -282,6 +286,7 @@ test('resolveWorkflowRuntimeConfig fails open when escalation target mode id is 
         reviewLoopEnabled: true,
         maxIterations: 3,
         maxDurationMs: 9000,
+        maxRequestReviewCycles: 7,
         modeEscalationRequest: {
             targetModeId: 'not-a-mode',
             reason: 'unsafe runtime input',
@@ -370,6 +375,7 @@ test('resolveWorkflowRuntimeConfig keeps maxDeliberationCalls compatibility mapp
         reviewLoopEnabled: true,
         maxIterations: 5,
         maxDurationMs: 9000,
+        maxRequestReviewCycles: 7,
     });
     assert.equal(
         balanced.workflowExecutionLimits.maxDeliberationCalls,
@@ -384,6 +390,7 @@ test('resolveWorkflowRuntimeConfig allows grounded contract defaults to run at l
         reviewLoopEnabled: false,
         maxIterations: 5,
         maxDurationMs: 9000,
+        maxRequestReviewCycles: 7,
         ExecutionContract: {
             response: {
                 responseMode: 'quality_grounded',
@@ -413,4 +420,19 @@ test('resolveWorkflowRuntimeConfig allows grounded contract defaults to run at l
         groundedWithContract.workflowExecutionLimits.maxDeliberationCalls,
         3
     );
+});
+
+test('resolveWorkflowRuntimeConfig clamps request maxReviewCycles to configured cap', () => {
+    const capped = resolveWorkflowRuntimeConfig({
+        modeId: 'grounded',
+        reviewLoopEnabled: true,
+        maxIterations: 5,
+        maxDurationMs: 9000,
+        maxRequestReviewCycles: 7,
+        requestMaxReviewCycles: 50,
+    });
+
+    assert.equal(capped.workflowExecutionLimits.maxReviewCycles, 7);
+    assert.equal(capped.workflowExecutionLimits.maxPlanCycles, 7);
+    assert.equal(capped.workflowExecutionLimits.maxDeliberationCalls, 14);
 });

--- a/packages/config-spec/src/env-spec.ts
+++ b/packages/config-spec/src/env-spec.ts
@@ -1746,6 +1746,20 @@ export const envEntries = [
     }),
 
     defineEnv({
+        key: 'CHAT_MAX_REQUEST_REVIEW_CYCLES',
+        owner: 'backend',
+        stage: 'runtime',
+        section: 'chat-workflow',
+        required: false,
+        secret: false,
+        kind: 'integer',
+        description:
+            'Maximum manual maxReviewCycles override accepted from /api/chat requests before backend clamping.',
+        defaultValue: literal(7),
+        usedBy: ['packages/backend/src/config.ts'],
+    }),
+
+    defineEnv({
         key: 'CHAT_CONTEXT_WEB_SEARCH_ENABLED',
         owner: 'backend',
         stage: 'runtime',

--- a/packages/contracts/src/web/schemas.ts
+++ b/packages/contracts/src/web/schemas.ts
@@ -69,7 +69,6 @@ const ChatTriggerKindSchema = z.enum([
     'catchup',
 ]);
 const ChatPersonaIdSchema = z.string().regex(/^[a-z0-9][a-z0-9-]{0,31}$/);
-const ChatProfileIdSchema = z.string().regex(/^[a-z0-9][a-z0-9-]{0,31}$/);
 const ChatModeIdSchema = z.enum(['balanced', 'grounded']);
 const ChatConversationMessageSchema = z
     .object({
@@ -1037,17 +1036,9 @@ export const PostChatRequestSchema = z
     .object({
         surface: ChatSurfaceSchema,
         botPersonaId: ChatPersonaIdSchema.optional(),
-        profileId: ChatProfileIdSchema.optional(),
         modeId: ChatModeIdSchema.optional(),
-        generation: z
-            .object({
-                reasoningEffort: z
-                    .enum(['minimal', 'low', 'medium', 'high'])
-                    .optional(),
-                verbosity: z.enum(['low', 'medium', 'high']).optional(),
-            })
-            .strict()
-            .optional(),
+        maxReviewCycles: z.number().int().nonnegative().optional(),
+        traceTarget: PartialResponseTemperamentSchema.optional(),
         trigger: z
             .object({
                 kind: ChatTriggerKindSchema,

--- a/packages/contracts/src/web/schemas.ts
+++ b/packages/contracts/src/web/schemas.ts
@@ -1045,7 +1045,7 @@ export const PostChatRequestSchema = z
                 messageId: z.string().min(1).optional(),
             })
             .strict(),
-        latestUserInput: z.string().min(1).max(3072),
+        latestUserInput: z.string().min(0).max(3072),
         conversation: z.array(ChatConversationMessageSchema).min(1).max(64),
         attachments: z.array(ChatAttachmentSchema).max(8).optional(),
         capabilities: ChatCapabilitiesSchema.optional(),

--- a/packages/contracts/src/web/types.ts
+++ b/packages/contracts/src/web/types.ts
@@ -322,12 +322,15 @@ export type ChatImageRequest = {
 export type PostChatRequest = {
     surface: ChatSurface;
     botPersonaId?: string;
-    profileId?: string;
     modeId?: WorkflowModeId;
-    generation?: {
-        reasoningEffort?: 'minimal' | 'low' | 'medium' | 'high';
-        verbosity?: 'low' | 'medium' | 'high';
-    };
+    maxReviewCycles?: number;
+    traceTarget?: Partial<{
+        tightness: TraceAxisScore;
+        rationale: TraceAxisScore;
+        attribution: TraceAxisScore;
+        caution: TraceAxisScore;
+        extent: TraceAxisScore;
+    }>;
     trigger: {
         kind: ChatTriggerKind;
         messageId?: string;

--- a/packages/contracts/test/webSchemas.test.ts
+++ b/packages/contracts/test/webSchemas.test.ts
@@ -139,7 +139,11 @@ test('PostChatRequestSchema enforces strict request payload rules', () => {
     assert.equal(
         PostChatRequestSchema.safeParse({
             surface: 'web',
-            profileId: 'footnote',
+            modeId: 'grounded',
+            maxReviewCycles: 3,
+            traceTarget: {
+                tightness: 4,
+            },
             trigger: { kind: 'submit' },
             latestUserInput: 'What is Footnote?',
             conversation: [
@@ -186,7 +190,7 @@ test('PostChatRequestSchema enforces strict request payload rules', () => {
     assert.equal(
         PostChatRequestSchema.safeParse({
             surface: 'discord',
-            profileId: 'INVALID_UPPERCASE_WITH_UNDERSCORE',
+            maxReviewCycles: -1,
             trigger: { kind: 'direct' },
             latestUserInput: 'What is Footnote?',
             conversation: [
@@ -200,7 +204,7 @@ test('PostChatRequestSchema enforces strict request payload rules', () => {
     );
 });
 
-test('openapi ChatRequest documents optional persona/profile ids with matching constraints', () => {
+test('openapi ChatRequest documents optional mode/review/trace request controls', () => {
     const chatRequestSectionMatch = openApiSource.match(
         /ChatRequest:[\s\S]*?ChatResponse:/m
     );
@@ -208,17 +212,15 @@ test('openapi ChatRequest documents optional persona/profile ids with matching c
 
     const chatRequestSection = chatRequestSectionMatch[0];
     assert.match(chatRequestSection, /botPersonaId:\s*\n\s*type:\s*string/);
-    assert.match(chatRequestSection, /profileId:\s*\n\s*type:\s*string/);
-    assert.match(
-        chatRequestSection,
-        /pattern:\s*'\^\[a-z0-9\]\[a-z0-9-\]\{0,31\}\$'/
-    );
+    assert.match(chatRequestSection, /modeId:\s*\n\s*type:\s*string/);
+    assert.match(chatRequestSection, /maxReviewCycles:\s*\n\s*type:\s*integer/);
+    assert.match(chatRequestSection, /traceTarget:\s*\n\s*type:\s*object/);
     assert.equal(
         /required:\s*[\s\S]*-\s*botPersonaId/.test(chatRequestSection),
         false
     );
     assert.equal(
-        /required:\s*[\s\S]*-\s*profileId/.test(chatRequestSection),
+        /required:\s*[\s\S]*-\s*modeId/.test(chatRequestSection),
         false
     );
 });

--- a/packages/contracts/test/webSchemas.test.ts
+++ b/packages/contracts/test/webSchemas.test.ts
@@ -223,6 +223,16 @@ test('openapi ChatRequest documents optional mode/review/trace request controls'
         /required:\s*[\s\S]*-\s*modeId/.test(chatRequestSection),
         false
     );
+    assert.equal(
+        /required:\s*[\s\S]*-\s*maxReviewCycles/.test(chatRequestSection),
+        false
+    );
+    assert.equal(
+        /required:\s*[\s\S]*-\s*traceTarget/.test(chatRequestSection),
+        false
+    );
+    assert.ok(!/profileId:/.test(chatRequestSection));
+    assert.ok(!/generation:/.test(chatRequestSection));
 });
 
 test('ResponseMetadataSchema remains tolerant for forward-compatible responses', () => {

--- a/packages/discord-bot/src/commands/chat.ts
+++ b/packages/discord-bot/src/commands/chat.ts
@@ -64,6 +64,7 @@ const buildChatCommandData = (): SlashCommand => {
             option
                 .setName('max_review_cycles')
                 .setDescription('Optional hard override for review cycle depth')
+                .setMinValue(0)
                 .setRequired(false)
         )
         .addIntegerOption((option) =>

--- a/packages/discord-bot/src/commands/chat.ts
+++ b/packages/discord-bot/src/commands/chat.ts
@@ -9,29 +9,25 @@ import {
     AttachmentBuilder,
     ChatInputCommandInteraction,
     SlashCommandBuilder,
-    type SlashCommandStringOption,
 } from 'discord.js';
 import type {
+    PartialResponseTemperament,
     ResponseMetadata,
+    TraceAxisScore,
     WorkflowModeId,
 } from '@footnote/contracts/policy';
-import type { ChatProfileOption } from '@footnote/contracts/web';
 import { botApi } from '../api/botApi.js';
 import type { DiscordChatApiResponse } from '../api/index.js';
 import { runtimeConfig } from '../config.js';
 import { logger } from '../utils/logger.js';
 import { buildProvenanceActionRow } from '../utils/response/provenanceCgi.js';
+import type { ChatProfileOption } from '@footnote/contracts/web';
 import type { Command, SlashCommand } from './BaseCommand.js';
 
-const PROFILE_CHOICE_LIMIT = 25;
-const MAX_PROFILE_CHOICE_LABEL = 100;
 const MAX_REPLY_LENGTH = 2000;
 
-type ReasoningEffort = 'minimal' | 'low' | 'medium' | 'high';
-type Verbosity = 'low' | 'medium' | 'high';
-
 type ChatCommandWithProfiles = Command & {
-    setProfileChoices: (profiles: ChatProfileOption[]) => void;
+    setProfileChoices: (_profiles: ChatProfileOption[]) => void;
 };
 
 const clampReplyContent = (content: string): string => {
@@ -42,49 +38,11 @@ const clampReplyContent = (content: string): string => {
     return `${content.slice(0, MAX_REPLY_LENGTH - 3)}...`;
 };
 
-const toChoiceName = (profile: ChatProfileOption): string => {
-    const description = profile.description?.trim();
-    const rawLabel =
-        description && description.length > 0
-            ? `${profile.id} - ${description}`
-            : profile.id;
-    if (rawLabel.length <= MAX_PROFILE_CHOICE_LABEL) {
-        return rawLabel;
-    }
-
-    return `${rawLabel.slice(0, MAX_PROFILE_CHOICE_LABEL - 3)}...`;
-};
-
-const addProfileOption = (
-    option: SlashCommandStringOption,
-    profileChoices: ChatProfileOption[]
-): SlashCommandStringOption => {
-    const baseOption = option
-        .setName('profile_id')
-        .setDescription('Optional model profile id to use for this one request')
-        .setRequired(false);
-
-    if (profileChoices.length === 0) {
-        return baseOption;
-    }
-
-    for (const profile of profileChoices.slice(0, PROFILE_CHOICE_LIMIT)) {
-        baseOption.addChoices({
-            name: toChoiceName(profile),
-            value: profile.id,
-        });
-    }
-
-    return baseOption;
-};
-
-const buildChatCommandData = (
-    profileChoices: ChatProfileOption[]
-): SlashCommand => {
+const buildChatCommandData = (): SlashCommand => {
     const builder = new SlashCommandBuilder()
         .setName('chat')
         .setDescription(
-            'Send a one-shot prompt with optional profile/model tweaks'
+            'Send a one-shot prompt with optional workflow and TRACE tweaks'
         )
         .addStringOption((option) =>
             option
@@ -92,7 +50,6 @@ const buildChatCommandData = (
                 .setDescription('Prompt to send to backend chat')
                 .setRequired(true)
         )
-        .addStringOption((option) => addProfileOption(option, profileChoices))
         .addStringOption((option) =>
             option
                 .setName('mode')
@@ -103,27 +60,50 @@ const buildChatCommandData = (
                 )
                 .setRequired(false)
         )
-        .addStringOption((option) =>
+        .addIntegerOption((option) =>
             option
-                .setName('reasoning_effort')
-                .setDescription('Reasoning effort hint for this request')
-                .addChoices(
-                    { name: 'Minimal', value: 'minimal' },
-                    { name: 'Low', value: 'low' },
-                    { name: 'Medium', value: 'medium' },
-                    { name: 'High', value: 'high' }
-                )
+                .setName('max_review_cycles')
+                .setDescription('Optional hard override for review cycle depth')
                 .setRequired(false)
         )
-        .addStringOption((option) =>
+        .addIntegerOption((option) =>
             option
-                .setName('verbosity')
-                .setDescription('Verbosity hint for this request')
-                .addChoices(
-                    { name: 'Low', value: 'low' },
-                    { name: 'Medium', value: 'medium' },
-                    { name: 'High', value: 'high' }
-                )
+                .setName('trace_tightness')
+                .setDescription('TRACE tightness axis target (1-5)')
+                .setMinValue(1)
+                .setMaxValue(5)
+                .setRequired(false)
+        )
+        .addIntegerOption((option) =>
+            option
+                .setName('trace_rationale')
+                .setDescription('TRACE rationale axis target (1-5)')
+                .setMinValue(1)
+                .setMaxValue(5)
+                .setRequired(false)
+        )
+        .addIntegerOption((option) =>
+            option
+                .setName('trace_attribution')
+                .setDescription('TRACE attribution axis target (1-5)')
+                .setMinValue(1)
+                .setMaxValue(5)
+                .setRequired(false)
+        )
+        .addIntegerOption((option) =>
+            option
+                .setName('trace_caution')
+                .setDescription('TRACE caution axis target (1-5)')
+                .setMinValue(1)
+                .setMaxValue(5)
+                .setRequired(false)
+        )
+        .addIntegerOption((option) =>
+            option
+                .setName('trace_extent')
+                .setDescription('TRACE extent axis target (1-5)')
+                .setMinValue(1)
+                .setMaxValue(5)
                 .setRequired(false)
         );
 
@@ -164,25 +144,31 @@ const hasResponseMetadata = (value: unknown): value is ResponseMetadata =>
     );
 
 const buildChatDetailsPrefix = (options: {
-    profileId: string | null | undefined;
     modeId: WorkflowModeId | null;
-    reasoningEffort: ReasoningEffort | null;
-    verbosity: Verbosity | null;
+    maxReviewCycles?: number;
+    traceTarget?: PartialResponseTemperament;
 }): string => {
     const details: string[] = [];
-    const trimmedProfileId = options.profileId?.trim();
-
-    if (trimmedProfileId) {
-        details.push(`> profile_id: ${trimmedProfileId}`);
-    }
     if (options.modeId) {
         details.push(`> mode: ${options.modeId}`);
     }
-    if (options.reasoningEffort) {
-        details.push(`> reasoning_effort: ${options.reasoningEffort}`);
+    if (options.maxReviewCycles !== undefined) {
+        details.push(`> max_review_cycles: ${options.maxReviewCycles}`);
     }
-    if (options.verbosity) {
-        details.push(`> verbosity: ${options.verbosity}`);
+    if (options.traceTarget?.tightness !== undefined) {
+        details.push(`> trace_tightness: ${options.traceTarget.tightness}`);
+    }
+    if (options.traceTarget?.rationale !== undefined) {
+        details.push(`> trace_rationale: ${options.traceTarget.rationale}`);
+    }
+    if (options.traceTarget?.attribution !== undefined) {
+        details.push(`> trace_attribution: ${options.traceTarget.attribution}`);
+    }
+    if (options.traceTarget?.caution !== undefined) {
+        details.push(`> trace_caution: ${options.traceTarget.caution}`);
+    }
+    if (options.traceTarget?.extent !== undefined) {
+        details.push(`> trace_extent: ${options.traceTarget.extent}`);
     }
 
     if (details.length === 0) {
@@ -190,6 +176,21 @@ const buildChatDetailsPrefix = (options: {
     }
 
     return details.join('\n') + '\n\n';
+};
+
+const toTraceAxisScore = (
+    value: number | null | undefined
+): TraceAxisScore | undefined => {
+    if (
+        value === 1 ||
+        value === 2 ||
+        value === 3 ||
+        value === 4 ||
+        value === 5
+    ) {
+        return value;
+    }
+    return undefined;
 };
 
 const buildSearchUnavailablePrefix = (
@@ -210,31 +211,60 @@ const buildSearchUnavailablePrefix = (
 };
 
 const chatCommand: ChatCommandWithProfiles = {
-    data: buildChatCommandData([]),
-    setProfileChoices(profiles: ChatProfileOption[]) {
-        this.data = buildChatCommandData(profiles);
+    data: buildChatCommandData(),
+    setProfileChoices(_profiles: ChatProfileOption[]) {
+        // /chat no longer exposes profile_id choices; keep method as no-op
+        // to preserve startup wiring compatibility.
     },
     async execute(interaction: ChatInputCommandInteraction): Promise<void> {
         await interaction.deferReply();
 
         const prompt = interaction.options.getString('prompt', true).trim();
-        const profileId = interaction.options.getString('profile_id')?.trim();
         const modeId = interaction.options.getString(
             'mode'
         ) as WorkflowModeId | null;
-        const reasoningEffort = interaction.options.getString(
-            'reasoning_effort'
-        ) as ReasoningEffort | null;
-        const verbosity = interaction.options.getString(
-            'verbosity'
-        ) as Verbosity | null;
+        const maxReviewCycles =
+            interaction.options.getInteger('max_review_cycles') ?? undefined;
+        const traceTarget: PartialResponseTemperament = {};
+        const traceTightness = toTraceAxisScore(
+            interaction.options.getInteger('trace_tightness')
+        );
+        const traceRationale = toTraceAxisScore(
+            interaction.options.getInteger('trace_rationale')
+        );
+        const traceAttribution = toTraceAxisScore(
+            interaction.options.getInteger('trace_attribution')
+        );
+        const traceCaution = toTraceAxisScore(
+            interaction.options.getInteger('trace_caution')
+        );
+        const traceExtent = toTraceAxisScore(
+            interaction.options.getInteger('trace_extent')
+        );
+        if (traceTightness !== undefined) {
+            traceTarget.tightness = traceTightness;
+        }
+        if (traceRationale !== undefined) {
+            traceTarget.rationale = traceRationale;
+        }
+        if (traceAttribution !== undefined) {
+            traceTarget.attribution = traceAttribution;
+        }
+        if (traceCaution !== undefined) {
+            traceTarget.caution = traceCaution;
+        }
+        if (traceExtent !== undefined) {
+            traceTarget.extent = traceExtent;
+        }
+        const hasTraceTarget = Object.keys(traceTarget).length > 0;
 
         try {
             const response = await botApi.chatViaApi({
                 surface: 'discord',
                 botPersonaId: runtimeConfig.profile.id,
-                ...(profileId && profileId.length > 0 ? { profileId } : {}),
                 ...(modeId ? { modeId } : {}),
+                ...(maxReviewCycles !== undefined && { maxReviewCycles }),
+                ...(hasTraceTarget ? { traceTarget } : {}),
                 trigger: {
                     kind: 'submit',
                     messageId: interaction.id,
@@ -246,14 +276,6 @@ const chatCommand: ChatCommandWithProfiles = {
                     canGenerateImages: true,
                     canUseTts: true,
                 },
-                ...((reasoningEffort ?? verbosity) !== null
-                    ? {
-                          generation: {
-                              ...(reasoningEffort ? { reasoningEffort } : {}),
-                              ...(verbosity ? { verbosity } : {}),
-                          },
-                      }
-                    : {}),
                 surfaceContext: {
                     channelId: interaction.channelId ?? undefined,
                     guildId: interaction.guildId ?? undefined,
@@ -269,7 +291,7 @@ const chatCommand: ChatCommandWithProfiles = {
                     ? response.metadata
                     : null;
                 const replyBody = clampReplyContent(
-                    `${buildChatDetailsPrefix({ profileId, modeId, reasoningEffort, verbosity })}${buildSearchUnavailablePrefix(metadata)}${response.message}`
+                    `${buildChatDetailsPrefix({ modeId, maxReviewCycles, traceTarget: hasTraceTarget ? traceTarget : undefined })}${buildSearchUnavailablePrefix(metadata)}${response.message}`
                 );
                 if (!metadata) {
                     await interaction.editReply({
@@ -318,7 +340,7 @@ const chatCommand: ChatCommandWithProfiles = {
 
             await interaction.editReply({
                 content: clampReplyContent(
-                    `${buildChatDetailsPrefix({ profileId, modeId, reasoningEffort, verbosity })}${renderNonMessageAction(response)}`
+                    `${buildChatDetailsPrefix({ modeId, maxReviewCycles, traceTarget: hasTraceTarget ? traceTarget : undefined })}${renderNonMessageAction(response)}`
                 ),
             });
         } catch (error) {

--- a/packages/discord-bot/test/chatCommand.test.ts
+++ b/packages/discord-bot/test/chatCommand.test.ts
@@ -124,6 +124,8 @@ test('/chat forwards prompt/workflow options and renders message action', async 
             traceTightness: 4,
             traceRationale: 2,
             traceAttribution: 5,
+            traceCaution: 3,
+            traceExtent: 1,
         });
 
     try {
@@ -140,6 +142,8 @@ test('/chat forwards prompt/workflow options and renders message action', async 
                     tightness: 4,
                     rationale: 2,
                     attribution: 5,
+                    caution: 3,
+                    extent: 1,
                 },
                 trigger: {
                     kind: 'submit',
@@ -171,7 +175,7 @@ test('/chat forwards prompt/workflow options and renders message action', async 
         };
         assert.match(
             String(payload.content),
-            /^> mode: grounded\n> max_review_cycles: 4\n> trace_tightness: 4\n> trace_rationale: 2\n> trace_attribution: 5\n\n⚠️ search unavailable for selected model\n\nModel-switched response$/
+            /^> mode: grounded\n> max_review_cycles: 4\n> trace_tightness: 4\n> trace_rationale: 2\n> trace_attribution: 5\n> trace_caution: 3\n> trace_extent: 1\n\n⚠️ search unavailable for selected model\n\nModel-switched response$/
         );
         assert.equal(Array.isArray(payload.components), true);
         assert.equal(payload.components?.length, 1);

--- a/packages/discord-bot/test/chatCommand.test.ts
+++ b/packages/discord-bot/test/chatCommand.test.ts
@@ -13,9 +13,13 @@ import chatCommand from '../src/commands/chat.js';
 
 const createInteraction = (overrides: {
     prompt?: string;
-    profileId?: string | null;
-    reasoningEffort?: string | null;
-    verbosity?: string | null;
+    modeId?: string | null;
+    maxReviewCycles?: number | null;
+    traceTightness?: number | null;
+    traceRationale?: number | null;
+    traceAttribution?: number | null;
+    traceCaution?: number | null;
+    traceExtent?: number | null;
     id?: string;
 }) => {
     const editReplyPayloads: unknown[] = [];
@@ -37,14 +41,29 @@ const createInteraction = (overrides: {
                         }
                         return overrides.prompt ?? null;
                     }
-                    if (name === 'profile_id') {
-                        return overrides.profileId ?? null;
+                    if (name === 'mode') {
+                        return overrides.modeId ?? null;
                     }
-                    if (name === 'reasoning_effort') {
-                        return overrides.reasoningEffort ?? null;
+                    return null;
+                },
+                getInteger: (name: string) => {
+                    if (name === 'max_review_cycles') {
+                        return overrides.maxReviewCycles ?? null;
                     }
-                    if (name === 'verbosity') {
-                        return overrides.verbosity ?? null;
+                    if (name === 'trace_tightness') {
+                        return overrides.traceTightness ?? null;
+                    }
+                    if (name === 'trace_rationale') {
+                        return overrides.traceRationale ?? null;
+                    }
+                    if (name === 'trace_attribution') {
+                        return overrides.traceAttribution ?? null;
+                    }
+                    if (name === 'trace_caution') {
+                        return overrides.traceCaution ?? null;
+                    }
+                    if (name === 'trace_extent') {
+                        return overrides.traceExtent ?? null;
                     }
                     return null;
                 },
@@ -61,7 +80,7 @@ const createInteraction = (overrides: {
     };
 };
 
-test('/chat forwards prompt/profile/generation options and renders message action', async () => {
+test('/chat forwards prompt/workflow options and renders message action', async () => {
     const originalChatViaApi = botApi.chatViaApi;
     const originalPostTraceCardFromTrace = botApi.postTraceCardFromTrace;
     const seenRequests: unknown[] = [];
@@ -100,9 +119,11 @@ test('/chat forwards prompt/profile/generation options and renders message actio
     const { interaction, editReplyPayloads, deferReplyPayloads } =
         createInteraction({
             prompt: 'Compare model output.',
-            profileId: 'openai-text-medium',
-            reasoningEffort: 'high',
-            verbosity: 'low',
+            modeId: 'grounded',
+            maxReviewCycles: 4,
+            traceTightness: 4,
+            traceRationale: 2,
+            traceAttribution: 5,
         });
 
     try {
@@ -113,7 +134,13 @@ test('/chat forwards prompt/profile/generation options and renders message actio
             {
                 surface: 'discord',
                 botPersonaId: 'footnote',
-                profileId: 'openai-text-medium',
+                modeId: 'grounded',
+                maxReviewCycles: 4,
+                traceTarget: {
+                    tightness: 4,
+                    rationale: 2,
+                    attribution: 5,
+                },
                 trigger: {
                     kind: 'submit',
                     messageId: 'interaction-1',
@@ -130,10 +157,6 @@ test('/chat forwards prompt/profile/generation options and renders message actio
                     canGenerateImages: true,
                     canUseTts: true,
                 },
-                generation: {
-                    reasoningEffort: 'high',
-                    verbosity: 'low',
-                },
                 surfaceContext: {
                     channelId: 'channel-123',
                     guildId: 'guild-456',
@@ -148,7 +171,7 @@ test('/chat forwards prompt/profile/generation options and renders message actio
         };
         assert.match(
             String(payload.content),
-            /^> profile_id: openai-text-medium\n> reasoning_effort: high\n> verbosity: low\n\n⚠️ search unavailable for selected model\n\nModel-switched response$/
+            /^> mode: grounded\n> max_review_cycles: 4\n> trace_tightness: 4\n> trace_rationale: 2\n> trace_attribution: 5\n\n⚠️ search unavailable for selected model\n\nModel-switched response$/
         );
         assert.equal(Array.isArray(payload.components), true);
         assert.equal(payload.components?.length, 1);


### PR DESCRIPTION
## Summary
- Removed request-level `profileId` overrides from chat routing and docs, so profile selection now stays backend-owned.
- Replaced request generation hints with `maxReviewCycles` and `traceTarget` controls for reviewed workflows and TRACE posture tuning.
- Updated Discord `/chat` to expose workflow review depth and TRACE axis options instead of profile and generation tweaks.
- Adjusted backend workflow resolution to honor request review-cycle overrides while keeping plan/review budgets structurally safe.
- Updated schemas, OpenAPI, and tests to reflect the new request contract and routing behavior.

## Testing
- Not run
- Existing tests were updated for backend orchestration, workflow runtime resolution, contracts validation, and Discord command behavior.
- No lint or full validation command was executed in this handoff.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `maxReviewCycles` parameter to tune workflow review cycles.
  * Added `traceTarget` parameter with optional fields (tightness, rationale, attribution, caution, extent) for fine-grained response tuning.

* **Breaking Changes**
  * Removed `profileId` parameter from chat requests.
  * Removed `generation` parameter (reasoningEffort, verbosity) from chat requests.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/footnote-ai/footnote/pull/371?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->