### PR TITLE
Centralize TRACE temperament contract in prompts

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -12,6 +12,7 @@ For first-time local setup, start at the root [Quickstart](../README.md#quicksta
   and reading order.
 - [Decisions](./decisions/): durable technical choices and why they were made.
 - [Proposals](./proposals/): unadopted or exploratory ideas.
+- [Status](./status/): branch-level implementation tracking documents.
 - [API](./api/README.md): OpenAPI source, operation mapping, and code-linking
   rules.
 - [AI](./ai/README.md): contributor workflow for AI-assisted changes.

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -14,11 +14,13 @@ detail once you have the main runtime shape in mind.
 2. [Answer Posture And Control Influence](./answer-posture-and-control-influence.md):
    use this when you need the metadata map for mode, TRACE, planner influence,
    control influence, and provenance.
-3. [Prompt Resolution Order](./prompt-resolution.md): how prompt layers and
+3. [TRACE Temperament Contract](./trace-temperament-contract.md): canonical
+   TRACE defaults, level matrix semantics, and compact rubric rules.
+4. [Prompt Resolution Order](./prompt-resolution.md): how prompt layers and
    overrides resolve at runtime.
-4. [Bounded User Control Mapping](./bounded-user-control-mapping.md): what
+5. [Bounded User Control Mapping](./bounded-user-control-mapping.md): what
    users can steer directly and what stays backend-owned.
-5. [Context Integrations](./context-integrations/README.md): shared rules for
+6. [Context Integrations](./context-integrations/README.md): shared rules for
    external systems that can add context without taking execution authority.
 
 ## Context Integrations

--- a/docs/architecture/answer-posture-and-control-influence.md
+++ b/docs/architecture/answer-posture-and-control-influence.md
@@ -74,9 +74,10 @@ implement a full TRACE lifecycle or history model. TRACE revision context is
 captured in workflow lineage signals (for example assess alignment outputs and
 planner trace-revision signals), not a separate top-level metadata field.
 
-TRACE target/final equality checks are now normalized through shared contracts
+TRACE target/final equality checks are normalized through shared contracts
 helpers keyed by canonical TRACE axis order, so schema and backend runtime use
-the same comparison semantics.
+the same comparison semantics. See
+[TRACE Temperament Contract](./trace-temperament-contract.md).
 
 ## TRACE boundaries
 

--- a/docs/architecture/trace-temperament-contract.md
+++ b/docs/architecture/trace-temperament-contract.md
@@ -1,0 +1,38 @@
+# TRACE Temperament Contract
+
+This TRACE temperament contract defines defaults, level meanings, and a
+compact matrix for LLM inference.
+
+## Purpose
+
+TRACE is answer-posture metadata which explains how an answer is expressed.
+
+It is designed to, at a glance, indicate the intended output style via a spread
+of distinct axes:
+
+- `(T)ightness` (how succinct)
+- `(R)ationale` (how well reasoned)
+- `(A)ttribution` (how well sourced)
+- `(C)aution` (how careful)
+- `(E)xtent` (how diverse of thought)
+
+Each axis range between `1..5`, with a default posture of `3`.
+
+## System-Context Constraints
+
+This contract is intended to live in always-on system context across workflows.
+
+- Keep wording persistent and stable so prompt-caching can reuse it reliably.
+- Keep wording token-conscious: compact, high-signal phrases over long prose.
+
+## Level Matrix
+
+The table below defines level semantics for TRACE axes.
+
+| Level | Tightness                                                                                        | Rationale                                                                                | Attribution                                                                                               | Caution                                                                                    | Extent                                                                                   |
+| ----- | ------------------------------------------------------------------------------------------------ | ---------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------ | ---------------------------------------------------------------------------------------- |
+| `1`   | expansive and loose; no compression pressure; best for exploratory or reflective exchanges       | conclusion-heavy; minimal supporting why; best for lightweight conversational flow       | boundary signaling mostly absent; minimal source-vs-inference marking; best when claims are low-stakes    | assertive stance; limited uncertainty signaling; best for low-risk direct replies          | single framing/path; no deliberate alternatives; best for straightforward asks           |
+| `2`   | somewhat concise, still broad; mild compression; good for casual conversation with some depth    | some supporting why; limited trade-off detail; good when brief reasoning is enough       | occasional boundary signaling; partial source-vs-inference clarity; good for mixed casual/factual replies | partial uncertainty calibration; some caveats where helpful; good for moderate-risk topics | primary path plus minor alternative; light breadth; good for simple choice contexts      |
+| `3`   | balanced clarity and brevity; moderate compression; default for most requests                    | key why and key trade-offs when useful; default reasoning posture                        | clear boundary signaling on material claims; default source-vs-inference clarity                          | calibrated certainty by default; caution where uncertainty matters                         | one to two viable framings; default breadth for most decisions                           |
+| `4`   | compact and well-structured; strong compression; good for task-focused or implementation asks    | explicit reasoning and trade-off handling; high signal-to-noise for technical decisions  | consistent source-vs-inference boundaries; strong clarity for factual/derived claims                      | conservative on uncertain or sensitive claims; explicit restraint against overclaiming     | multiple viable framings with contrast; good when user must choose between paths         |
+| `5`   | maximally compact without losing intent; highest compression; best for direct transactional asks | dense explicit reasoning with assumptions surfaced; best for high-accountability outputs | strict boundary signaling plus uncertainty boundaries; best when provenance clarity is critical           | strongest restraint against overclaiming; maximal calibration and safeguards               | broad option framing with explicit comparison; best for high-stakes trade-off evaluation |

--- a/docs/status/feat-trace-temperament-contract.md
+++ b/docs/status/feat-trace-temperament-contract.md
@@ -1,0 +1,38 @@
+# Branch Status: feat/trace-temperament-contract
+
+Last updated: 2026-05-17
+
+## Goal
+
+Define and centralize TRACE temperament semantics so default posture and level
+meanings are clear, compact, and prompt-ready.
+
+## Minimum Scope (Current)
+
+- canonical TRACE default anchor is `3`
+- level matrix for `1..5` across all TRACE axes
+- YAML-first prompt-configuration shape for low-token always-on guidance
+
+## Progress
+
+- [x] Branch created and checked out
+- [x] Standalone architecture contract doc drafted
+- [x] Architecture reading guide linked to contract
+- [x] TRACE posture architecture doc linked to contract
+- [x] Prompt YAML source added/updated
+- [x] Prompt assembly wiring updated to use matrix source
+- [x] Backend normalization/default helper alignment reviewed
+- [x] Tests added for defaulting and matrix-driven behavior
+
+## Settled Decisions
+
+- Keep planner fallback behavior as-is: missing temperament stays missing on
+  fallback.
+- Keep first shipped matrix global-only (no surface/profile variants).
+- Enforce exact v1 parity by rendering planner TRACE rubric from one YAML source.
+
+## Notes
+
+- Keep this status doc lightweight. It tracks branch reality, not long-term
+  architecture.
+- Update when scope changes or implementation starts landing.

--- a/packages/backend/test/plannerResultApplier.test.ts
+++ b/packages/backend/test/plannerResultApplier.test.ts
@@ -150,6 +150,9 @@ test('PlannerResultApplier merges request TRACE target overrides', () => {
 
     assert.equal(output.generationForExecution.temperament?.tightness, 5);
     assert.equal(output.generationForExecution.temperament?.caution, 4);
+    assert.equal(output.generationForExecution.temperament?.rationale, 3);
+    assert.equal(output.generationForExecution.temperament?.attribution, 3);
+    assert.equal(output.generationForExecution.temperament?.extent, 3);
 });
 
 test('PlannerResultApplier enforces single-tool policy and derives weather context-step request', () => {

--- a/packages/prompts/src/defaults.yaml
+++ b/packages/prompts/src/defaults.yaml
@@ -1,3 +1,38 @@
+traceTemperamentContract:
+    defaultAnchor: 3
+    axes: [tightness, rationale, attribution, caution, extent]
+    levels:
+        '1':
+            tightness: expansive and loose; no compression pressure; best for exploratory or reflective exchanges
+            rationale: conclusion-heavy; minimal supporting why; best for lightweight conversational flow
+            attribution: boundary signaling mostly absent; minimal source-vs-inference marking; best when claims are low-stakes
+            caution: assertive stance; limited uncertainty signaling; best for low-risk direct replies
+            extent: single framing/path; no deliberate alternatives; best for straightforward asks
+        '2':
+            tightness: somewhat concise, still broad; mild compression; good for casual conversation with some depth
+            rationale: some supporting why; limited trade-off detail; good when brief reasoning is enough
+            attribution: occasional boundary signaling; partial source-vs-inference clarity; good for mixed casual/factual replies
+            caution: partial uncertainty calibration; some caveats where helpful; good for moderate-risk topics
+            extent: primary path plus minor alternative; light breadth; good for simple choice contexts
+        '3':
+            tightness: balanced clarity and brevity; moderate compression; default for most requests
+            rationale: key why and key trade-offs when useful; default reasoning posture
+            attribution: clear boundary signaling on material claims; default source-vs-inference clarity
+            caution: calibrated certainty by default; caution where uncertainty matters
+            extent: one to two viable framings; default breadth for most decisions
+        '4':
+            tightness: compact and well-structured; strong compression; good for task-focused or implementation asks
+            rationale: explicit reasoning and trade-off handling; high signal-to-noise for technical decisions
+            attribution: consistent source-vs-inference boundaries; strong clarity for factual/derived claims
+            caution: conservative on uncertain or sensitive claims; explicit restraint against overclaiming
+            extent: multiple viable framings with contrast; good when user must choose between paths
+        '5':
+            tightness: maximally compact without losing intent; highest compression; best for direct transactional asks
+            rationale: dense explicit reasoning with assumptions surfaced; best for high-accountability outputs
+            attribution: strict boundary signaling plus uncertainty boundaries; best when provenance clarity is critical
+            caution: strongest restraint against overclaiming; maximal calibration and safeguards
+            extent: broad option framing with explicit comparison; best for high-stakes trade-off evaluation
+
 conversation:
     shared:
         system:
@@ -282,11 +317,8 @@ chat:
                   - generation.temperament is required for message responses and must include all five TRACE axes.
                   - Every TRACE axis must be an integer from 1 to 5.
                   - TRACE scoring rubric for message responses:
-                    tightness: 1 = verbose/loosely structured; 5 = compact, well-structured.
-                    rationale: 1 = conclusions only; 5 = key reasoning + trade-offs shown.
-                    attribution: 1 = sources vs inference not marked; 5 = boundaries explicitly marked.
-                    caution: 1 = assertive without support; 5 = calibrated uncertainty + appropriate safeguards.
-                    extent: 1 = single framing/path; 5 = multiple viable options/perspectives.
+                    default posture anchor: {{trace_temperament_default_anchor}}
+                    {{trace_temperament_rubric}}
                   - Select each axis score deliberately from the rubric before finalizing the plan; never leave an axis undecided.
                   - Choose the rubric score intentionally per axis; do not default to identical values unless truly warranted.
                   - TRACE values must be concrete integers (1,2,3,4,5), not ranges, decimals, or placeholders.

--- a/packages/prompts/src/promptRegistry.ts
+++ b/packages/prompts/src/promptRegistry.ts
@@ -273,8 +273,8 @@ class SharedPromptRegistry implements PromptRegistry {
     ): RenderedPrompt {
         const definition = this.getPrompt(key);
         const content = interpolateTemplate(definition.template, {
-            ...this.globalTemplateVariables,
             ...variables,
+            ...this.globalTemplateVariables,
         });
         return {
             content,
@@ -352,6 +352,16 @@ const parseTraceTemperamentContract = (
     context: PromptValidationContext
 ): TraceTemperamentContract | undefined => {
     if (value === undefined) {
+        if (context.mode === 'strict') {
+            reportPromptValidationIssue(
+                context,
+                'Missing required trace temperament contract entry.',
+                {
+                    promptKey: 'traceTemperamentContract',
+                    reason: 'traceTemperamentContract is required in strict mode',
+                }
+            );
+        }
         return undefined;
     }
 

--- a/packages/prompts/src/promptRegistry.ts
+++ b/packages/prompts/src/promptRegistry.ts
@@ -19,6 +19,9 @@ import type {
     PromptRegistry,
     PromptVariables,
     RenderedPrompt,
+    TraceTemperamentAxisKey,
+    TraceTemperamentContract,
+    TraceTemperamentLevel,
 } from './types.js';
 import { promptKeys } from './types.js';
 
@@ -26,6 +29,23 @@ const currentDirectory = path.dirname(fileURLToPath(import.meta.url));
 const knownPromptKeys = new Set<PromptKey>(promptKeys);
 
 type PromptMap = Partial<Record<PromptKey, PromptDefinition>>;
+const TRACE_TEMPERAMENT_LEVELS: readonly TraceTemperamentLevel[] = [
+    '1',
+    '2',
+    '3',
+    '4',
+    '5',
+] as const;
+const TRACE_TEMPERAMENT_AXES: readonly TraceTemperamentAxisKey[] = [
+    'tightness',
+    'rationale',
+    'attribution',
+    'caution',
+    'extent',
+] as const;
+const TRACE_TEMPERAMENT_RUBRIC_TEMPLATE_VARIABLE = 'trace_temperament_rubric';
+const TRACE_TEMPERAMENT_DEFAULT_TEMPLATE_VARIABLE =
+    'trace_temperament_default_anchor';
 /**
  * Validation mode used while loading prompt catalogs.
  * - strict: throw on invalid prompt node shape (used for canonical defaults)
@@ -154,17 +174,23 @@ const reportPromptValidationIssue = (
 
 class SharedPromptRegistry implements PromptRegistry {
     private readonly prompts: PromptMap;
+    private readonly globalTemplateVariables: PromptVariables;
 
     constructor(options: CreatePromptRegistryOptions = {}) {
         // Shared prompt resolution order:
         // 1) bundled defaults
         // 2) optional PROMPT_CONFIG_PATH-style overrides (full key replacement)
-        const defaults = loadPromptFile(resolveBundledDefaultsPath(), {
-            optional: false,
-            mode: 'strict',
-            logger: options.logger,
-        });
-        let merged = defaults;
+        const defaultsLoadResult = loadPromptFile(
+            resolveBundledDefaultsPath(),
+            {
+                optional: false,
+                mode: 'strict',
+                logger: options.logger,
+            }
+        );
+        let merged = defaultsLoadResult.prompts;
+        let traceTemperamentContract =
+            defaultsLoadResult.traceTemperamentContract;
 
         if (options.overridePath) {
             const resolvedOverridePath = resolveAbsolutePath(
@@ -178,15 +204,33 @@ class SharedPromptRegistry implements PromptRegistry {
                     }
                 );
                 this.prompts = merged;
+                this.globalTemplateVariables =
+                    traceTemperamentContract === undefined
+                        ? {}
+                        : {
+                              [TRACE_TEMPERAMENT_DEFAULT_TEMPLATE_VARIABLE]:
+                                  traceTemperamentContract.defaultAnchor,
+                              [TRACE_TEMPERAMENT_RUBRIC_TEMPLATE_VARIABLE]:
+                                  renderTraceTemperamentRubric(
+                                      traceTemperamentContract
+                                  ),
+                          };
                 return;
             }
             try {
-                const overrideData = loadPromptFile(resolvedOverridePath, {
-                    optional: true,
-                    mode: 'warn-and-skip',
-                    logger: options.logger,
-                });
-                merged = mergePromptCatalog(merged, overrideData);
+                const overrideLoadResult = loadPromptFile(
+                    resolvedOverridePath,
+                    {
+                        optional: true,
+                        mode: 'warn-and-skip',
+                        logger: options.logger,
+                    }
+                );
+                merged = mergePromptCatalog(merged, overrideLoadResult.prompts);
+                if (overrideLoadResult.traceTemperamentContract) {
+                    traceTemperamentContract =
+                        overrideLoadResult.traceTemperamentContract;
+                }
             } catch (error) {
                 options.logger?.warn?.(
                     'Ignoring prompt override file due to load failure.',
@@ -202,6 +246,17 @@ class SharedPromptRegistry implements PromptRegistry {
         }
 
         this.prompts = merged;
+        this.globalTemplateVariables =
+            traceTemperamentContract === undefined
+                ? {}
+                : {
+                      [TRACE_TEMPERAMENT_DEFAULT_TEMPLATE_VARIABLE]:
+                          traceTemperamentContract.defaultAnchor,
+                      [TRACE_TEMPERAMENT_RUBRIC_TEMPLATE_VARIABLE]:
+                          renderTraceTemperamentRubric(
+                              traceTemperamentContract
+                          ),
+                  };
     }
 
     public getPrompt(key: PromptKey): PromptDefinition {
@@ -217,7 +272,10 @@ class SharedPromptRegistry implements PromptRegistry {
         variables: PromptVariables = {}
     ): RenderedPrompt {
         const definition = this.getPrompt(key);
-        const content = interpolateTemplate(definition.template, variables);
+        const content = interpolateTemplate(definition.template, {
+            ...this.globalTemplateVariables,
+            ...variables,
+        });
         return {
             content,
             description: definition.description,
@@ -248,14 +306,17 @@ const loadPromptFile = (
         mode: PromptValidationMode;
         logger?: CreatePromptRegistryOptions['logger'];
     }
-): PromptMap => {
+): {
+    prompts: PromptMap;
+    traceTemperamentContract?: TraceTemperamentContract;
+} => {
     const resolvedPath = path.isAbsolute(filePath)
         ? filePath
         : path.resolve(filePath);
 
     if (!fs.existsSync(resolvedPath)) {
         if (options.optional) {
-            return {};
+            return { prompts: {} };
         }
         throw new Error(`Prompt configuration file not found: ${resolvedPath}`);
     }
@@ -268,12 +329,146 @@ const loadPromptFile = (
         );
     }
 
-    return flattenPromptTree(parsed as Record<string, unknown>, {
-        sourcePath: resolvedPath,
-        mode: options.mode,
-        logger: options.logger,
-    });
+    const parsedRoot = parsed as Record<string, unknown>;
+    return {
+        prompts: flattenPromptTree(parsedRoot, {
+            sourcePath: resolvedPath,
+            mode: options.mode,
+            logger: options.logger,
+        }),
+        traceTemperamentContract: parseTraceTemperamentContract(
+            parsedRoot.traceTemperamentContract,
+            {
+                sourcePath: resolvedPath,
+                mode: options.mode,
+                logger: options.logger,
+            }
+        ),
+    };
 };
+
+const parseTraceTemperamentContract = (
+    value: unknown,
+    context: PromptValidationContext
+): TraceTemperamentContract | undefined => {
+    if (value === undefined) {
+        return undefined;
+    }
+
+    if (!value || typeof value !== 'object' || Array.isArray(value)) {
+        reportPromptValidationIssue(
+            context,
+            'Ignoring invalid trace temperament contract entry.',
+            {
+                promptKey: 'traceTemperamentContract',
+                reason: 'traceTemperamentContract must be an object',
+            }
+        );
+        return undefined;
+    }
+
+    const candidate = value as Record<string, unknown>;
+    if (candidate.defaultAnchor !== 3) {
+        reportPromptValidationIssue(
+            context,
+            'Ignoring invalid trace temperament contract entry.',
+            {
+                promptKey: 'traceTemperamentContract.defaultAnchor',
+                reason: 'defaultAnchor must be 3',
+            }
+        );
+        return undefined;
+    }
+
+    const axesRaw = candidate.axes;
+    if (
+        !Array.isArray(axesRaw) ||
+        axesRaw.length !== TRACE_TEMPERAMENT_AXES.length ||
+        !TRACE_TEMPERAMENT_AXES.every((axis, index) => axesRaw[index] === axis)
+    ) {
+        reportPromptValidationIssue(
+            context,
+            'Ignoring invalid trace temperament contract entry.',
+            {
+                promptKey: 'traceTemperamentContract.axes',
+                reason: 'axes must be [tightness, rationale, attribution, caution, extent] in canonical order',
+            }
+        );
+        return undefined;
+    }
+
+    const levelsRaw = candidate.levels;
+    if (
+        !levelsRaw ||
+        typeof levelsRaw !== 'object' ||
+        Array.isArray(levelsRaw)
+    ) {
+        reportPromptValidationIssue(
+            context,
+            'Ignoring invalid trace temperament contract entry.',
+            {
+                promptKey: 'traceTemperamentContract.levels',
+                reason: 'levels must be an object',
+            }
+        );
+        return undefined;
+    }
+
+    const levelsCandidate = levelsRaw as Record<string, unknown>;
+    const levels = {} as TraceTemperamentContract['levels'];
+    for (const level of TRACE_TEMPERAMENT_LEVELS) {
+        const levelRaw = levelsCandidate[level];
+        if (
+            !levelRaw ||
+            typeof levelRaw !== 'object' ||
+            Array.isArray(levelRaw)
+        ) {
+            reportPromptValidationIssue(
+                context,
+                'Ignoring invalid trace temperament contract entry.',
+                {
+                    promptKey: `traceTemperamentContract.levels.${level}`,
+                    reason: 'each level must be an object',
+                }
+            );
+            return undefined;
+        }
+        const levelCandidate = levelRaw as Record<string, unknown>;
+        const axisMap = {} as Record<TraceTemperamentAxisKey, string>;
+        for (const axis of TRACE_TEMPERAMENT_AXES) {
+            const axisText = levelCandidate[axis];
+            if (typeof axisText !== 'string' || axisText.trim().length === 0) {
+                reportPromptValidationIssue(
+                    context,
+                    'Ignoring invalid trace temperament contract entry.',
+                    {
+                        promptKey: `traceTemperamentContract.levels.${level}.${axis}`,
+                        reason: 'axis text must be a non-empty string',
+                    }
+                );
+                return undefined;
+            }
+            axisMap[axis] = axisText.trim();
+        }
+        levels[level] = axisMap;
+    }
+
+    return {
+        defaultAnchor: 3,
+        axes: [...TRACE_TEMPERAMENT_AXES],
+        levels,
+    };
+};
+
+const renderTraceTemperamentRubric = (
+    contract: TraceTemperamentContract
+): string =>
+    TRACE_TEMPERAMENT_LEVELS.map((level) => {
+        const levelAxes = contract.levels[level];
+        return TRACE_TEMPERAMENT_AXES.map(
+            (axis) => `${axis} ${level}: ${levelAxes[axis]}`
+        ).join('\n');
+    }).join('\n');
 
 /**
  * Walks nested YAML prompt trees and extracts valid prompt definitions.

--- a/packages/prompts/src/types.ts
+++ b/packages/prompts/src/types.ts
@@ -53,6 +53,24 @@ export interface PromptDefinition extends PromptMetadata {
     template: string;
 }
 
+export type TraceTemperamentAxisKey =
+    | 'tightness'
+    | 'rationale'
+    | 'attribution'
+    | 'caution'
+    | 'extent';
+
+export type TraceTemperamentLevel = '1' | '2' | '3' | '4' | '5';
+
+export type TraceTemperamentContract = {
+    defaultAnchor: 3;
+    axes: TraceTemperamentAxisKey[];
+    levels: Record<
+        TraceTemperamentLevel,
+        Record<TraceTemperamentAxisKey, string>
+    >;
+};
+
 export interface PromptCatalog {
     prompts: Record<PromptKey, PromptDefinition>;
 }

--- a/packages/prompts/test/promptRegistry.test.ts
+++ b/packages/prompts/test/promptRegistry.test.ts
@@ -12,6 +12,7 @@ import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
+import yaml from 'js-yaml';
 
 import { createPromptRegistry } from '../src/index.js';
 
@@ -249,4 +250,67 @@ test('legacy backend and discord default prompt files are gone', () => {
 
     assert.equal(fs.existsSync(legacyBackendDefaultsPath), false);
     assert.equal(fs.existsSync(legacyDiscordDefaultsPath), false);
+});
+
+test('chat planner TRACE rubric is rendered from traceTemperamentContract defaults', () => {
+    const registry = createPromptRegistry();
+    const renderedPlannerPrompt = registry.renderPrompt(
+        'chat.planner.system'
+    ).content;
+
+    assert.match(renderedPlannerPrompt, /default posture anchor: 3/);
+    assert.match(
+        renderedPlannerPrompt,
+        /tightness 1: expansive and loose; no compression pressure; best for exploratory or reflective exchanges/
+    );
+    assert.match(
+        renderedPlannerPrompt,
+        /extent 5: broad option framing with explicit comparison; best for high-stakes trade-off evaluation/
+    );
+    const tightness1Index = renderedPlannerPrompt.indexOf('tightness 1:');
+    const extent1Index = renderedPlannerPrompt.indexOf('extent 1:');
+    const tightness2Index = renderedPlannerPrompt.indexOf('tightness 2:');
+    assert.ok(tightness1Index > -1);
+    assert.ok(extent1Index > tightness1Index);
+    assert.ok(tightness2Index > extent1Index);
+});
+
+test('traceTemperamentContract defaults include canonical anchor axes and levels', () => {
+    const defaultsPath = path.resolve(
+        testDirectory,
+        '..',
+        'src',
+        'defaults.yaml'
+    );
+    const parsed = yaml.load(fs.readFileSync(defaultsPath, 'utf8')) as Record<
+        string,
+        unknown
+    >;
+    const contract = parsed.traceTemperamentContract as
+        | {
+              defaultAnchor?: number;
+              axes?: unknown[];
+              levels?: Record<string, Record<string, unknown>>;
+          }
+        | undefined;
+
+    assert.ok(contract);
+    assert.equal(contract?.defaultAnchor, 3);
+    assert.deepEqual(contract?.axes, [
+        'tightness',
+        'rationale',
+        'attribution',
+        'caution',
+        'extent',
+    ]);
+    for (const level of ['1', '2', '3', '4', '5'] as const) {
+        const levelMap: Record<string, unknown> | undefined =
+            contract?.levels?.[level];
+        assert.ok(levelMap);
+        assert.equal(typeof levelMap?.tightness, 'string');
+        assert.equal(typeof levelMap?.rationale, 'string');
+        assert.equal(typeof levelMap?.attribution, 'string');
+        assert.equal(typeof levelMap?.caution, 'string');
+        assert.equal(typeof levelMap?.extent, 'string');
+    }
 });

--- a/packages/prompts/test/promptRegistry.test.ts
+++ b/packages/prompts/test/promptRegistry.test.ts
@@ -276,6 +276,9 @@ test('chat planner TRACE rubric is rendered from traceTemperamentContract defaul
 });
 
 test('traceTemperamentContract defaults include canonical anchor axes and levels', () => {
+    // Dual strategy: this test parses defaults.yaml directly to validate source
+    // data integrity (anchor, axes, levels), while the planner-render test
+    // verifies runtime consumption/rendering through PromptRegistry.
     const defaultsPath = path.resolve(
         testDirectory,
         '..',


### PR DESCRIPTION
## Summary
- Centralize TRACE temperament defaults and level semantics in `packages/prompts/src/defaults.yaml`.
- Render the planner TRACE rubric from the shared contract so prompt text and runtime defaults stay aligned.
- Add validation and tests for the TRACE contract shape, default anchor, and rendered rubric output.
- Update architecture docs and branch status docs to point at the new TRACE temperament contract.

## Testing
- Added `packages/prompts/test/promptRegistry.test.ts` coverage for contract rendering and canonical defaults.
- Added `packages/backend/test/plannerResultApplier.test.ts` assertions for missing TRACE axes falling back to the shared default posture.
- Not run: `pnpm lint:fix`.
- Not run: `pnpm lint`.
- Not run: `pnpm review`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced TRACE Temperament Contract defining answer-posture metadata with five calibration axes (Tightness, Rationale, Attribution, Caution, Extent), each with a 1–5 scale and default posture of 3. Enables configurable system behavior through YAML-based temperament levels.

* **Documentation**
  * Added comprehensive documentation for TRACE Temperament Contract and its integration.
  * Updated architecture reference materials with new TRACE semantics links.

* **Tests**
  * Added test coverage for temperament contract defaults and rubric rendering behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/footnote-ai/footnote/pull/372?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->