### PR TITLE
Refactor chat review loop into phase helpers

### DIFF
--- a/packages/backend/src/services/chatService.ts
+++ b/packages/backend/src/services/chatService.ts
@@ -926,404 +926,418 @@ export const createChatService = ({
                 finalToolExecutionTelemetry,
             };
         };
-        const generationStartedAt = Date.now();
-        const normalizedGeneration = normalizeGenerationPlan(generation);
-        // Repo-explainer mode appends one helper system hint so responses stay
-        // aligned with Footnote repository-explanation expectations.
-        const repoExplainerHint = normalizedGeneration
-            ? buildRepoExplainerResponseHint(normalizedGeneration)
-            : null;
-        const messagesWithHints: RuntimeMessage[] = repoExplainerHint
-            ? [
-                  ...messages,
-                  {
-                      role: 'system',
-                      content: repoExplainerHint,
-                  },
-              ]
-            : messages;
-        const generationRequest: GenerationRequest = {
-            messages: messagesWithHints,
-            model: model ?? defaultModel,
-            ...((provider ?? defaultProvider) !== undefined && {
-                provider: provider ?? defaultProvider,
-            }),
-            ...((capabilities ?? defaultCapabilities) !== undefined && {
-                capabilities: capabilities ?? defaultCapabilities,
-            }),
-            ...(normalizedGeneration?.reasoningEffort !== undefined && {
-                reasoningEffort: normalizedGeneration.reasoningEffort,
-            }),
-            ...(normalizedGeneration?.verbosity !== undefined && {
-                verbosity: normalizedGeneration.verbosity,
-            }),
-            ...(normalizedGeneration?.search !== undefined && {
-                search: normalizedGeneration.search,
-            }),
-        };
-        let effectiveMessagesWithHints = messagesWithHints;
-        let effectiveGenerationRequest = generationRequest;
-        let effectiveNormalizedGeneration = normalizedGeneration;
-        let effectivePlannerTemperament = plannerTemperament;
-        // Execution Contract governs allowed policy shape. Runtime resolution
-        // here applies initial mode routing, then profile shape selection,
-        // and composes workflow execution settings within that contract.
-        const workflowRuntimeConfig = resolveWorkflowRuntimeConfig({
-            modeId: workflowModeId ?? chatWorkflowConfig.modeId,
-            reviewLoopEnabled: chatWorkflowConfig.reviewLoopEnabled,
-            maxIterations: chatWorkflowConfig.maxIterations,
-            maxDurationMs: chatWorkflowConfig.maxDurationMs,
-            maxRequestReviewCycles:
-                chatWorkflowConfig.maxRequestReviewCycles ??
-                runtimeConfig.chatWorkflow.maxRequestReviewCycles,
-            requestMaxReviewCycles: workflowMaxReviewCycles,
-            ExecutionContract:
-                ExecutionContract !== undefined
-                    ? {
-                          response: ExecutionContract.response,
-                          limits: ExecutionContract.limits,
-                      }
-                    : undefined,
-            modeEscalationRequest: workflowModeEscalationRequest,
-        });
-        const workflowProfile = workflowRuntimeConfig.runtimeProfile;
-        const workflowExecutionEnabled =
-            workflowRuntimeConfig.workflowExecutionEnabled;
-        const workflowExecutionLimits =
-            workflowRuntimeConfig.workflowExecutionLimits;
-        const enabledProfiles = runtimeConfig.modelProfiles.catalog.filter(
-            (profile) => profile.enabled
-        );
-        const enabledProfilesById = new Map<string, ModelProfile>(
-            enabledProfiles.map((profile) => [profile.id, profile])
-        );
-        const allProfilesById = new Map<string, ModelProfile>(
-            runtimeConfig.modelProfiles.catalog.map((profile) => [
-                profile.id,
-                profile,
-            ])
-        );
-        const routingCorrelationId =
-            routingRequest?.trigger.messageId ?? 'none';
-        const routingBaseRequest = {
-            sessionId: routingRequest?.sessionId,
-            traceTarget: routingRequest?.traceTarget,
-        };
-        const generateProfileCandidates = resolveStepRoutingChain(
-            {
-                modeId: workflowRuntimeConfig.modeDecision.modeId,
-                step: 'generate',
-                request: routingBaseRequest,
-                correlationId: routingCorrelationId,
-                stepOverrideProfileId: routingRequest?.generateProfileId,
-            },
-            enabledProfilesById,
-            allProfilesById
-        );
-        const assessProfileCandidates = resolveStepRoutingChain(
-            {
-                modeId: workflowRuntimeConfig.modeDecision.modeId,
-                step: 'assess',
-                request: routingBaseRequest,
-                correlationId: routingCorrelationId,
-                stepOverrideProfileId: routingRequest?.assessProfileId,
-            },
-            enabledProfilesById,
-            allProfilesById
-        );
-        const runGenerateWithChain = async (
-            request: GenerationRequest
-        ): Promise<{
-            generationResult: GenerationResult;
-            selectedProfile: ModelProfile;
-            attempts: Array<{
-                index: number;
-                step: string;
-                profileId: string;
-                provider?: string;
-                model?: string;
-                status: string;
-                reasonCode?: string;
-                errorMessage?: string;
-                chooseOneUsed: boolean;
-                chooseOneCandidates?: string[];
-                chooseOneSelectedIndex?: number;
-                seedKeyType?: 'session_id' | 'correlation_id';
-            }>;
-        }> => {
-            const chainResult = await executeStepRoutingChain({
-                step: 'generate',
-                candidates: generateProfileCandidates,
-                enabledProfilesById,
-                requiresSearch: request.search !== undefined,
-                runWithProfile: async (profile) =>
-                    generationRuntime.generate({
-                        ...request,
-                        model: profile.providerModel,
-                        provider: profile.provider,
-                        capabilities: profile.capabilities,
-                    }),
+        const initializeChatExecutionPhases = () => {
+            const generationStartedAt = Date.now();
+            const normalizedGeneration = normalizeGenerationPlan(generation);
+            // Repo-explainer mode appends one helper system hint so responses stay
+            // aligned with Footnote repository-explanation expectations.
+            const repoExplainerHint = normalizedGeneration
+                ? buildRepoExplainerResponseHint(normalizedGeneration)
+                : null;
+            const messagesWithHints: RuntimeMessage[] = repoExplainerHint
+                ? [
+                      ...messages,
+                      {
+                          role: 'system',
+                          content: repoExplainerHint,
+                      },
+                  ]
+                : messages;
+            const generationRequest: GenerationRequest = {
+                messages: messagesWithHints,
+                model: model ?? defaultModel,
+                ...((provider ?? defaultProvider) !== undefined && {
+                    provider: provider ?? defaultProvider,
+                }),
+                ...((capabilities ?? defaultCapabilities) !== undefined && {
+                    capabilities: capabilities ?? defaultCapabilities,
+                }),
+                ...(normalizedGeneration?.reasoningEffort !== undefined && {
+                    reasoningEffort: normalizedGeneration.reasoningEffort,
+                }),
+                ...(normalizedGeneration?.verbosity !== undefined && {
+                    verbosity: normalizedGeneration.verbosity,
+                }),
+                ...(normalizedGeneration?.search !== undefined && {
+                    search: normalizedGeneration.search,
+                }),
+            };
+            // Execution Contract governs allowed policy shape. Runtime resolution
+            // here applies initial mode routing, then profile shape selection,
+            // and composes workflow execution settings within that contract.
+            const workflowRuntimeConfig = resolveWorkflowRuntimeConfig({
+                modeId: workflowModeId ?? chatWorkflowConfig.modeId,
+                reviewLoopEnabled: chatWorkflowConfig.reviewLoopEnabled,
+                maxIterations: chatWorkflowConfig.maxIterations,
+                maxDurationMs: chatWorkflowConfig.maxDurationMs,
+                maxRequestReviewCycles:
+                    chatWorkflowConfig.maxRequestReviewCycles ??
+                    runtimeConfig.chatWorkflow.maxRequestReviewCycles,
+                requestMaxReviewCycles: workflowMaxReviewCycles,
+                ExecutionContract:
+                    ExecutionContract !== undefined
+                        ? {
+                              response: ExecutionContract.response,
+                              limits: ExecutionContract.limits,
+                          }
+                        : undefined,
+                modeEscalationRequest: workflowModeEscalationRequest,
             });
-            if (chainResult.status !== 'executed') {
-                throw new Error(chainResult.reasonCode);
-            }
+            const enabledProfiles = runtimeConfig.modelProfiles.catalog.filter(
+                (profile) => profile.enabled
+            );
+            const enabledProfilesById = new Map<string, ModelProfile>(
+                enabledProfiles.map((profile) => [profile.id, profile])
+            );
+            const allProfilesById = new Map<string, ModelProfile>(
+                runtimeConfig.modelProfiles.catalog.map((profile) => [
+                    profile.id,
+                    profile,
+                ])
+            );
+            const routingCorrelationId =
+                routingRequest?.trigger.messageId ?? 'none';
+            const routingBaseRequest = {
+                sessionId: routingRequest?.sessionId,
+                traceTarget: routingRequest?.traceTarget,
+            };
+            const generateProfileCandidates = resolveStepRoutingChain(
+                {
+                    modeId: workflowRuntimeConfig.modeDecision.modeId,
+                    step: 'generate',
+                    request: routingBaseRequest,
+                    correlationId: routingCorrelationId,
+                    stepOverrideProfileId: routingRequest?.generateProfileId,
+                },
+                enabledProfilesById,
+                allProfilesById
+            );
+            const assessProfileCandidates = resolveStepRoutingChain(
+                {
+                    modeId: workflowRuntimeConfig.modeDecision.modeId,
+                    step: 'assess',
+                    request: routingBaseRequest,
+                    correlationId: routingCorrelationId,
+                    stepOverrideProfileId: routingRequest?.assessProfileId,
+                },
+                enabledProfilesById,
+                allProfilesById
+            );
+            const runGenerateWithChain = async (
+                request: GenerationRequest
+            ): Promise<{
+                generationResult: GenerationResult;
+                selectedProfile: ModelProfile;
+                attempts: Array<{
+                    index: number;
+                    step: string;
+                    profileId: string;
+                    provider?: string;
+                    model?: string;
+                    status: string;
+                    reasonCode?: string;
+                    errorMessage?: string;
+                    chooseOneUsed: boolean;
+                    chooseOneCandidates?: string[];
+                    chooseOneSelectedIndex?: number;
+                    seedKeyType?: 'session_id' | 'correlation_id';
+                }>;
+            }> => {
+                const chainResult = await executeStepRoutingChain({
+                    step: 'generate',
+                    candidates: generateProfileCandidates,
+                    enabledProfilesById,
+                    requiresSearch: request.search !== undefined,
+                    runWithProfile: async (profile) =>
+                        generationRuntime.generate({
+                            ...request,
+                            model: profile.providerModel,
+                            provider: profile.provider,
+                            capabilities: profile.capabilities,
+                        }),
+                });
+                if (chainResult.status !== 'executed') {
+                    throw new Error(chainResult.reasonCode);
+                }
+                return {
+                    generationResult: chainResult.value,
+                    selectedProfile: chainResult.selected.profile,
+                    attempts: chainResult.attempts,
+                };
+            };
+
             return {
-                generationResult: chainResult.value,
-                selectedProfile: chainResult.selected.profile,
-                attempts: chainResult.attempts,
+                generationStartedAt,
+                workflowRuntimeConfig,
+                workflowProfile: workflowRuntimeConfig.runtimeProfile,
+                workflowExecutionEnabled:
+                    workflowRuntimeConfig.workflowExecutionEnabled,
+                workflowExecutionLimits:
+                    workflowRuntimeConfig.workflowExecutionLimits,
+                enabledProfilesById,
+                generateProfileCandidates,
+                assessProfileCandidates,
+                runGenerateWithChain,
+                initialMessagesWithHints: messagesWithHints,
+                initialGenerationRequest: generationRequest,
+                initialNormalizedGeneration: normalizedGeneration,
+                initialPlannerTemperament: plannerTemperament,
             };
         };
+        const executionPhases = initializeChatExecutionPhases();
+        const generationStartedAt = executionPhases.generationStartedAt;
+        const workflowProfile = executionPhases.workflowProfile;
+        const workflowExecutionEnabled =
+            executionPhases.workflowExecutionEnabled;
+        const workflowExecutionLimits = executionPhases.workflowExecutionLimits;
+        const enabledProfilesById = executionPhases.enabledProfilesById;
+        const generateProfileCandidates =
+            executionPhases.generateProfileCandidates;
+        const assessProfileCandidates = executionPhases.assessProfileCandidates;
+        const runGenerateWithChain = executionPhases.runGenerateWithChain;
+        let effectiveMessagesWithHints =
+            executionPhases.initialMessagesWithHints;
+        let effectiveGenerationRequest =
+            executionPhases.initialGenerationRequest;
+        let effectiveNormalizedGeneration =
+            executionPhases.initialNormalizedGeneration;
+        let effectivePlannerTemperament =
+            executionPhases.initialPlannerTemperament;
 
-        let generationResult: GenerationResult;
-        let routedGenerationSelectedProfile: ModelProfile | undefined;
-        let workflowLineage: WorkflowRecord | undefined;
-        let workflowContextStepResult: ContextStepResult | undefined;
-        let workflowContextStepResults: ContextStepResult[] | undefined;
-        let workflowPlannerSummary: AppliedPlanState | undefined;
-        let workflowPlannerStepResult: PlannerStepResult | undefined;
-        let workflowConversationSnapshot: string | undefined;
-        let fallbackAfterInternalNoGeneration = false;
-        const effectivePlannerStepRequest = plannerStepRequest;
-        const effectivePlannerStepExecutor = plannerStepExecutor;
-        if (workflowExecutionEnabled) {
-            const workflowPolicy: WorkflowRunPolicy = workflowProfile.policy;
-            const sanitizedReviewModuleIds = sanitizeReviewModuleIds(
-                workflowProfile.optionalExtensions?.reviewModuleIds
-            );
-            const trustGraphContextStepRequest =
-                buildTrustGraphContextStepRequest(
-                    executionContractTrustGraph,
-                    executionContractTrustGraphContext
+        const executeGenerationPhase = async (): Promise<
+            | {
+                  kind: 'result';
+                  result: RunChatMessagesResult;
+              }
+            | {
+                  kind: 'continue';
+                  generationResult: GenerationResult;
+                  routedGenerationSelectedProfile?: ModelProfile;
+                  workflowLineage?: WorkflowRecord;
+                  workflowContextStepResult?: ContextStepResult;
+                  workflowContextStepResults?: ContextStepResult[];
+                  workflowPlannerSummary?: AppliedPlanState;
+                  workflowPlannerStepResult?: PlannerStepResult;
+                  workflowConversationSnapshot?: string;
+                  fallbackAfterInternalNoGeneration: boolean;
+              }
+        > => {
+            let generationResult: GenerationResult;
+            let routedGenerationSelectedProfile: ModelProfile | undefined;
+            let workflowLineage: WorkflowRecord | undefined;
+            let workflowContextStepResult: ContextStepResult | undefined;
+            let workflowContextStepResults: ContextStepResult[] | undefined;
+            let workflowPlannerSummary: AppliedPlanState | undefined;
+            let workflowPlannerStepResult: PlannerStepResult | undefined;
+            let workflowConversationSnapshot: string | undefined;
+            let fallbackAfterInternalNoGeneration = false;
+
+            if (workflowExecutionEnabled) {
+                const workflowPolicy: WorkflowRunPolicy =
+                    workflowProfile.policy;
+                const sanitizedReviewModuleIds = sanitizeReviewModuleIds(
+                    workflowProfile.optionalExtensions?.reviewModuleIds
                 );
-            const effectiveContextStepRequests = mergeContextStepRequests({
-                contextStepRequests,
-                trustGraphContextStepRequest,
-            });
-            const workflowResult = await runReviewWorkflow({
-                generationRuntime,
-                generationRequest: effectiveGenerationRequest,
-                messagesWithHints: effectiveMessagesWithHints,
-                generationStartedAtMs: generationStartedAt,
-                workflowConfig: {
-                    workflowName: workflowProfile.workflowName,
-                    maxIterations: Math.max(
-                        0,
-                        Math.min(
-                            workflowExecutionLimits.maxReviewCycles ??
-                                Math.ceil(
-                                    workflowExecutionLimits.maxDeliberationCalls /
-                                        2
-                                ),
-                            Math.ceil(
-                                Math.max(
-                                    0,
-                                    workflowExecutionLimits.maxWorkflowSteps - 1
-                                ) / 2
-                            )
-                        )
-                    ),
-                    maxDurationMs: workflowExecutionLimits.maxDurationMs,
-                    executionLimits: workflowExecutionLimits,
-                },
-                workflowPolicy,
-                ...(workflowProfile.optionalExtensions?.reviewDecisionPrompt !==
-                    undefined && {
-                    reviewDecisionPrompt:
-                        workflowProfile.optionalExtensions.reviewDecisionPrompt,
-                }),
-                ...(workflowProfile.optionalExtensions?.revisionPromptPrefix !==
-                    undefined && {
-                    revisionPromptPrefix:
-                        workflowProfile.optionalExtensions.revisionPromptPrefix,
-                }),
-                ...(sanitizedReviewModuleIds.length > 0 && {
-                    reviewModuleIds: sanitizedReviewModuleIds,
-                }),
-                captureUsage: (result, requestedModel) =>
-                    recordUsageForStep(result, requestedModel),
-                plannerStepRequest: effectivePlannerStepRequest,
-                plannerStepExecutor: effectivePlannerStepExecutor,
-                planContinuationBuilder,
-                contextEnvelope,
-                contextStepRequests:
-                    effectiveContextStepRequests.length > 0
-                        ? effectiveContextStepRequests
-                        : undefined,
-                contextStepExecutor,
-                contextStepExecutorRegistry: {
-                    ...(contextStepExecutorRegistry ?? {}),
-                    [TRUSTGRAPH_CONTEXT_STEP_NAME]:
-                        createTrustGraphContextStepExecutor({
-                            runtimeOptions: executionContractTrustGraph,
-                            onWarn: (message, meta) =>
-                                logger.warn(message, meta),
-                        }),
-                },
-                openAiNativeSearchFromHintsEnabled:
-                    runtimeConfig.chatWorkflow.contextIntegrations.webSearch
-                        .openAiNativeSearchFromHintsEnabled,
-                stepRoutingChainSet: {
-                    enabledProfilesById,
-                    generateCandidates: generateProfileCandidates,
-                    assessCandidates: assessProfileCandidates,
-                },
-            });
-            workflowPlannerStepResult = workflowResult.plannerStepResult;
-            workflowPlannerSummary =
-                workflowResult.planContinuation?.plannerSummary;
-            if (
-                workflowResult.planContinuation?.continuation ===
-                'continue_message'
-            ) {
-                workflowConversationSnapshot =
-                    workflowResult.planContinuation.conversationSnapshot;
-                effectiveGenerationRequest =
-                    workflowResult.planContinuation.generationRequest;
-                effectivePlannerTemperament =
-                    workflowResult.planContinuation.plannerTemperament ??
-                    workflowResult.planContinuation.plannerSummary.executionPlan
-                        .generation.temperament ??
-                    effectivePlannerTemperament;
-                effectiveNormalizedGeneration =
-                    workflowResult.planContinuation.plannerSummary
-                        .generationForExecution;
-            } else {
-                workflowConversationSnapshot = undefined;
-            }
-            workflowContextStepResult = workflowResult.contextStepResult;
-            workflowContextStepResults = workflowResult.contextStepResults;
-            switch (workflowResult.outcome) {
-                case 'generated': {
-                    generationResult = workflowResult.generationResult;
-                    workflowLineage = workflowResult.workflowLineage;
-                    const generatedShortCircuit = buildContextStepShortCircuit({
-                        workflowContextStepResult,
-                        workflowContextStepResults,
-                        executionContext,
-                        plannerTemperament: effectivePlannerTemperament,
-                        toolRequest,
-                        model,
-                        defaultModel,
-                        conversationSnapshot:
-                            workflowConversationSnapshot ??
-                            conversationSnapshot,
-                        latestUserInput,
-                        buildResponseMetadata,
-                    });
-                    if (
-                        generatedShortCircuit !== undefined &&
-                        generatedShortCircuit.response !== undefined
-                    ) {
-                        return toShortCircuitMessageResult(
-                            generatedShortCircuit.response,
-                            generatedShortCircuit.telemetry
-                        );
-                    }
-                    break;
-                }
-                case 'terminal_action': {
-                    return {
-                        kind: 'terminal_action',
-                        response: planTerminalActionToResponse(
-                            workflowResult.terminalAction
-                        ),
-                        generationDurationMs: Math.max(
+                const trustGraphContextStepRequest =
+                    buildTrustGraphContextStepRequest(
+                        executionContractTrustGraph,
+                        executionContractTrustGraphContext
+                    );
+                const effectiveContextStepRequests = mergeContextStepRequests({
+                    contextStepRequests,
+                    trustGraphContextStepRequest,
+                });
+                const workflowResult = await runReviewWorkflow({
+                    generationRuntime,
+                    generationRequest: effectiveGenerationRequest,
+                    messagesWithHints: effectiveMessagesWithHints,
+                    generationStartedAtMs: generationStartedAt,
+                    workflowConfig: {
+                        workflowName: workflowProfile.workflowName,
+                        maxIterations: Math.max(
                             0,
-                            Date.now() - generationStartedAt
+                            Math.min(
+                                workflowExecutionLimits.maxReviewCycles ??
+                                    Math.ceil(
+                                        workflowExecutionLimits.maxDeliberationCalls /
+                                            2
+                                    ),
+                                Math.ceil(
+                                    Math.max(
+                                        0,
+                                        workflowExecutionLimits.maxWorkflowSteps -
+                                            1
+                                    ) / 2
+                                )
+                            )
                         ),
-                    };
+                        maxDurationMs: workflowExecutionLimits.maxDurationMs,
+                        executionLimits: workflowExecutionLimits,
+                    },
+                    workflowPolicy,
+                    ...(workflowProfile.optionalExtensions
+                        ?.reviewDecisionPrompt !== undefined && {
+                        reviewDecisionPrompt:
+                            workflowProfile.optionalExtensions
+                                .reviewDecisionPrompt,
+                    }),
+                    ...(workflowProfile.optionalExtensions
+                        ?.revisionPromptPrefix !== undefined && {
+                        revisionPromptPrefix:
+                            workflowProfile.optionalExtensions
+                                .revisionPromptPrefix,
+                    }),
+                    ...(sanitizedReviewModuleIds.length > 0 && {
+                        reviewModuleIds: sanitizedReviewModuleIds,
+                    }),
+                    captureUsage: (result, requestedModel) =>
+                        recordUsageForStep(result, requestedModel),
+                    plannerStepRequest,
+                    plannerStepExecutor,
+                    planContinuationBuilder,
+                    contextEnvelope,
+                    contextStepRequests:
+                        effectiveContextStepRequests.length > 0
+                            ? effectiveContextStepRequests
+                            : undefined,
+                    contextStepExecutor,
+                    contextStepExecutorRegistry: {
+                        ...(contextStepExecutorRegistry ?? {}),
+                        [TRUSTGRAPH_CONTEXT_STEP_NAME]:
+                            createTrustGraphContextStepExecutor({
+                                runtimeOptions: executionContractTrustGraph,
+                                onWarn: (message, meta) =>
+                                    logger.warn(message, meta),
+                            }),
+                    },
+                    openAiNativeSearchFromHintsEnabled:
+                        runtimeConfig.chatWorkflow.contextIntegrations.webSearch
+                            .openAiNativeSearchFromHintsEnabled,
+                    stepRoutingChainSet: {
+                        enabledProfilesById,
+                        generateCandidates: generateProfileCandidates,
+                        assessCandidates: assessProfileCandidates,
+                    },
+                });
+                workflowPlannerStepResult = workflowResult.plannerStepResult;
+                workflowPlannerSummary =
+                    workflowResult.planContinuation?.plannerSummary;
+                if (
+                    workflowResult.planContinuation?.continuation ===
+                    'continue_message'
+                ) {
+                    workflowConversationSnapshot =
+                        workflowResult.planContinuation.conversationSnapshot;
+                    effectiveGenerationRequest =
+                        workflowResult.planContinuation.generationRequest;
+                    effectivePlannerTemperament =
+                        workflowResult.planContinuation.plannerTemperament ??
+                        workflowResult.planContinuation.plannerSummary
+                            .executionPlan.generation.temperament ??
+                        effectivePlannerTemperament;
+                    effectiveNormalizedGeneration =
+                        workflowResult.planContinuation.plannerSummary
+                            .generationForExecution;
+                } else {
+                    workflowConversationSnapshot = undefined;
                 }
-                case 'no_generation': {
-                    workflowLineage = workflowResult.workflowLineage;
-                    const noGenShortCircuit = buildContextStepShortCircuit({
-                        workflowContextStepResult,
-                        workflowContextStepResults,
-                        executionContext,
-                        plannerTemperament: effectivePlannerTemperament,
-                        toolRequest,
-                        model,
-                        defaultModel,
-                        conversationSnapshot:
-                            workflowConversationSnapshot ??
-                            conversationSnapshot,
-                        latestUserInput,
-                        buildResponseMetadata,
-                    });
-                    if (
-                        noGenShortCircuit !== undefined &&
-                        noGenShortCircuit.response !== undefined
-                    ) {
-                        return toShortCircuitMessageResult(
-                            noGenShortCircuit.response,
-                            noGenShortCircuit.telemetry
-                        );
-                    }
-                    const noGenerationResolution =
-                        resolveNoGenerationHandlingFromTermination({
-                            terminationReason:
-                                workflowResult.workflowLineage
-                                    .terminationReason,
-                            generationEnabledByPolicy:
-                                workflowPolicy.enableGeneration !== false,
-                        });
-                    if (
-                        noGenerationResolution.kind ===
-                        'unsupported_termination_reason'
-                    ) {
-                        logger.error(
-                            'Unsupported no-generation termination reason.',
-                            {
-                                workflowName: workflowProfile.workflowName,
-                                terminationReason:
-                                    noGenerationResolution.terminationReason,
-                                noGenerationResolution,
-                            }
-                        );
-                        generationResult = {
-                            text: SURFACED_NO_GENERATION_MESSAGE,
-                            model: effectiveGenerationRequest.model,
-                            provenance: 'Inferred',
-                            citations: [],
-                        };
+                workflowContextStepResult = workflowResult.contextStepResult;
+                workflowContextStepResults = workflowResult.contextStepResults;
+                switch (workflowResult.outcome) {
+                    case 'generated': {
+                        generationResult = workflowResult.generationResult;
+                        workflowLineage = workflowResult.workflowLineage;
+                        const generatedShortCircuit =
+                            buildContextStepShortCircuit({
+                                workflowContextStepResult,
+                                workflowContextStepResults,
+                                executionContext,
+                                plannerTemperament: effectivePlannerTemperament,
+                                toolRequest,
+                                model,
+                                defaultModel,
+                                conversationSnapshot:
+                                    workflowConversationSnapshot ??
+                                    conversationSnapshot,
+                                latestUserInput,
+                                buildResponseMetadata,
+                            });
+                        if (
+                            generatedShortCircuit !== undefined &&
+                            generatedShortCircuit.response !== undefined
+                        ) {
+                            return {
+                                kind: 'result',
+                                result: toShortCircuitMessageResult(
+                                    generatedShortCircuit.response,
+                                    generatedShortCircuit.telemetry
+                                ),
+                            };
+                        }
                         break;
                     }
-
-                    const handling = noGenerationResolution.handling;
-                    const backendFailOpenAllowed =
-                        ExecutionContract?.failOpen.allowFallbackGeneration ??
-                        true;
-
-                    if (
-                        handling.runtimeAction === 'run_fallback_generation' &&
-                        backendFailOpenAllowed
-                    ) {
-                        try {
-                            const chainGenerationResult =
-                                await runGenerateWithChain(
-                                    effectiveGenerationRequest
-                                );
-                            generationResult =
-                                chainGenerationResult.generationResult;
-                            routedGenerationSelectedProfile =
-                                chainGenerationResult.selectedProfile;
-                            recordUsageForStep(
-                                generationResult,
-                                effectiveGenerationRequest.model
-                            );
-                        } catch (error) {
-                            logger.warn(
-                                'Fallback generation after internal no-generation failed; preserving no-generation lineage.',
+                    case 'terminal_action': {
+                        return {
+                            kind: 'result',
+                            result: {
+                                kind: 'terminal_action',
+                                response: planTerminalActionToResponse(
+                                    workflowResult.terminalAction
+                                ),
+                                generationDurationMs: Math.max(
+                                    0,
+                                    Date.now() - generationStartedAt
+                                ),
+                            },
+                        };
+                    }
+                    case 'no_generation': {
+                        workflowLineage = workflowResult.workflowLineage;
+                        const noGenShortCircuit = buildContextStepShortCircuit({
+                            workflowContextStepResult,
+                            workflowContextStepResults,
+                            executionContext,
+                            plannerTemperament: effectivePlannerTemperament,
+                            toolRequest,
+                            model,
+                            defaultModel,
+                            conversationSnapshot:
+                                workflowConversationSnapshot ??
+                                conversationSnapshot,
+                            latestUserInput,
+                            buildResponseMetadata,
+                        });
+                        if (
+                            noGenShortCircuit !== undefined &&
+                            noGenShortCircuit.response !== undefined
+                        ) {
+                            return {
+                                kind: 'result',
+                                result: toShortCircuitMessageResult(
+                                    noGenShortCircuit.response,
+                                    noGenShortCircuit.telemetry
+                                ),
+                            };
+                        }
+                        const noGenerationResolution =
+                            resolveNoGenerationHandlingFromTermination({
+                                terminationReason:
+                                    workflowResult.workflowLineage
+                                        .terminationReason,
+                                generationEnabledByPolicy:
+                                    workflowPolicy.enableGeneration !== false,
+                            });
+                        if (
+                            noGenerationResolution.kind ===
+                            'unsupported_termination_reason'
+                        ) {
+                            logger.error(
+                                'Unsupported no-generation termination reason.',
                                 {
                                     workflowName: workflowProfile.workflowName,
-                                    reasonCode:
-                                        noGenerationResolution.reasonCode,
                                     terminationReason:
-                                        workflowResult.workflowLineage
-                                            .terminationReason,
-                                    error:
-                                        error instanceof Error
-                                            ? error.message
-                                            : String(error),
+                                        noGenerationResolution.terminationReason,
+                                    noGenerationResolution,
                                 }
                             );
                             generationResult = {
@@ -1332,56 +1346,140 @@ export const createChatService = ({
                                 provenance: 'Inferred',
                                 citations: [],
                             };
+                            break;
                         }
-                        fallbackAfterInternalNoGeneration = true;
+
+                        const handling = noGenerationResolution.handling;
+                        const backendFailOpenAllowed =
+                            ExecutionContract?.failOpen
+                                .allowFallbackGeneration ?? true;
+
+                        if (
+                            handling.runtimeAction ===
+                                'run_fallback_generation' &&
+                            backendFailOpenAllowed
+                        ) {
+                            try {
+                                const chainGenerationResult =
+                                    await runGenerateWithChain(
+                                        effectiveGenerationRequest
+                                    );
+                                generationResult =
+                                    chainGenerationResult.generationResult;
+                                routedGenerationSelectedProfile =
+                                    chainGenerationResult.selectedProfile;
+                                recordUsageForStep(
+                                    generationResult,
+                                    effectiveGenerationRequest.model
+                                );
+                            } catch (error) {
+                                logger.warn(
+                                    'Fallback generation after internal no-generation failed; preserving no-generation lineage.',
+                                    {
+                                        workflowName:
+                                            workflowProfile.workflowName,
+                                        reasonCode:
+                                            noGenerationResolution.reasonCode,
+                                        terminationReason:
+                                            workflowResult.workflowLineage
+                                                .terminationReason,
+                                        error:
+                                            error instanceof Error
+                                                ? error.message
+                                                : String(error),
+                                    }
+                                );
+                                generationResult = {
+                                    text: SURFACED_NO_GENERATION_MESSAGE,
+                                    model: effectiveGenerationRequest.model,
+                                    provenance: 'Inferred',
+                                    citations: [],
+                                };
+                            }
+                            fallbackAfterInternalNoGeneration = true;
+                            break;
+                        }
+                        if (
+                            handling.runtimeAction ===
+                                'run_fallback_generation' &&
+                            !backendFailOpenAllowed
+                        ) {
+                            logger.info(
+                                'Execution policy disabled fallback generation after internal no-generation outcome.',
+                                {
+                                    workflowName: workflowProfile.workflowName,
+                                    failOpenAuthority:
+                                        ExecutionContract?.failOpen.authority ??
+                                        'backend',
+                                    reasonCode:
+                                        noGenerationResolution.reasonCode,
+                                    terminationReason:
+                                        workflowResult.workflowLineage
+                                            .terminationReason,
+                                }
+                            );
+                        }
+
+                        generationResult = {
+                            text: SURFACED_NO_GENERATION_MESSAGE,
+                            model: effectiveGenerationRequest.model,
+                            provenance: 'Inferred',
+                            citations: [],
+                        };
                         break;
                     }
-                    if (
-                        handling.runtimeAction === 'run_fallback_generation' &&
-                        !backendFailOpenAllowed
-                    ) {
-                        logger.info(
-                            'Execution policy disabled fallback generation after internal no-generation outcome.',
-                            {
-                                workflowName: workflowProfile.workflowName,
-                                failOpenAuthority:
-                                    ExecutionContract?.failOpen.authority ??
-                                    'backend',
-                                reasonCode: noGenerationResolution.reasonCode,
-                                terminationReason:
-                                    workflowResult.workflowLineage
-                                        .terminationReason,
-                            }
+                    default: {
+                        const exhaustiveCheck: never = workflowResult;
+                        throw new Error(
+                            `Unsupported workflow outcome: ${JSON.stringify(exhaustiveCheck)}`
                         );
                     }
-
-                    generationResult = {
-                        text: SURFACED_NO_GENERATION_MESSAGE,
-                        model: effectiveGenerationRequest.model,
-                        provenance: 'Inferred',
-                        citations: [],
-                    };
-                    break;
                 }
-                default: {
-                    const exhaustiveCheck: never = workflowResult;
-                    throw new Error(
-                        `Unsupported workflow outcome: ${JSON.stringify(exhaustiveCheck)}`
-                    );
-                }
+            } else {
+                const chainGenerationResult = await runGenerateWithChain(
+                    effectiveGenerationRequest
+                );
+                generationResult = chainGenerationResult.generationResult;
+                routedGenerationSelectedProfile =
+                    chainGenerationResult.selectedProfile;
+                recordUsageForStep(
+                    generationResult,
+                    effectiveGenerationRequest.model
+                );
             }
-        } else {
-            const chainGenerationResult = await runGenerateWithChain(
-                effectiveGenerationRequest
-            );
-            generationResult = chainGenerationResult.generationResult;
-            routedGenerationSelectedProfile =
-                chainGenerationResult.selectedProfile;
-            recordUsageForStep(
+
+            return {
+                kind: 'continue',
                 generationResult,
-                effectiveGenerationRequest.model
-            );
+                routedGenerationSelectedProfile,
+                workflowLineage,
+                workflowContextStepResult,
+                workflowContextStepResults,
+                workflowPlannerSummary,
+                workflowPlannerStepResult,
+                workflowConversationSnapshot,
+                fallbackAfterInternalNoGeneration,
+            };
+        };
+        const generationPhase = await executeGenerationPhase();
+        if (generationPhase.kind === 'result') {
+            return generationPhase.result;
         }
+        const generationResult = generationPhase.generationResult;
+        const routedGenerationSelectedProfile =
+            generationPhase.routedGenerationSelectedProfile;
+        const workflowLineage = generationPhase.workflowLineage;
+        const workflowContextStepResult =
+            generationPhase.workflowContextStepResult;
+        const workflowContextStepResults =
+            generationPhase.workflowContextStepResults;
+        const workflowPlannerSummary = generationPhase.workflowPlannerSummary;
+        const workflowPlannerStepResult =
+            generationPhase.workflowPlannerStepResult;
+        const workflowConversationSnapshot =
+            generationPhase.workflowConversationSnapshot;
+        const fallbackAfterInternalNoGeneration =
+            generationPhase.fallbackAfterInternalNoGeneration;
 
         const effectiveContextStepResults = getEffectiveContextStepResults(
             workflowContextStepResults,

--- a/packages/backend/src/services/workflowEngine.ts
+++ b/packages/backend/src/services/workflowEngine.ts
@@ -64,8 +64,12 @@ import {
     selectContextStepExecutor,
     selectFollowUpSearchHint,
 } from './workflowEngine/contextStepHelpers.js';
-import { executeStepRoutingChain } from './stepRoutingExecutor.js';
+import {
+    executeStepRoutingChain,
+    type RoutingChainAttemptLog,
+} from './stepRoutingExecutor.js';
 import type { ResolvedStepRoutingCandidate } from './stepRoutingChains.js';
+import { buildRoutingChainSignals } from './workflowEngine/routingSignals.js';
 
 /**
  * Canonical Execution Contract workflow-policy surface.
@@ -874,19 +878,7 @@ export const runBoundedReviewWorkflow = async ({
             });
             try {
                 let initialRoutingChainAttempts:
-                    | Array<{
-                          index: number;
-                          step: string;
-                          profileId: string;
-                          provider?: string;
-                          model?: string;
-                          status: string;
-                          reasonCode?: string;
-                          chooseOneUsed: boolean;
-                          chooseOneCandidates?: string[];
-                          chooseOneSelectedIndex?: number;
-                          seedKeyType?: 'session_id' | 'correlation_id';
-                      }>
+                    | RoutingChainAttemptLog[]
                     | undefined;
                 let initialRoutedProfile:
                     | {
@@ -959,15 +951,18 @@ export const runBoundedReviewWorkflow = async ({
                     attempt: 1,
                     ...(initialRoutingChainAttempts !== undefined && {
                         signals: {
-                            routingChainAttemptCount:
-                                initialRoutingChainAttempts.length,
-                            routingChainAttemptsJson: JSON.stringify(
-                                initialRoutingChainAttempts
-                            ),
-                            ...(initialRoutedProfile !== undefined && {
-                                routedProfileId: initialRoutedProfile.profileId,
-                                routedProvider: initialRoutedProfile.provider,
-                                routedModel: initialRoutedProfile.model,
+                            ...buildRoutingChainSignals({
+                                attempts: initialRoutingChainAttempts,
+                                selectedProfileId:
+                                    initialRoutedProfile?.profileId,
+                                selectedProvider:
+                                    initialRoutedProfile?.provider,
+                                selectedModel: initialRoutedProfile?.model,
+                                signalKeys: {
+                                    profileId: 'routedProfileId',
+                                    provider: 'routedProvider',
+                                    model: 'routedModel',
+                                },
                             }),
                         },
                     }),

--- a/packages/backend/src/services/workflowEngine/reviewLoopExecutor.ts
+++ b/packages/backend/src/services/workflowEngine/reviewLoopExecutor.ts
@@ -41,6 +41,10 @@ import {
     extractRoutingHintsFromAssess,
     reorderRevisionCandidatesByHintLane,
 } from './revisionRoutingHints.js';
+import {
+    buildAssessRoutingHintSignals,
+    buildRoutingChainSignals,
+} from './routingSignals.js';
 
 type CaptureStep = (input: {
     stepKind: 'plan' | 'tool' | 'generate' | 'assess' | 'revise' | 'finalize';
@@ -195,26 +199,27 @@ export const executeReviewLoop = async (ctx: {
         exhaustedLimitKey = evaluation.exhaustedLimitKey;
         return true;
     };
-
-    for (
-        let iteration = 1;
-        iteration <= ctx.effectiveMaxIterations && !shouldStop;
-        iteration += 1
-    ) {
-        if (
-            !isWorkflowTransitionAllowed(
-                workflowState.currentStepKind,
-                'assess',
-                ctx.workflowPolicy
-            )
-        ) {
-            terminationReason = 'transition_blocked_by_policy';
-            workflowStatus = 'degraded';
-            break;
-        }
-        if (syncLimitStop(ctx.stopIfOverLimits('assess'))) {
-            break;
-        }
+    const toLatestRoutingHintSignals = (): Record<
+        string,
+        string | number | boolean | null
+    > =>
+        buildAssessRoutingHintSignals({
+            assessRoutingHintsCsv: latestAssessRoutingHintsCsv,
+            routingHintApplied: latestRoutingHintApplied,
+            routingHintConflictResolved: latestRoutingHintConflictResolved,
+        });
+    const executeAssessStep = async (
+        iteration: number
+    ): Promise<
+        | {
+              status: 'executed';
+              decision: ReviewDecision;
+              reviewStepId: string;
+          }
+        | {
+              status: 'stopped';
+          }
+    > => {
         const reviewStartedAt = Date.now();
         try {
             const assessPrompt = composeAssessPrompt({
@@ -300,7 +305,7 @@ export const executeReviewLoop = async (ctx: {
                 terminationReason = 'executor_error_fail_open';
                 workflowStatus = 'degraded';
                 shouldStop = true;
-                break;
+                return { status: 'stopped' };
             }
             const assessSignals = buildAssessSignals(decision);
             const assessRoutingHints = extractRoutingHintsFromAssess({
@@ -329,325 +334,22 @@ export const executeReviewLoop = async (ctx: {
                 attempt: iteration,
                 signals: {
                     ...assessSignals,
-                    ...(latestAssessRoutingHintsCsv !== undefined && {
-                        assessRoutingHintsCsv: latestAssessRoutingHintsCsv,
-                    }),
-                    routingHintApplied: latestRoutingHintApplied ?? 'none',
-                    ...(latestRoutingHintConflictResolved !== undefined && {
-                        routingHintConflictResolved:
-                            latestRoutingHintConflictResolved,
-                    }),
-                    ...(assessChainResult !== undefined && {
-                        routingChainAttemptCount:
-                            assessChainResult.attempts.length,
-                        routingChainAttemptsJson: JSON.stringify(
-                            assessChainResult.attempts
-                        ),
+                    ...toLatestRoutingHintSignals(),
+                    ...buildRoutingChainSignals({
+                        attempts: assessChainResult?.attempts,
                         selectedProfileId:
-                            assessChainResult.status === 'executed'
+                            assessChainResult?.status === 'executed'
                                 ? assessChainResult.selected.profile.id
                                 : null,
                     }),
                 },
             });
             latestRevisionInstruction = decision.revisionInstruction;
-            if (decision.reviewDecision === 'finalize') {
-                terminationReason = 'goal_satisfied';
-                workflowStatus = 'completed';
-                shouldStop = true;
-                break;
-            }
-            if (iteration >= ctx.effectiveMaxIterations) {
-                terminationReason = 'budget_exhausted_steps';
-                exhaustedLimitKey = 'maxWorkflowSteps';
-                workflowStatus = 'degraded';
-                shouldStop = true;
-                break;
-            }
-            if (!ctx.workflowPolicy.enableRevision) {
-                terminationReason = 'transition_blocked_by_policy';
-                workflowStatus = 'degraded';
-                shouldStop = true;
-                break;
-            }
-            if (
-                !isWorkflowTransitionAllowed(
-                    workflowState.currentStepKind,
-                    'generate',
-                    ctx.workflowPolicy
-                )
-            ) {
-                terminationReason = 'transition_blocked_by_policy';
-                workflowStatus = 'degraded';
-                shouldStop = true;
-                break;
-            }
-            if (syncLimitStop(ctx.stopIfOverLimits('generate'))) {
-                break;
-            }
-            let reentryAttempt = 0;
-            if (
-                ctx.plannerStepRequest !== undefined &&
-                ctx.plannerStepExecutor !== undefined &&
-                ctx.planContinuationBuilder !== undefined
-            ) {
-                if (
-                    !isWorkflowTransitionAllowed(
-                        workflowState.currentStepKind,
-                        'plan',
-                        ctx.workflowPolicy
-                    )
-                ) {
-                    terminationReason = 'transition_blocked_by_policy';
-                    workflowStatus = 'degraded';
-                    shouldStop = true;
-                    break;
-                }
-                if (syncLimitStop(ctx.stopIfOverLimits('plan'))) {
-                    break;
-                }
-                const plannerReentryStartedAt = Date.now();
-                try {
-                    const plannerReentryResult = await ctx.plannerStepExecutor({
-                        ...ctx.plannerStepRequest,
-                        workflowId: ctx.workflowId,
-                        workflowName: ctx.workflowName,
-                        attempt: iteration + 1,
-                    });
-                    const plannerReentryFinishedAt = Date.now();
-                    const plannerReentryStep = buildPlannerStepRecord({
-                        stepId: `step_${ctx.stepCounterRef.value + 1}`,
-                        attempt: iteration + 1,
-                        parentStepId: reviewStepId,
-                        startedAtMs: plannerReentryStartedAt,
-                        finishedAtMs: plannerReentryFinishedAt,
-                        summary: {
-                            status: plannerReentryResult.execution.status,
-                            ...(plannerReentryResult.execution.reasonCode !==
-                                undefined && {
-                                reasonCode:
-                                    plannerReentryResult.execution.reasonCode,
-                            }),
-                            purpose: plannerReentryResult.execution.purpose,
-                            contractType:
-                                plannerReentryResult.execution.contractType,
-                            applyOutcome:
-                                plannerReentryResult.execution.status ===
-                                'executed'
-                                    ? 'applied'
-                                    : 'not_applied',
-                            durationMs:
-                                plannerReentryResult.execution.durationMs,
-                            action: plannerReentryResult.plan.action,
-                            modality: plannerReentryResult.plan.modality,
-                            requestedCapabilityProfile:
-                                plannerReentryResult.plan
-                                    .requestedCapabilityProfile,
-                            ...(plannerReentryResult.execution
-                                .routingChainAttempts !== undefined && {
-                                routingChainAttempts:
-                                    plannerReentryResult.execution
-                                        .routingChainAttempts,
-                            }),
-                        },
-                    });
-                    ctx.workflowStepsRef.value.push(plannerReentryStep);
-                    ctx.stepCounterRef.value += 1;
-                    workflowState = applyStepExecutionToState(
-                        workflowState,
-                        'plan',
-                        0,
-                        0,
-                        1
-                    );
-                    planContinuation = ctx.planContinuationBuilder({
-                        plannerStepResult: plannerReentryResult,
-                        workflowId: ctx.workflowId,
-                        workflowName: ctx.workflowName,
-                        attempt: iteration + 1,
-                        baseMessagesWithHints: effectiveMessagesWithHints,
-                        baseGenerationRequest: effectiveGenerationRequest,
-                        contextEnvelope: effectiveContextEnvelope,
-                    });
-                    if (planContinuation.continuation !== 'continue_message') {
-                        terminationReason = 'executor_error_fail_open';
-                        workflowStatus = 'degraded';
-                        shouldStop = true;
-                        break;
-                    }
-                    reentryAttempt = iteration;
-                    effectiveGenerationRequest =
-                        planContinuation.generationRequest;
-                    effectiveMessagesWithHints =
-                        planContinuation.messagesWithHints;
-                    effectiveContextEnvelope = planContinuation.contextEnvelope;
-                    messagesWithContext = effectiveMessagesWithHints;
-                } catch {
-                    terminationReason = 'executor_error_fail_open';
-                    workflowStatus = 'degraded';
-                    shouldStop = true;
-                    break;
-                }
-            }
-            if (syncLimitStop(ctx.stopIfOverLimits('generate'))) {
-                break;
-            }
-            const revisionStartedAt = Date.now();
-            try {
-                const refinementModuleIds =
-                    decision.moduleHints !== undefined &&
-                    decision.moduleHints.length > 0
-                        ? decision.moduleHints
-                        : ctx.selectedReviewModuleIds;
-                const refinementPrompt = composeRefinementPrompt({
-                    revisionPromptPrefix: ctx.effectiveRevisionPromptPrefix,
-                    revisionInstruction: latestRevisionInstruction,
-                    moduleIds: refinementModuleIds,
-                });
-                const revisionRequest: GenerationRequest = {
-                    ...effectiveGenerationRequest,
-                    messages: [
-                        ...effectiveMessagesWithHints,
-                        { role: 'assistant', content: draftResult?.text ?? '' },
-                        { role: 'system', content: refinementPrompt.prompt },
-                    ],
-                };
-                const revisionChainResult =
-                    ctx.stepRoutingChainSet?.generateCandidates &&
-                    ctx.stepRoutingChainSet.generateCandidates.length > 0
-                        ? await executeStepRoutingChain({
-                              step: 'generate',
-                              candidates: reorderRevisionCandidatesByHintLane({
-                                  candidates:
-                                      ctx.stepRoutingChainSet
-                                          .generateCandidates,
-                                  enabledProfilesById:
-                                      ctx.stepRoutingChainSet
-                                          .enabledProfilesById,
-                                  lane: latestRoutingHintApplied ?? 'none',
-                              }),
-                              enabledProfilesById:
-                                  ctx.stepRoutingChainSet.enabledProfilesById,
-                              requiresSearch:
-                                  revisionRequest.search !== undefined,
-                              runWithProfile: async (profile) =>
-                                  ctx.generationRuntime.generate({
-                                      ...revisionRequest,
-                                      model: profile.providerModel,
-                                      provider: profile.provider,
-                                      capabilities: profile.capabilities,
-                                  }),
-                          })
-                        : undefined;
-                if (revisionChainResult?.status === 'exhausted') {
-                    throw new Error(revisionChainResult.reasonCode);
-                }
-                const revisionResult =
-                    revisionChainResult?.status === 'executed'
-                        ? revisionChainResult.value
-                        : await ctx.generationRuntime.generate(revisionRequest);
-                const revisionUsageModel =
-                    revisionChainResult?.status === 'executed'
-                        ? revisionChainResult.selected.profile.providerModel
-                        : effectiveGenerationRequest.model;
-                const revisionFinishedAt = Date.now();
-                const revisionUsage = ctx.captureUsage(
-                    revisionResult,
-                    revisionUsageModel
-                );
-                const revisionStepId = ctx.captureStep({
-                    stepKind: 'generate',
-                    status: 'executed',
-                    summary:
-                        'Generated refinement draft from assessment guidance.',
-                    startedAtMs: revisionStartedAt,
-                    finishedAtMs: revisionFinishedAt,
-                    model: revisionUsage.model,
-                    usage: revisionResult.usage,
-                    estimatedCost: revisionUsage.estimatedCost,
-                    parentStepId: reviewStepId,
-                    attempt: iteration,
-                    signals: {
-                        refinementApplied: true,
-                        refinementSourceStepId: reviewStepId,
-                        appliedModuleCount:
-                            refinementPrompt.appliedModuleIds.length,
-                        ...(refinementPrompt.appliedModuleIds.length > 0 && {
-                            appliedModuleIdsCsv:
-                                refinementPrompt.appliedModuleIds.join(','),
-                        }),
-                        ...(reentryAttempt > 0 && { reentryAttempt }),
-                        ...(latestAssessRoutingHintsCsv !== undefined && {
-                            assessRoutingHintsCsv: latestAssessRoutingHintsCsv,
-                        }),
-                        routingHintApplied: latestRoutingHintApplied ?? 'none',
-                        ...(latestRoutingHintConflictResolved !== undefined && {
-                            routingHintConflictResolved:
-                                latestRoutingHintConflictResolved,
-                        }),
-                        ...(revisionChainResult !== undefined && {
-                            routingChainAttemptCount:
-                                revisionChainResult.attempts.length,
-                            routingChainAttemptsJson: JSON.stringify(
-                                revisionChainResult.attempts
-                            ),
-                            selectedProfileId:
-                                revisionChainResult.status === 'executed'
-                                    ? revisionChainResult.selected.profile.id
-                                    : null,
-                        }),
-                    },
-                });
-                workflowState = applyStepExecutionToState(
-                    workflowState,
-                    'generate',
-                    revisionUsage.totalTokens,
-                    0,
-                    0
-                );
-                draftResult = revisionResult;
-                draftParentStepId = revisionStepId;
-            } catch (error) {
-                const revisionFinishedAt = Date.now();
-                const errorMessage =
-                    error instanceof Error ? error.message : String(error);
-                const reasonCode: ExecutionReasonCode =
-                    errorMessage === 'routing_chain_exhausted' ||
-                    errorMessage === 'routing_chain_non_transient_error'
-                        ? (errorMessage as ExecutionReasonCode)
-                        : 'generation_runtime_error';
-                ctx.captureStep({
-                    stepKind: 'generate',
-                    status: 'failed',
-                    summary:
-                        'Refinement generation failed; fail-open returned latest successful draft.',
-                    reasonCode,
-                    startedAtMs: revisionStartedAt,
-                    finishedAtMs: revisionFinishedAt,
-                    parentStepId: reviewStepId,
-                    attempt: iteration,
-                    signals: {
-                        ...(latestAssessRoutingHintsCsv !== undefined && {
-                            assessRoutingHintsCsv: latestAssessRoutingHintsCsv,
-                        }),
-                        routingHintApplied: latestRoutingHintApplied ?? 'none',
-                        ...(latestRoutingHintConflictResolved !== undefined && {
-                            routingHintConflictResolved:
-                                latestRoutingHintConflictResolved,
-                        }),
-                    },
-                });
-                workflowState = applyStepExecutionToState(
-                    workflowState,
-                    'generate',
-                    0,
-                    0,
-                    0
-                );
-                terminationReason = 'executor_error_fail_open';
-                workflowStatus = 'degraded';
-                shouldStop = true;
-            }
+            return {
+                status: 'executed',
+                decision,
+                reviewStepId,
+            };
         } catch (error) {
             const reviewFinishedAt = Date.now();
             const errorMessage =
@@ -667,16 +369,7 @@ export const executeReviewLoop = async (ctx: {
                 finishedAtMs: reviewFinishedAt,
                 parentStepId: draftParentStepId,
                 attempt: iteration,
-                signals: {
-                    ...(latestAssessRoutingHintsCsv !== undefined && {
-                        assessRoutingHintsCsv: latestAssessRoutingHintsCsv,
-                    }),
-                    routingHintApplied: latestRoutingHintApplied ?? 'none',
-                    ...(latestRoutingHintConflictResolved !== undefined && {
-                        routingHintConflictResolved:
-                            latestRoutingHintConflictResolved,
-                    }),
-                },
+                signals: toLatestRoutingHintSignals(),
             });
             workflowState = applyStepExecutionToState(
                 workflowState,
@@ -688,6 +381,346 @@ export const executeReviewLoop = async (ctx: {
             terminationReason = 'executor_error_fail_open';
             workflowStatus = 'degraded';
             shouldStop = true;
+            return { status: 'stopped' };
+        }
+    };
+    const executePlannerReentryStep = async (
+        iteration: number,
+        reviewStepId: string
+    ): Promise<
+        | {
+              status: 'executed';
+              reentryAttempt: number;
+          }
+        | {
+              status: 'skipped';
+              reentryAttempt: number;
+          }
+        | {
+              status: 'stopped';
+          }
+    > => {
+        if (
+            ctx.plannerStepRequest === undefined ||
+            ctx.plannerStepExecutor === undefined ||
+            ctx.planContinuationBuilder === undefined
+        ) {
+            return {
+                status: 'skipped',
+                reentryAttempt: 0,
+            };
+        }
+        if (
+            !isWorkflowTransitionAllowed(
+                workflowState.currentStepKind,
+                'plan',
+                ctx.workflowPolicy
+            )
+        ) {
+            terminationReason = 'transition_blocked_by_policy';
+            workflowStatus = 'degraded';
+            shouldStop = true;
+            return { status: 'stopped' };
+        }
+        if (syncLimitStop(ctx.stopIfOverLimits('plan'))) {
+            return { status: 'stopped' };
+        }
+        const plannerReentryStartedAt = Date.now();
+        try {
+            const plannerReentryResult = await ctx.plannerStepExecutor({
+                ...ctx.plannerStepRequest,
+                workflowId: ctx.workflowId,
+                workflowName: ctx.workflowName,
+                attempt: iteration + 1,
+            });
+            const plannerReentryFinishedAt = Date.now();
+            const plannerReentryStep = buildPlannerStepRecord({
+                stepId: `step_${ctx.stepCounterRef.value + 1}`,
+                attempt: iteration + 1,
+                parentStepId: reviewStepId,
+                startedAtMs: plannerReentryStartedAt,
+                finishedAtMs: plannerReentryFinishedAt,
+                summary: {
+                    status: plannerReentryResult.execution.status,
+                    ...(plannerReentryResult.execution.reasonCode !==
+                        undefined && {
+                        reasonCode: plannerReentryResult.execution.reasonCode,
+                    }),
+                    purpose: plannerReentryResult.execution.purpose,
+                    contractType: plannerReentryResult.execution.contractType,
+                    applyOutcome:
+                        plannerReentryResult.execution.status === 'executed'
+                            ? 'applied'
+                            : 'not_applied',
+                    durationMs: plannerReentryResult.execution.durationMs,
+                    action: plannerReentryResult.plan.action,
+                    modality: plannerReentryResult.plan.modality,
+                    requestedCapabilityProfile:
+                        plannerReentryResult.plan.requestedCapabilityProfile,
+                    ...(plannerReentryResult.execution.routingChainAttempts !==
+                        undefined && {
+                        routingChainAttempts:
+                            plannerReentryResult.execution.routingChainAttempts,
+                    }),
+                },
+            });
+            ctx.workflowStepsRef.value.push(plannerReentryStep);
+            ctx.stepCounterRef.value += 1;
+            workflowState = applyStepExecutionToState(
+                workflowState,
+                'plan',
+                0,
+                0,
+                1
+            );
+            planContinuation = ctx.planContinuationBuilder({
+                plannerStepResult: plannerReentryResult,
+                workflowId: ctx.workflowId,
+                workflowName: ctx.workflowName,
+                attempt: iteration + 1,
+                baseMessagesWithHints: effectiveMessagesWithHints,
+                baseGenerationRequest: effectiveGenerationRequest,
+                contextEnvelope: effectiveContextEnvelope,
+            });
+            if (planContinuation.continuation !== 'continue_message') {
+                terminationReason = 'executor_error_fail_open';
+                workflowStatus = 'degraded';
+                shouldStop = true;
+                return { status: 'stopped' };
+            }
+            effectiveGenerationRequest = planContinuation.generationRequest;
+            effectiveMessagesWithHints = planContinuation.messagesWithHints;
+            effectiveContextEnvelope = planContinuation.contextEnvelope;
+            messagesWithContext = effectiveMessagesWithHints;
+            return {
+                status: 'executed',
+                reentryAttempt: iteration,
+            };
+        } catch {
+            terminationReason = 'executor_error_fail_open';
+            workflowStatus = 'degraded';
+            shouldStop = true;
+            return { status: 'stopped' };
+        }
+    };
+    const executeRevisionStep = async (input: {
+        iteration: number;
+        decision: ReviewDecision;
+        reviewStepId: string;
+        reentryAttempt: number;
+    }): Promise<void> => {
+        const revisionStartedAt = Date.now();
+        try {
+            const refinementModuleIds =
+                input.decision.moduleHints !== undefined &&
+                input.decision.moduleHints.length > 0
+                    ? input.decision.moduleHints
+                    : ctx.selectedReviewModuleIds;
+            const refinementPrompt = composeRefinementPrompt({
+                revisionPromptPrefix: ctx.effectiveRevisionPromptPrefix,
+                revisionInstruction: latestRevisionInstruction,
+                moduleIds: refinementModuleIds,
+            });
+            const revisionRequest: GenerationRequest = {
+                ...effectiveGenerationRequest,
+                messages: [
+                    ...effectiveMessagesWithHints,
+                    { role: 'assistant', content: draftResult?.text ?? '' },
+                    { role: 'system', content: refinementPrompt.prompt },
+                ],
+            };
+            const revisionChainResult =
+                ctx.stepRoutingChainSet?.generateCandidates &&
+                ctx.stepRoutingChainSet.generateCandidates.length > 0
+                    ? await executeStepRoutingChain({
+                          step: 'generate',
+                          candidates: reorderRevisionCandidatesByHintLane({
+                              candidates:
+                                  ctx.stepRoutingChainSet.generateCandidates,
+                              enabledProfilesById:
+                                  ctx.stepRoutingChainSet.enabledProfilesById,
+                              lane: latestRoutingHintApplied ?? 'none',
+                          }),
+                          enabledProfilesById:
+                              ctx.stepRoutingChainSet.enabledProfilesById,
+                          requiresSearch: revisionRequest.search !== undefined,
+                          runWithProfile: async (profile) =>
+                              ctx.generationRuntime.generate({
+                                  ...revisionRequest,
+                                  model: profile.providerModel,
+                                  provider: profile.provider,
+                                  capabilities: profile.capabilities,
+                              }),
+                      })
+                    : undefined;
+            if (revisionChainResult?.status === 'exhausted') {
+                throw new Error(revisionChainResult.reasonCode);
+            }
+            const revisionResult =
+                revisionChainResult?.status === 'executed'
+                    ? revisionChainResult.value
+                    : await ctx.generationRuntime.generate(revisionRequest);
+            const revisionUsageModel =
+                revisionChainResult?.status === 'executed'
+                    ? revisionChainResult.selected.profile.providerModel
+                    : effectiveGenerationRequest.model;
+            const revisionFinishedAt = Date.now();
+            const revisionUsage = ctx.captureUsage(
+                revisionResult,
+                revisionUsageModel
+            );
+            const revisionStepId = ctx.captureStep({
+                stepKind: 'generate',
+                status: 'executed',
+                summary: 'Generated refinement draft from assessment guidance.',
+                startedAtMs: revisionStartedAt,
+                finishedAtMs: revisionFinishedAt,
+                model: revisionUsage.model,
+                usage: revisionResult.usage,
+                estimatedCost: revisionUsage.estimatedCost,
+                parentStepId: input.reviewStepId,
+                attempt: input.iteration,
+                signals: {
+                    refinementApplied: true,
+                    refinementSourceStepId: input.reviewStepId,
+                    appliedModuleCount:
+                        refinementPrompt.appliedModuleIds.length,
+                    ...(refinementPrompt.appliedModuleIds.length > 0 && {
+                        appliedModuleIdsCsv:
+                            refinementPrompt.appliedModuleIds.join(','),
+                    }),
+                    ...(input.reentryAttempt > 0 && {
+                        reentryAttempt: input.reentryAttempt,
+                    }),
+                    ...toLatestRoutingHintSignals(),
+                    ...buildRoutingChainSignals({
+                        attempts: revisionChainResult?.attempts,
+                        selectedProfileId:
+                            revisionChainResult?.status === 'executed'
+                                ? revisionChainResult.selected.profile.id
+                                : null,
+                    }),
+                },
+            });
+            workflowState = applyStepExecutionToState(
+                workflowState,
+                'generate',
+                revisionUsage.totalTokens,
+                0,
+                0
+            );
+            draftResult = revisionResult;
+            draftParentStepId = revisionStepId;
+        } catch (error) {
+            const revisionFinishedAt = Date.now();
+            const errorMessage =
+                error instanceof Error ? error.message : String(error);
+            const reasonCode: ExecutionReasonCode =
+                errorMessage === 'routing_chain_exhausted' ||
+                errorMessage === 'routing_chain_non_transient_error'
+                    ? (errorMessage as ExecutionReasonCode)
+                    : 'generation_runtime_error';
+            ctx.captureStep({
+                stepKind: 'generate',
+                status: 'failed',
+                summary:
+                    'Refinement generation failed; fail-open returned latest successful draft.',
+                reasonCode,
+                startedAtMs: revisionStartedAt,
+                finishedAtMs: revisionFinishedAt,
+                parentStepId: input.reviewStepId,
+                attempt: input.iteration,
+                signals: toLatestRoutingHintSignals(),
+            });
+            workflowState = applyStepExecutionToState(
+                workflowState,
+                'generate',
+                0,
+                0,
+                0
+            );
+            terminationReason = 'executor_error_fail_open';
+            workflowStatus = 'degraded';
+            shouldStop = true;
+        }
+    };
+
+    for (
+        let iteration = 1;
+        iteration <= ctx.effectiveMaxIterations && !shouldStop;
+        iteration += 1
+    ) {
+        if (
+            !isWorkflowTransitionAllowed(
+                workflowState.currentStepKind,
+                'assess',
+                ctx.workflowPolicy
+            )
+        ) {
+            terminationReason = 'transition_blocked_by_policy';
+            workflowStatus = 'degraded';
+            break;
+        }
+        if (syncLimitStop(ctx.stopIfOverLimits('assess'))) {
+            break;
+        }
+        const assessStepResult = await executeAssessStep(iteration);
+        if (assessStepResult.status === 'stopped' || shouldStop) {
+            break;
+        }
+        const { decision, reviewStepId } = assessStepResult;
+        if (decision.reviewDecision === 'finalize') {
+            terminationReason = 'goal_satisfied';
+            workflowStatus = 'completed';
+            shouldStop = true;
+            break;
+        }
+        if (iteration >= ctx.effectiveMaxIterations) {
+            terminationReason = 'budget_exhausted_steps';
+            exhaustedLimitKey = 'maxWorkflowSteps';
+            workflowStatus = 'degraded';
+            shouldStop = true;
+            break;
+        }
+        if (!ctx.workflowPolicy.enableRevision) {
+            terminationReason = 'transition_blocked_by_policy';
+            workflowStatus = 'degraded';
+            shouldStop = true;
+            break;
+        }
+        if (
+            !isWorkflowTransitionAllowed(
+                workflowState.currentStepKind,
+                'generate',
+                ctx.workflowPolicy
+            )
+        ) {
+            terminationReason = 'transition_blocked_by_policy';
+            workflowStatus = 'degraded';
+            shouldStop = true;
+            break;
+        }
+        if (syncLimitStop(ctx.stopIfOverLimits('generate'))) {
+            break;
+        }
+        const plannerReentryResult = await executePlannerReentryStep(
+            iteration,
+            reviewStepId
+        );
+        if (plannerReentryResult.status === 'stopped' || shouldStop) {
+            break;
+        }
+        if (syncLimitStop(ctx.stopIfOverLimits('generate'))) {
+            break;
+        }
+        await executeRevisionStep({
+            iteration,
+            decision,
+            reviewStepId,
+            reentryAttempt: plannerReentryResult.reentryAttempt,
+        });
+        if (shouldStop) {
+            break;
         }
     }
 

--- a/packages/backend/src/services/workflowEngine/routingSignals.ts
+++ b/packages/backend/src/services/workflowEngine/routingSignals.ts
@@ -1,0 +1,70 @@
+/**
+ * @description: Shared signal-shaping helpers for workflow routing-chain telemetry and assess hint lineage.
+ * @footnote-scope: core
+ * @footnote-module: WorkflowEngineRoutingSignals
+ * @footnote-risk: low - Signal mapping drift affects observability metadata only.
+ * @footnote-ethics: medium - Routing and hint signals support governance interpretation.
+ */
+import type { RoutingChainAttemptLog } from '../stepRoutingExecutor.js';
+
+export type WorkflowRoutingHintLane =
+    | 'openai_first_logic'
+    | 'ollama_first_style'
+    | 'cheaper_first'
+    | 'none';
+
+export type WorkflowRoutingHintConflictResolution = 'logic_over_style';
+
+type StepSignalValue = string | number | boolean | null;
+
+type StepSignals = Record<string, StepSignalValue>;
+
+export const buildRoutingChainSignals = (input: {
+    attempts?: RoutingChainAttemptLog[];
+    selectedProfileId?: string | null;
+    selectedProvider?: string | null;
+    selectedModel?: string | null;
+    signalKeys?: {
+        profileId?: string;
+        provider?: string;
+        model?: string;
+    };
+}): StepSignals => {
+    if (!Array.isArray(input.attempts)) {
+        return {};
+    }
+
+    const profileIdKey = input.signalKeys?.profileId ?? 'selectedProfileId';
+    const providerKey = input.signalKeys?.provider ?? 'selectedProvider';
+    const modelKey = input.signalKeys?.model ?? 'selectedModel';
+    const signals: StepSignals = {
+        routingChainAttemptCount: input.attempts.length,
+        routingChainAttemptsJson: JSON.stringify(input.attempts),
+    };
+
+    if (input.selectedProfileId !== undefined) {
+        signals[profileIdKey] = input.selectedProfileId;
+    }
+    if (input.selectedProvider !== undefined) {
+        signals[providerKey] = input.selectedProvider;
+    }
+    if (input.selectedModel !== undefined) {
+        signals[modelKey] = input.selectedModel;
+    }
+
+    return signals;
+};
+
+export const buildAssessRoutingHintSignals = (input: {
+    assessRoutingHintsCsv?: string;
+    routingHintApplied?: WorkflowRoutingHintLane;
+    routingHintConflictResolved?: WorkflowRoutingHintConflictResolution;
+}): StepSignals => ({
+    ...(input.assessRoutingHintsCsv !== undefined && {
+        assessRoutingHintsCsv: input.assessRoutingHintsCsv,
+    }),
+    routingHintApplied: input.routingHintApplied ?? 'none',
+    ...(input.routingHintConflictResolved !== undefined && {
+        routingHintConflictResolved: input.routingHintConflictResolved,
+    }),
+});


### PR DESCRIPTION
## Summary
- Split the chat execution flow into smaller phase-oriented helpers in `chatService` to reduce nesting and make the review loop easier to follow.
- Moved workflow routing signal logic into dedicated routing helpers under `workflowEngine`.
- Kept the generation, workflow, and fallback handling paths functionally aligned while improving readability and localizing setup state.

## Testing
- Not run (not requested).
- Review the refactored execution path in `packages/backend/src/services/chatService.ts` for the generated, terminal action, and no-generation branches.
- Review the workflow routing helper changes in `packages/backend/src/services/workflowEngine/reviewLoopExecutor.ts` and `packages/backend/src/services/workflowEngine/routingSignals.ts` for shape and call-site consistency.