### PR TITLE
Add pnpm start bootstrap flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,20 +8,21 @@ Footnote is an AI assistant focused on transparency and provenance.
 
 ## Quickstart
 
-1. Clone and bootstrap:
+1. Clone and start:
 
 ```bash
 git clone https://github.com/footnote-ai/footnote.git
 cd footnote
-pnpm setup
+pnpm start
 ```
 
-`pnpm setup` will:
+`pnpm start` will:
 
 - create `.env` from `.env.example` if missing
 - generate required local secrets if missing
 - generate `footnote.yaml` if missing
-- install dependencies
+- install dependencies if missing
+- start backend + web
 
 2. Add provider secrets in `.env` (optional at startup, required for model features):
 
@@ -31,13 +32,15 @@ OPENAI_API_KEY=...
 OLLAMA_API_KEY=...
 ```
 
-3. Start backend + web:
+3. For later local runs, use:
 
 ```bash
-pnpm dev
+pnpm start
 ```
 
 Open `http://localhost:8080`.
+
+Native wrappers (`.sh`, `.ps1`, `.exe`) are planned as follow-up work and are not part of this flow yet.
 
 ## Where Settings Go
 

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -11,11 +11,19 @@ Canonical artifacts:
 
 ## First Setup
 
-1. Run setup once:
+1. Run local start once:
 
 ```bash
-pnpm setup
+pnpm start
 ```
+
+`pnpm start` will:
+
+- create `.env` from `.env.example` if missing
+- generate required local secrets if missing
+- generate `footnote.yaml` if missing
+- install dependencies if missing
+- start backend + web
 
 2. Keep or edit `footnote.yaml` (non-secret runtime settings):
     - default path: `./footnote.yaml`

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
         "packages/*"
     ],
     "scripts": {
+        "start": "node scripts/start.cjs",
         "dev": "concurrently \"pnpm dev:backend\" \"pnpm dev:web\"",
         "dev:backend": "pnpm backend:prepare && pnpm exec tsx packages/backend/src/server.ts",
         "dev:web": "pnpm --filter @footnote/web dev",

--- a/scripts/setup.cjs
+++ b/scripts/setup.cjs
@@ -164,7 +164,7 @@ const printChecklist = () => {
     }
 
     console.log('[setup] Runtime settings live in footnote.yaml.');
-    console.log('[setup] Complete. Start with: pnpm dev');
+    console.log('[setup] Complete. Start with: pnpm start');
 };
 
 const main = () => {

--- a/scripts/start.cjs
+++ b/scripts/start.cjs
@@ -1,0 +1,71 @@
+#!/usr/bin/env node
+/* eslint-env node */
+/* global __dirname, process */
+
+/**
+ * @description: Starts local web-first development flow with automatic first-run bootstrap and dependency install checks.
+ * @footnote-scope: utility
+ * @footnote-module: StartScript
+ * @footnote-risk: medium - Incorrect orchestration can fail startup or run redundant setup/install steps.
+ * @footnote-ethics: low - Local developer startup helper with no direct human-impact decisions.
+ */
+const fs = require('node:fs');
+const path = require('node:path');
+const { spawnSync } = require('node:child_process');
+
+const repoRoot = path.resolve(__dirname, '..');
+const envPath = path.join(repoRoot, '.env');
+const settingsPath = path.join(repoRoot, 'footnote.yaml');
+const nodeModulesPath = path.join(repoRoot, 'node_modules');
+const pnpmStorePath = path.join(nodeModulesPath, '.pnpm');
+const setupScriptPath = path.join(repoRoot, 'scripts', 'setup.cjs');
+
+const pnpmBin = process.platform === 'win32' ? 'pnpm.cmd' : 'pnpm';
+const nodeBin = process.execPath;
+const isWindows = process.platform === 'win32';
+
+const run = (command, args, env = process.env) => {
+    const normalizedCommand = command.toLowerCase();
+    const isWindowsBatchCommand =
+        isWindows &&
+        (normalizedCommand.endsWith('.cmd') ||
+            normalizedCommand.endsWith('.bat'));
+
+    // Windows batch files like `pnpm.cmd` need `cmd.exe` to launch reliably.
+    const executable = isWindowsBatchCommand ? 'cmd.exe' : command;
+    const executableArgs = isWindowsBatchCommand
+        ? ['/d', '/s', '/c', command, ...args]
+        : args;
+
+    const result = spawnSync(executable, executableArgs, {
+        cwd: repoRoot,
+        env,
+        stdio: 'inherit',
+    });
+
+    if (result.error) {
+        throw result.error;
+    }
+
+    return result.status ?? 1;
+};
+
+const needsBootstrapFiles =
+    !fs.existsSync(envPath) || !fs.existsSync(settingsPath);
+const needsDependencyInstall =
+    !fs.existsSync(nodeModulesPath) || !fs.existsSync(pnpmStorePath);
+
+if (needsBootstrapFiles) {
+    const setupStatus = run(nodeBin, [setupScriptPath]);
+    if (setupStatus !== 0) {
+        process.exit(setupStatus);
+    }
+} else if (needsDependencyInstall) {
+    const installStatus = run(pnpmBin, ['install']);
+    if (installStatus !== 0) {
+        process.exit(installStatus);
+    }
+}
+
+const devStatus = run(pnpmBin, ['dev']);
+process.exit(devStatus);

--- a/scripts/start.cjs
+++ b/scripts/start.cjs
@@ -24,23 +24,46 @@ const pnpmBin = process.platform === 'win32' ? 'pnpm.cmd' : 'pnpm';
 const nodeBin = process.execPath;
 const isWindows = process.platform === 'win32';
 
+const resolveCommand = (command, env = process.env) => {
+    if (path.isAbsolute(command)) {
+        return command;
+    }
+
+    if (command.includes(path.sep) || (path.sep === '\\' && command.includes('/'))) {
+        return path.resolve(repoRoot, command);
+    }
+
+    const pathValue = env.PATH || env.Path || env.path || '';
+    const pathDirs = pathValue.split(path.delimiter).filter(Boolean);
+    const pathext = isWindows
+        ? (env.PATHEXT || '.COM;.EXE;.BAT;.CMD')
+              .split(';')
+              .map((ext) => ext.toLowerCase())
+        : [''];
+    const hasExtension = !!path.extname(command);
+    const candidates = isWindows && !hasExtension
+        ? pathext.map((ext) => `${command}${ext}`)
+        : [command];
+
+    for (const dir of pathDirs) {
+        for (const candidate of candidates) {
+            const fullPath = path.join(dir, candidate);
+            if (fs.existsSync(fullPath)) {
+                return fullPath;
+            }
+        }
+    }
+
+    throw new Error(`Unable to resolve executable: ${command}`);
+};
+
 const run = (command, args, env = process.env) => {
-    const normalizedCommand = command.toLowerCase();
-    const isWindowsBatchCommand =
-        isWindows &&
-        (normalizedCommand.endsWith('.cmd') ||
-            normalizedCommand.endsWith('.bat'));
-
-    // Windows batch files like `pnpm.cmd` need `cmd.exe` to launch reliably.
-    const executable = isWindowsBatchCommand ? 'cmd.exe' : command;
-    const executableArgs = isWindowsBatchCommand
-        ? ['/d', '/s', '/c', command, ...args]
-        : args;
-
-    const result = spawnSync(executable, executableArgs, {
+    const executable = resolveCommand(command, env);
+    const result = spawnSync(executable, args, {
         cwd: repoRoot,
         env,
         stdio: 'inherit',
+        shell: false,
     });
 
     if (result.error) {


### PR DESCRIPTION
## Summary
- Add a new top-level `pnpm start` script that bootstraps first-run local setup, installs dependencies when needed, and then starts the backend/web dev flow.
- Update `README.md` and `deploy/README.md` to document `pnpm start` as the primary local startup path.
- Update `scripts/setup.cjs` to point users to `pnpm start` after setup completes.
- Add Windows-safe process launching in `scripts/start.cjs` for `pnpm.cmd`.

## Testing
- Not run: `pnpm lint:fix`
- Not run: `pnpm lint`
- Not run: local startup verification with `pnpm start`
- Not run: Windows-specific bootstrap path verification

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced unified `pnpm start` command that automatically creates configuration files, generates local secrets, installs missing dependencies, and launches the development server in one step.

* **Documentation**
  * Updated README and deployment documentation to reflect the simplified startup workflow using the new `pnpm start` command for both initial setup and subsequent development sessions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/footnote-ai/footnote/pull/389?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->