### PR TITLE
Add launcher info menu and update command

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,12 +11,13 @@ Footnote is an AI framework that tries to show its work.
 ### Run the app
 
 - Download the binary from [Releases](https://github.com/footnote-ai/footnote/releases)
-- Either:
-  - double-click the binary, or
-  - run:
+- Double-click the binary to open the launcher menu.
+- Or run explicit commands:
 
 ```bash
 footnote start
+footnote setup
+footnote update
 ```
 
 That's it!

--- a/docs/README.md
+++ b/docs/README.md
@@ -10,6 +10,10 @@ For first-time setup:
 - Developer source path: [README Quickstart](../README.md#quickstart)
 - Deployment path: [deploy README](../deploy/README.md)
 
+Standalone launcher note: running `footnote` with no command (or double-clicking
+the binary) opens the `footnote info` launcher menu. Use explicit commands like
+`footnote start`, `footnote setup`, and `footnote update` for automation.
+
 ## Sections
 
 - [Architecture](./architecture/README.md): current system shape, boundaries,

--- a/docs/ci/README.md
+++ b/docs/ci/README.md
@@ -86,6 +86,10 @@ This checks the launcher packages without doing the full SEA release build.
 
 It runs on pushes to `main` and on pull requests. It builds the launcher on Linux, macOS, and Windows. It also checks that the help command works and that `footnote status --config-dir <temp>` does not create config files.
 
+Launcher invocation behavior: `footnote` with no command routes to `footnote info`.
+CI workflows should keep using explicit commands (`footnote status`, `footnote start`,
+`footnote update`) for deterministic automation.
+
 If this fails, check which operating system failed first. A Windows-only failure is often a path or shell issue.
 
 ### `launcher-sea-spike.yml`

--- a/packages/launcher-cli/src/args.test.ts
+++ b/packages/launcher-cli/src/args.test.ts
@@ -21,3 +21,22 @@ test('parseLauncherArgs keeps setup command compatible with shared options', () 
     assert.equal(parsed.command, 'setup');
     assert.equal(parsed.configDir, './tmp');
 });
+
+test('parseLauncherArgs defaults no-arg command to info', () => {
+    const parsed = parseLauncherArgs([]);
+    assert.equal(parsed.command, 'info');
+    assert.equal(parsed.headless, false);
+    assert.equal(parsed.follow, true);
+});
+
+test('parseLauncherArgs accepts info command', () => {
+    const parsed = parseLauncherArgs(['info']);
+    assert.equal(parsed.command, 'info');
+    assert.equal(parsed.headless, false);
+});
+
+test('parseLauncherArgs accepts update command', () => {
+    const parsed = parseLauncherArgs(['update']);
+    assert.equal(parsed.command, 'update');
+    assert.equal(parsed.headless, false);
+});

--- a/packages/launcher-cli/src/args.ts
+++ b/packages/launcher-cli/src/args.ts
@@ -9,7 +9,9 @@
 import { LauncherError } from '@footnote/launcher-core';
 
 export type LauncherCommand =
+    | 'info'
     | 'start'
+    | 'update'
     | 'stop'
     | 'status'
     | 'open'
@@ -40,7 +42,7 @@ const expectValue = (
 export const parseLauncherArgs = (argv: readonly string[]): LauncherArgs => {
     if (argv.length === 0) {
         return {
-            command: 'start',
+            command: 'info',
             headless: false,
             follow: true,
         };
@@ -56,7 +58,9 @@ export const parseLauncherArgs = (argv: readonly string[]): LauncherArgs => {
     }
 
     if (
+        first !== 'info' &&
         first !== 'start' &&
+        first !== 'update' &&
         first !== 'stop' &&
         first !== 'status' &&
         first !== 'open' &&

--- a/packages/launcher-cli/src/cli.test.ts
+++ b/packages/launcher-cli/src/cli.test.ts
@@ -13,7 +13,7 @@ import type {
     LauncherConfigPaths,
     LauncherMetadata,
 } from '@footnote/launcher-core';
-import { runCli } from './cli.js';
+import { runCliWithDeps } from './cli.js';
 
 const TEST_CONFIG_PATHS: LauncherConfigPaths = {
     configRoot: '/tmp/footnote-test',
@@ -63,7 +63,7 @@ const createNoopRuntime = (): FootnoteRuntime => ({
 test('runCli info non-TTY prints read-only status/help snapshot and exits', async () => {
     const output: string[] = [];
 
-    const exitCode = await runCli(['info'], {
+    const exitCode = await runCliWithDeps(['info'], {
         createRuntime: createNoopRuntime,
         resolveConfigPathsFn: () => TEST_CONFIG_PATHS,
         readLauncherMetadataFn: async () => null,
@@ -80,12 +80,42 @@ test('runCli info non-TTY prints read-only status/help snapshot and exits', asyn
     assert.match(text, /footnote update/);
 });
 
+test('runCli info non-TTY still prints snapshot when status path fails', async () => {
+    const output: string[] = [];
+
+    const exitCode = await runCliWithDeps(['info'], {
+        resolveConfigPathsFn: () => TEST_CONFIG_PATHS,
+        readLauncherMetadataFn: async () => ({
+            version: 1,
+            runtime: 'docker',
+            instance: 'default',
+            imageRepository: 'ghcr.io/footnote-ai/footnote',
+            defaultTag: 'stable',
+        }),
+        isInteractiveTty: () => false,
+        writeStdout: (text: string) => {
+            output.push(text);
+        },
+        createRuntime: () => ({
+            ...createNoopRuntime(),
+            async status() {
+                throw new Error('status failed');
+            },
+        }),
+    });
+
+    const text = output.join('');
+    assert.equal(exitCode, 0);
+    assert.match(text, /\[warn\] status failed/);
+    assert.match(text, /Read-only launcher snapshot/);
+});
+
 test('runCli update fails with setup guidance when settings file is missing', async () => {
     const runtime = createNoopRuntime();
 
     await assert.rejects(
         async () =>
-            runCli(['update'], {
+            runCliWithDeps(['update'], {
                 createRuntime: () => runtime,
                 resolveConfigPathsFn: () => TEST_CONFIG_PATHS,
                 bootstrapConfigFilesFn: async () => ({
@@ -149,7 +179,7 @@ test('runCli update executes stop->start and writes refreshed metadata', async (
         },
     };
 
-    const exitCode = await runCli(['update'], {
+    const exitCode = await runCliWithDeps(['update'], {
         createRuntime: () => runtime,
         resolveConfigPathsFn: () => TEST_CONFIG_PATHS,
         bootstrapConfigFilesFn: async () => ({
@@ -226,7 +256,7 @@ test('runCli info menu maps Start selection to start command flow', async () => 
 
     const menuSelections: Array<'start' | 'exit'> = ['start', 'exit'];
 
-    const exitCode = await runCli(['info'], {
+    const exitCode = await runCliWithDeps(['info'], {
         createRuntime: () => runtime,
         resolveConfigPathsFn: () => TEST_CONFIG_PATHS,
         bootstrapConfigFilesFn: async () => ({

--- a/packages/launcher-cli/src/cli.test.ts
+++ b/packages/launcher-cli/src/cli.test.ts
@@ -1,0 +1,261 @@
+/**
+ * @description: Unit tests for launcher CLI command orchestration and menu behavior.
+ * @footnote-scope: test
+ * @footnote-module: LauncherCliTests
+ * @footnote-risk: low - Tests verify command routing behavior without mutating real runtime resources.
+ * @footnote-ethics: low - Behavior tests improve operator clarity and do not impact governance decisions.
+ */
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import type {
+    FootnoteRuntime,
+    LauncherConfigPaths,
+    LauncherMetadata,
+} from '@footnote/launcher-core';
+import { runCli } from './cli.js';
+
+const TEST_CONFIG_PATHS: LauncherConfigPaths = {
+    configRoot: '/tmp/footnote-test',
+    envFilePath: '/tmp/footnote-test/.env',
+    settingsFilePath: '/tmp/footnote-test/footnote.yaml',
+    launcherMetadataPath: '/tmp/footnote-test/launcher.metadata.json',
+};
+
+const createNoopRuntime = (): FootnoteRuntime => ({
+    async start() {
+        return {
+            state: 'running',
+            url: 'http://localhost:8080',
+            port: 8080,
+            tag: 'latest',
+            imageRef: 'ghcr.io/footnote-ai/footnote:latest',
+            containerId: 'container-1',
+            volumeName: 'footnote_data',
+            warnings: [],
+        };
+    },
+    async stop() {
+        return {
+            stopped: true,
+            removed: true,
+            message: 'stopped',
+        };
+    },
+    async status() {
+        return {
+            state: 'running',
+            containerName: 'footnote-server',
+            containerId: 'container-1',
+            url: 'http://localhost:8080',
+            port: 8080,
+            imageRef: 'ghcr.io/footnote-ai/footnote:latest',
+            configRoot: TEST_CONFIG_PATHS.configRoot,
+            volumeName: 'footnote_data',
+            ownershipMatches: true,
+        };
+    },
+    async *logs() {
+        yield { text: 'log-line', stream: 'stdout' };
+    },
+});
+
+test('runCli info non-TTY prints read-only status/help snapshot and exits', async () => {
+    const output: string[] = [];
+
+    const exitCode = await runCli(['info'], {
+        createRuntime: createNoopRuntime,
+        resolveConfigPathsFn: () => TEST_CONFIG_PATHS,
+        readLauncherMetadataFn: async () => null,
+        isInteractiveTty: () => false,
+        writeStdout: (text: string) => {
+            output.push(text);
+        },
+    });
+
+    const text = output.join('');
+    assert.equal(exitCode, 0);
+    assert.match(text, /\[info\] state: not_found/);
+    assert.match(text, /Read-only launcher snapshot/);
+    assert.match(text, /footnote update/);
+});
+
+test('runCli update fails with setup guidance when settings file is missing', async () => {
+    const runtime = createNoopRuntime();
+
+    await assert.rejects(
+        async () =>
+            runCli(['update'], {
+                createRuntime: () => runtime,
+                resolveConfigPathsFn: () => TEST_CONFIG_PATHS,
+                bootstrapConfigFilesFn: async () => ({
+                    createdPaths: [],
+                    metadata: {
+                        version: 1,
+                        runtime: 'docker',
+                        instance: 'default',
+                        imageRepository: 'ghcr.io/footnote-ai/footnote',
+                        defaultTag: 'stable',
+                    },
+                }),
+                isSettingsFileMissingFn: async () => true,
+                writeStdout: () => {
+                    // Ignore output for this test.
+                },
+            }),
+        /Run `footnote setup`/
+    );
+});
+
+test('runCli update executes stop->start and writes refreshed metadata', async () => {
+    const callOrder: string[] = [];
+    const writes: LauncherMetadata[] = [];
+
+    const runtime: FootnoteRuntime = {
+        async start(input) {
+            callOrder.push('start');
+            assert.equal(input.defaultTag, 'stable');
+            return {
+                state: 'running',
+                url: 'http://localhost:9090',
+                port: 9090,
+                tag: 'stable',
+                imageRef: 'ghcr.io/footnote-ai/footnote:stable',
+                containerId: 'container-2',
+                volumeName: 'footnote_data',
+                warnings: [],
+            };
+        },
+        async stop() {
+            callOrder.push('stop');
+            return {
+                stopped: true,
+                removed: true,
+                message:
+                    'Stopped and removed launcher-managed container "footnote-server".',
+            };
+        },
+        async status() {
+            return {
+                state: 'not_found',
+                containerName: 'footnote-server',
+                configRoot: TEST_CONFIG_PATHS.configRoot,
+                volumeName: 'footnote_data',
+                ownershipMatches: false,
+            };
+        },
+        async *logs() {
+            // No logs needed.
+        },
+    };
+
+    const exitCode = await runCli(['update'], {
+        createRuntime: () => runtime,
+        resolveConfigPathsFn: () => TEST_CONFIG_PATHS,
+        bootstrapConfigFilesFn: async () => ({
+            createdPaths: [],
+            metadata: {
+                version: 1,
+                runtime: 'docker',
+                instance: 'default',
+                imageRepository: 'ghcr.io/footnote-ai/footnote',
+                defaultTag: 'stable',
+            },
+        }),
+        isSettingsFileMissingFn: async () => false,
+        writeLauncherMetadataFn: async (_path, metadata) => {
+            writes.push(metadata);
+        },
+        writeStdout: () => {
+            // Ignore output for this test.
+        },
+        nowIso: () => '2026-05-22T00:00:00.000Z',
+    });
+
+    assert.equal(exitCode, 0);
+    assert.deepEqual(callOrder, ['stop', 'start']);
+    assert.equal(writes.length, 1);
+    assert.equal(writes[0]?.lastKnown?.url, 'http://localhost:9090');
+    assert.equal(writes[0]?.lastKnown?.tag, 'stable');
+    assert.equal(
+        writes[0]?.lastKnown?.updatedAtIso,
+        '2026-05-22T00:00:00.000Z'
+    );
+});
+
+test('runCli info menu maps Start selection to start command flow', async () => {
+    const calls = {
+        start: 0,
+        openInBrowser: 0,
+    };
+
+    const runtime: FootnoteRuntime = {
+        async start() {
+            calls.start += 1;
+            return {
+                state: 'running',
+                url: 'http://localhost:8080',
+                port: 8080,
+                tag: 'stable',
+                imageRef: 'ghcr.io/footnote-ai/footnote:stable',
+                containerId: 'container-3',
+                volumeName: 'footnote_data',
+                warnings: [],
+            };
+        },
+        async stop() {
+            return {
+                stopped: false,
+                removed: false,
+                message: 'nothing',
+            };
+        },
+        async status() {
+            return {
+                state: 'not_found',
+                containerName: 'footnote-server',
+                configRoot: TEST_CONFIG_PATHS.configRoot,
+                volumeName: 'footnote_data',
+                ownershipMatches: false,
+            };
+        },
+        async *logs() {
+            // No logs needed.
+        },
+    };
+
+    const menuSelections: Array<'start' | 'exit'> = ['start', 'exit'];
+
+    const exitCode = await runCli(['info'], {
+        createRuntime: () => runtime,
+        resolveConfigPathsFn: () => TEST_CONFIG_PATHS,
+        bootstrapConfigFilesFn: async () => ({
+            createdPaths: [],
+            metadata: {
+                version: 1,
+                runtime: 'docker',
+                instance: 'default',
+                imageRepository: 'ghcr.io/footnote-ai/footnote',
+                defaultTag: 'stable',
+            },
+        }),
+        isInteractiveTty: () => true,
+        promptInfoMenuAction: async () => {
+            const next = menuSelections.shift();
+            return next ?? 'exit';
+        },
+        openInBrowserFn: async () => {
+            calls.openInBrowser += 1;
+        },
+        writeLauncherMetadataFn: async () => {
+            // Avoid filesystem writes in this test.
+        },
+        writeStdout: () => {
+            // Ignore output for this test.
+        },
+    });
+
+    assert.equal(exitCode, 0);
+    assert.equal(calls.start, 1);
+    assert.equal(calls.openInBrowser, 1);
+});

--- a/packages/launcher-cli/src/cli.ts
+++ b/packages/launcher-cli/src/cli.ts
@@ -8,6 +8,7 @@
 
 import path from 'node:path';
 import { access } from 'node:fs/promises';
+import { createInterface } from 'node:readline/promises';
 import {
     bootstrapConfigFiles,
     computeConfigRootHash,
@@ -24,6 +25,8 @@ import {
     parseSetupBootstrapEventLine,
     isSetupBootstrapEventUsable,
     writeLauncherMetadata,
+    type FootnoteRuntime,
+    type LauncherConfigPaths,
     type LauncherMetadata,
     type SetupBootstrapEvent,
     type StatusResult,
@@ -35,20 +38,82 @@ import {
     DEFAULT_VOLUME_NAME,
     LAUNCHER_ID,
 } from './constants.js';
-import { parseLauncherArgs } from './args.js';
+import {
+    parseLauncherArgs,
+    type LauncherArgs,
+    type LauncherCommand,
+} from './args.js';
 import { DockerRuntime } from './runtime/dockerRuntime.js';
 
-const printHelp = (): void => {
+type InfoMenuAction =
+    | 'start'
+    | 'setup'
+    | 'update'
+    | 'status'
+    | 'open'
+    | 'logs_no_follow'
+    | 'stop'
+    | 'help'
+    | 'exit';
+
+type CliDependencies = {
+    parseArgs: (argv: readonly string[]) => LauncherArgs;
+    createRuntime: () => FootnoteRuntime;
+    bootstrapConfigFilesFn: typeof bootstrapConfigFiles;
+    readLauncherMetadataFn: typeof readLauncherMetadata;
+    writeLauncherMetadataFn: typeof writeLauncherMetadata;
+    openInBrowserFn: typeof openInBrowser;
+    resolveDefaultConfigRootFn: typeof resolveDefaultConfigRoot;
+    resolveConfigPathsFn: typeof resolveConfigPaths;
+    computeConfigRootHashFn: typeof computeConfigRootHash;
+    isSettingsFileMissingFn: (settingsFilePath: string) => Promise<boolean>;
+    isInteractiveTty: () => boolean;
+    promptInfoMenuAction: () => Promise<InfoMenuAction>;
+    nowIso: () => string;
+    writeStdout: (text: string) => void;
+};
+
+type CommandContext = {
+    parsed: LauncherArgs;
+    configRoot: string;
+    paths: LauncherConfigPaths;
+    configRootHash: string;
+    runtime: FootnoteRuntime;
+    dependencies: CliDependencies;
+};
+
+const INFO_MENU_ITEMS: ReadonlyArray<{
+    action: InfoMenuAction;
+    label: string;
+}> = [
+    { action: 'start', label: 'Start' },
+    { action: 'setup', label: 'Setup' },
+    { action: 'update', label: 'Update' },
+    { action: 'status', label: 'Status' },
+    { action: 'open', label: 'Open' },
+    { action: 'logs_no_follow', label: 'Logs (no-follow)' },
+    { action: 'stop', label: 'Stop' },
+    { action: 'help', label: 'Help' },
+    { action: 'exit', label: 'Exit' },
+];
+
+const writeLine = (dependencies: CliDependencies, line: string): void => {
+    dependencies.writeStdout(`${line}\n`);
+};
+
+const printHelp = (dependencies: CliDependencies): void => {
     const lines = [
         'footnote <command> [options]',
-        'No command defaults to: footnote start',
+        'No command defaults to: footnote info',
         '',
         'Commands:',
+        '  info    Show launcher info and interactive menu in TTY mode',
         '  start   Start Footnote using Docker + GHCR image',
+        '  setup   Open first-setup link when footnote.yaml is missing',
+        '  update  Restart launcher-managed runtime with persisted/default tag',
         '  stop    Stop/remove launcher-managed container',
         '  status  Show runtime status without bootstrapping config files',
         '  open    Open the running launcher-managed URL if live',
-        '  setup   Open first-setup link when footnote.yaml is missing',
         '  logs    Stream logs from launcher-managed container',
         '',
         'Options:',
@@ -57,7 +122,7 @@ const printHelp = (): void => {
         '  --headless           Do not auto-open browser on start',
         '  --no-follow          For logs, print current logs and exit',
     ];
-    process.stdout.write(`${lines.join('\n')}\n`);
+    dependencies.writeStdout(`${lines.join('\n')}\n`);
 };
 
 const mapErrorToExitCode = (error: unknown): number => {
@@ -89,6 +154,7 @@ const resolveMetadataWithDefaults = (
 };
 
 const printStatus = (
+    dependencies: CliDependencies,
     status: StatusResult,
     metadata: LauncherMetadata | null,
     configRoot: string
@@ -129,7 +195,35 @@ const printStatus = (
         );
     }
 
-    process.stdout.write(`${lines.join('\n')}\n`);
+    dependencies.writeStdout(`${lines.join('\n')}\n`);
+};
+
+const printReadOnlyInfoSnapshot = (
+    dependencies: CliDependencies,
+    configRoot: string
+): void => {
+    writeLine(
+        dependencies,
+        formatMessage(
+            'info',
+            'Read-only launcher snapshot (non-interactive mode).'
+        )
+    );
+    writeLine(
+        dependencies,
+        formatMessage(
+            'info',
+            `Use \`footnote info\` in a terminal for the interactive menu.`
+        )
+    );
+    writeLine(dependencies, formatMessage('info', `configRoot: ${configRoot}`));
+    writeLine(
+        dependencies,
+        formatMessage(
+            'info',
+            'Actions: footnote start | footnote setup | footnote update | footnote status | footnote open | footnote logs --no-follow | footnote stop'
+        )
+    );
 };
 
 const ensureLiveUrl = async (url: string): Promise<void> => {
@@ -177,7 +271,7 @@ const captureLatestSetupEventFromRuntimeLogs = async ({
     configRootHash,
     instance,
 }: {
-    runtime: DockerRuntime;
+    runtime: FootnoteRuntime;
     configRoot: string;
     configRootHash: string;
     instance: string;
@@ -229,69 +323,237 @@ const isSetupRequiredByMissingSettingsFile = async (
     }
 };
 
-/**
- * Parses launcher CLI arguments and orchestrates command routing for runtime operations.
- * This function decides command flow and exit semantics, while delegating runtime actions to DockerRuntime and shared launcher-core helpers.
- * @param argv Raw CLI arguments after the executable name.
- * @returns Promise<number> Exit code following launcher contract (0/1/2/3).
- */
-export const runCli = async (argv: readonly string[]): Promise<number> => {
-    const parsed = parseLauncherArgs(argv);
+const defaultPromptInfoMenuAction = async (): Promise<InfoMenuAction> => {
+    const readline = createInterface({
+        input: process.stdin,
+        output: process.stdout,
+    });
 
-    if (parsed.command === 'help') {
-        printHelp();
-        return 0;
-    }
+    try {
+        while (true) {
+            process.stdout.write('\nFootnote Launcher Menu\n');
+            for (const [index, item] of INFO_MENU_ITEMS.entries()) {
+                process.stdout.write(`${index + 1}. ${item.label}\n`);
+            }
+            const answer = (
+                await readline.question('Choose an action: ')
+            ).trim();
+            const selectedIndex = Number.parseInt(answer, 10);
 
-    const configRoot = path.resolve(
-        parsed.configDir ??
-            resolveDefaultConfigRoot(process.platform, process.env)
-    );
-    const paths = resolveConfigPaths(configRoot);
-    const configRootHash = computeConfigRootHash(configRoot);
+            if (
+                Number.isInteger(selectedIndex) &&
+                selectedIndex >= 1 &&
+                selectedIndex <= INFO_MENU_ITEMS.length
+            ) {
+                return INFO_MENU_ITEMS[selectedIndex - 1].action;
+            }
 
-    const runtime = new DockerRuntime();
-
-    if (parsed.command === 'start') {
-        const bootstrapResult = await bootstrapConfigFiles(paths);
-        const metadata = resolveMetadataWithDefaults(bootstrapResult.metadata);
-        const persistedTag = parsed.tag ?? metadata.defaultTag;
-        const metadataForStart: LauncherMetadata = {
-            ...metadata,
-            defaultTag: persistedTag,
-        };
-
-        if (parsed.tag) {
-            await writeLauncherMetadata(
-                paths.launcherMetadataPath,
-                metadataForStart
+            process.stdout.write(
+                `${formatMessage('warn', `Invalid selection "${answer}". Enter a number from 1-${INFO_MENU_ITEMS.length}.`)}\n`
             );
         }
+    } finally {
+        readline.close();
+    }
+};
 
-        const preferredPort =
-            metadataForStart.lastKnown?.port ?? DEFAULT_PREFERRED_PORT;
+const DEFAULT_CLI_DEPENDENCIES: CliDependencies = {
+    parseArgs: parseLauncherArgs,
+    createRuntime: () => new DockerRuntime(),
+    bootstrapConfigFilesFn: bootstrapConfigFiles,
+    readLauncherMetadataFn: readLauncherMetadata,
+    writeLauncherMetadataFn: writeLauncherMetadata,
+    openInBrowserFn: openInBrowser,
+    resolveDefaultConfigRootFn: resolveDefaultConfigRoot,
+    resolveConfigPathsFn: resolveConfigPaths,
+    computeConfigRootHashFn: computeConfigRootHash,
+    isSettingsFileMissingFn: isSetupRequiredByMissingSettingsFile,
+    isInteractiveTty: () =>
+        Boolean(process.stdin.isTTY && process.stdout.isTTY),
+    promptInfoMenuAction: defaultPromptInfoMenuAction,
+    nowIso: () => new Date().toISOString(),
+    writeStdout: (text: string) => {
+        process.stdout.write(text);
+    },
+};
 
-        const startResult = await runtime.start({
+const handleStartCommand = async (
+    context: CommandContext,
+    input: {
+        headless: boolean;
+        tagOverride?: string;
+    }
+): Promise<number> => {
+    const { configRoot, configRootHash, paths, runtime, dependencies } =
+        context;
+    const bootstrapResult = await dependencies.bootstrapConfigFilesFn(paths);
+    const metadata = resolveMetadataWithDefaults(bootstrapResult.metadata);
+    const persistedTag = input.tagOverride ?? metadata.defaultTag;
+    const metadataForStart: LauncherMetadata = {
+        ...metadata,
+        defaultTag: persistedTag,
+    };
+
+    if (input.tagOverride) {
+        await dependencies.writeLauncherMetadataFn(
+            paths.launcherMetadataPath,
+            metadataForStart
+        );
+    }
+
+    const preferredPort =
+        metadataForStart.lastKnown?.port ?? DEFAULT_PREFERRED_PORT;
+
+    const startResult = await runtime.start({
+        configRoot,
+        configRootHash,
+        instance: metadataForStart.instance,
+        launcherId: LAUNCHER_ID,
+        containerName: DEFAULT_CONTAINER_NAME,
+        volumeName: DEFAULT_VOLUME_NAME,
+        imageRepository: metadataForStart.imageRepository,
+        defaultTag: metadataForStart.defaultTag,
+        tagOverride: input.tagOverride,
+        digestByTag: metadataForStart.digestByTag,
+        preferredPort,
+        envFilePath: paths.envFilePath,
+        settingsFilePath: paths.settingsFilePath,
+        headless: input.headless,
+        readinessTimeoutMs: DEFAULT_READINESS_TIMEOUT_MS,
+    });
+
+    let updatedMetadata: LauncherMetadata = {
+        ...metadataForStart,
+        defaultTag: persistedTag,
+        lastKnown: {
+            url: startResult.url,
+            port: startResult.port,
+            tag: startResult.tag,
+            imageRef: startResult.imageRef,
+            containerName: DEFAULT_CONTAINER_NAME,
+            volumeName: DEFAULT_VOLUME_NAME,
+            updatedAtIso: dependencies.nowIso(),
+        },
+    };
+
+    try {
+        const latestSetupEvent = await captureLatestSetupEventFromRuntimeLogs({
+            runtime,
             configRoot,
             configRootHash,
             instance: metadataForStart.instance,
+        });
+        if (latestSetupEvent) {
+            updatedMetadata = {
+                ...updatedMetadata,
+                setup: {
+                    ...updatedMetadata.setup,
+                    lastBootstrapEvent: {
+                        ...latestSetupEvent,
+                        capturedAtIso: dependencies.nowIso(),
+                    },
+                },
+            };
+        }
+    } catch {
+        // Fail-open: setup-event capture is best-effort metadata enrichment.
+    }
+
+    await dependencies.writeLauncherMetadataFn(
+        paths.launcherMetadataPath,
+        updatedMetadata
+    );
+
+    if (bootstrapResult.createdPaths.length > 0) {
+        writeLine(
+            dependencies,
+            formatMessage(
+                'info',
+                `Created config files:\n${bootstrapResult.createdPaths.join('\n')}`
+            )
+        );
+    }
+
+    for (const warning of startResult.warnings) {
+        writeLine(dependencies, formatMessage('warn', warning));
+    }
+
+    writeLine(
+        dependencies,
+        formatMessage('success', `Footnote is running at ${startResult.url}`)
+    );
+
+    if (!input.headless) {
+        try {
+            await dependencies.openInBrowserFn(startResult.url);
+        } catch (error: unknown) {
+            const message =
+                error instanceof Error
+                    ? error.message
+                    : 'Unknown browser open error.';
+            writeLine(
+                dependencies,
+                formatMessage(
+                    'warn',
+                    `Could not open browser automatically: ${message}`
+                )
+            );
+        }
+    }
+
+    return 0;
+};
+
+const handleSetupCommand = async (context: CommandContext): Promise<number> => {
+    const { configRoot, configRootHash, paths, runtime, dependencies } =
+        context;
+
+    const bootstrapResult = await dependencies.bootstrapConfigFilesFn(paths, {
+        createSettingsFile: false,
+    });
+    const metadata = resolveMetadataWithDefaults(bootstrapResult.metadata);
+    const setupRequiredNow = await dependencies.isSettingsFileMissingFn(
+        paths.settingsFilePath
+    );
+
+    const statusBefore = await runtime.status({
+        configRoot,
+        configRootHash,
+        instance: metadata.instance,
+        launcherId: LAUNCHER_ID,
+        containerName: DEFAULT_CONTAINER_NAME,
+        volumeName: DEFAULT_VOLUME_NAME,
+    });
+
+    let activeMetadata: LauncherMetadata = metadata;
+    if (
+        statusBefore.state !== 'running' ||
+        !statusBefore.ownershipMatches ||
+        !statusBefore.url ||
+        statusBefore.port === undefined
+    ) {
+        const preferredPort =
+            metadata.lastKnown?.port ?? DEFAULT_PREFERRED_PORT;
+        const startResult = await runtime.start({
+            configRoot,
+            configRootHash,
+            instance: metadata.instance,
             launcherId: LAUNCHER_ID,
             containerName: DEFAULT_CONTAINER_NAME,
             volumeName: DEFAULT_VOLUME_NAME,
-            imageRepository: metadataForStart.imageRepository,
-            defaultTag: metadataForStart.defaultTag,
-            tagOverride: parsed.tag,
-            digestByTag: metadataForStart.digestByTag,
+            imageRepository: metadata.imageRepository,
+            defaultTag: metadata.defaultTag,
+            digestByTag: metadata.digestByTag,
             preferredPort,
             envFilePath: paths.envFilePath,
             settingsFilePath: paths.settingsFilePath,
-            headless: parsed.headless,
+            settingsMountMode: 'directory',
+            headless: true,
             readinessTimeoutMs: DEFAULT_READINESS_TIMEOUT_MS,
         });
 
-        let updatedMetadata: LauncherMetadata = {
-            ...metadataForStart,
-            defaultTag: persistedTag,
+        activeMetadata = {
+            ...metadata,
             lastKnown: {
                 url: startResult.url,
                 port: startResult.port,
@@ -299,336 +561,467 @@ export const runCli = async (argv: readonly string[]): Promise<number> => {
                 imageRef: startResult.imageRef,
                 containerName: DEFAULT_CONTAINER_NAME,
                 volumeName: DEFAULT_VOLUME_NAME,
-                updatedAtIso: new Date().toISOString(),
+                updatedAtIso: dependencies.nowIso(),
             },
         };
-
-        try {
-            const latestSetupEvent =
-                await captureLatestSetupEventFromRuntimeLogs({
-                    runtime,
-                    configRoot,
-                    configRootHash,
-                    instance: metadataForStart.instance,
-                });
-            if (latestSetupEvent) {
-                updatedMetadata = {
-                    ...updatedMetadata,
-                    setup: {
-                        ...updatedMetadata.setup,
-                        lastBootstrapEvent: {
-                            ...latestSetupEvent,
-                            capturedAtIso: new Date().toISOString(),
-                        },
-                    },
-                };
-            }
-        } catch {
-            // Fail-open: setup-event capture is best-effort metadata enrichment.
-        }
-
-        await writeLauncherMetadata(
+        await dependencies.writeLauncherMetadataFn(
             paths.launcherMetadataPath,
-            updatedMetadata
+            activeMetadata
         );
-
-        if (bootstrapResult.createdPaths.length > 0) {
-            process.stdout.write(
-                `${formatMessage('info', `Created config files:\n${bootstrapResult.createdPaths.join('\n')}`)}\n`
-            );
-        }
 
         for (const warning of startResult.warnings) {
-            process.stdout.write(`${formatMessage('warn', warning)}\n`);
+            writeLine(dependencies, formatMessage('warn', warning));
         }
-
-        process.stdout.write(
-            `${formatMessage('success', `Footnote is running at ${startResult.url}`)}\n`
-        );
-
-        if (!parsed.headless) {
-            try {
-                await openInBrowser(startResult.url);
-            } catch (error: unknown) {
-                const message =
-                    error instanceof Error
-                        ? error.message
-                        : 'Unknown browser open error.';
-                process.stdout.write(
-                    `${formatMessage('warn', `Could not open browser automatically: ${message}`)}\n`
-                );
-            }
-        }
-
-        return 0;
     }
 
-    if (parsed.command === 'setup') {
-        const bootstrapResult = await bootstrapConfigFiles(paths, {
-            createSettingsFile: false,
-        });
-        const metadata = resolveMetadataWithDefaults(bootstrapResult.metadata);
-        const setupRequiredNow = await isSetupRequiredByMissingSettingsFile(
-            paths.settingsFilePath
-        );
-
-        const statusBefore = await runtime.status({
+    let setupEvent = readUsableSetupEventFromMetadata(
+        activeMetadata,
+        setupRequiredNow
+    );
+    if (!setupEvent) {
+        const latestFromLogs = await captureLatestSetupEventFromRuntimeLogs({
+            runtime,
             configRoot,
             configRootHash,
-            instance: metadata.instance,
-            launcherId: LAUNCHER_ID,
-            containerName: DEFAULT_CONTAINER_NAME,
-            volumeName: DEFAULT_VOLUME_NAME,
+            instance: activeMetadata.instance,
         });
-
-        let activeMetadata: LauncherMetadata = metadata;
-        if (
-            statusBefore.state !== 'running' ||
-            !statusBefore.ownershipMatches ||
-            !statusBefore.url ||
-            statusBefore.port === undefined
-        ) {
-            const preferredPort =
-                metadata.lastKnown?.port ?? DEFAULT_PREFERRED_PORT;
-            const startResult = await runtime.start({
-                configRoot,
-                configRootHash,
-                instance: metadata.instance,
-                launcherId: LAUNCHER_ID,
-                containerName: DEFAULT_CONTAINER_NAME,
-                volumeName: DEFAULT_VOLUME_NAME,
-                imageRepository: metadata.imageRepository,
-                defaultTag: metadata.defaultTag,
-                digestByTag: metadata.digestByTag,
-                preferredPort,
-                envFilePath: paths.envFilePath,
-                settingsFilePath: paths.settingsFilePath,
-                settingsMountMode: 'directory',
-                headless: true,
-                readinessTimeoutMs: DEFAULT_READINESS_TIMEOUT_MS,
-            });
-
+        if (latestFromLogs) {
             activeMetadata = {
-                ...metadata,
-                lastKnown: {
-                    url: startResult.url,
-                    port: startResult.port,
-                    tag: startResult.tag,
-                    imageRef: startResult.imageRef,
-                    containerName: DEFAULT_CONTAINER_NAME,
-                    volumeName: DEFAULT_VOLUME_NAME,
-                    updatedAtIso: new Date().toISOString(),
+                ...activeMetadata,
+                setup: {
+                    ...activeMetadata.setup,
+                    lastBootstrapEvent: {
+                        ...latestFromLogs,
+                        capturedAtIso: dependencies.nowIso(),
+                    },
                 },
             };
-            await writeLauncherMetadata(
+            await dependencies.writeLauncherMetadataFn(
                 paths.launcherMetadataPath,
                 activeMetadata
             );
-
-            for (const warning of startResult.warnings) {
-                process.stdout.write(`${formatMessage('warn', warning)}\n`);
+            if (isSetupBootstrapEventUsable(latestFromLogs)) {
+                setupEvent = latestFromLogs;
             }
         }
+    }
 
-        let setupEvent = readUsableSetupEventFromMetadata(
-            activeMetadata,
-            setupRequiredNow
+    if (!setupEvent) {
+        throw new LauncherError(
+            'environment',
+            formatSteps(
+                'No usable setup bootstrap link is available from launcher-managed state or runtime logs.',
+                [
+                    'Confirm setup is required (footnote.yaml missing).',
+                    'If the previous setup code expired, restart the runtime and run `footnote setup` again.',
+                    'Run `footnote logs --no-follow` to inspect setup startup events.',
+                ]
+            )
         );
-        if (!setupEvent) {
-            const latestFromLogs = await captureLatestSetupEventFromRuntimeLogs(
-                {
-                    runtime,
-                    configRoot,
-                    configRootHash,
-                    instance: activeMetadata.instance,
-                }
+    }
+
+    const runtimeUrlForSetup =
+        statusBefore.state === 'running' &&
+        statusBefore.ownershipMatches &&
+        statusBefore.url
+            ? statusBefore.url
+            : activeMetadata.lastKnown?.url;
+
+    const setupUrl = resolveSetupUrlForLauncher({
+        setupEvent,
+        runtimeUrl: runtimeUrlForSetup,
+    });
+
+    try {
+        await dependencies.openInBrowserFn(setupUrl);
+        writeLine(
+            dependencies,
+            formatMessage('success', `Opened setup link: ${setupUrl}`)
+        );
+    } catch (error: unknown) {
+        const message =
+            error instanceof Error
+                ? error.message
+                : 'Unknown browser open error.';
+        writeLine(
+            dependencies,
+            formatMessage(
+                'warn',
+                `Could not open browser automatically: ${message}`
+            )
+        );
+        writeLine(
+            dependencies,
+            formatMessage('info', `Setup link: ${setupUrl}`)
+        );
+    }
+
+    return 0;
+};
+
+const handleUpdateCommand = async (
+    context: CommandContext
+): Promise<number> => {
+    const { configRoot, configRootHash, paths, runtime, dependencies } =
+        context;
+
+    const bootstrapResult = await dependencies.bootstrapConfigFilesFn(paths, {
+        createSettingsFile: false,
+    });
+    const metadata = resolveMetadataWithDefaults(bootstrapResult.metadata);
+
+    const settingsMissing = await dependencies.isSettingsFileMissingFn(
+        paths.settingsFilePath
+    );
+    if (settingsMissing) {
+        throw new LauncherError(
+            'environment',
+            formatSteps(
+                `Cannot run update because ${path.basename(paths.settingsFilePath)} is missing.`,
+                [
+                    'Run `footnote setup` to complete first-time setup.',
+                    'Then run `footnote update` again.',
+                ]
+            )
+        );
+    }
+
+    if (bootstrapResult.createdPaths.length > 0) {
+        writeLine(
+            dependencies,
+            formatMessage(
+                'info',
+                `Created config files:\n${bootstrapResult.createdPaths.join('\n')}`
+            )
+        );
+    }
+
+    const stopResult = await runtime.stop({
+        configRoot,
+        configRootHash,
+        instance: metadata.instance,
+        launcherId: LAUNCHER_ID,
+        containerName: DEFAULT_CONTAINER_NAME,
+        volumeName: DEFAULT_VOLUME_NAME,
+    });
+    writeLine(dependencies, formatMessage('info', stopResult.message));
+
+    const preferredPort = metadata.lastKnown?.port ?? DEFAULT_PREFERRED_PORT;
+    const startResult = await runtime.start({
+        configRoot,
+        configRootHash,
+        instance: metadata.instance,
+        launcherId: LAUNCHER_ID,
+        containerName: DEFAULT_CONTAINER_NAME,
+        volumeName: DEFAULT_VOLUME_NAME,
+        imageRepository: metadata.imageRepository,
+        defaultTag: metadata.defaultTag,
+        digestByTag: metadata.digestByTag,
+        preferredPort,
+        envFilePath: paths.envFilePath,
+        settingsFilePath: paths.settingsFilePath,
+        headless: true,
+        readinessTimeoutMs: DEFAULT_READINESS_TIMEOUT_MS,
+    });
+
+    const updatedMetadata: LauncherMetadata = {
+        ...metadata,
+        lastKnown: {
+            url: startResult.url,
+            port: startResult.port,
+            tag: startResult.tag,
+            imageRef: startResult.imageRef,
+            containerName: DEFAULT_CONTAINER_NAME,
+            volumeName: DEFAULT_VOLUME_NAME,
+            updatedAtIso: dependencies.nowIso(),
+        },
+    };
+
+    await dependencies.writeLauncherMetadataFn(
+        paths.launcherMetadataPath,
+        updatedMetadata
+    );
+
+    for (const warning of startResult.warnings) {
+        writeLine(dependencies, formatMessage('warn', warning));
+    }
+
+    writeLine(
+        dependencies,
+        formatMessage(
+            'success',
+            `Footnote update complete at ${startResult.url}`
+        )
+    );
+
+    return 0;
+};
+
+const handleStatusCommand = async (
+    context: CommandContext
+): Promise<number> => {
+    const { configRoot, configRootHash, paths, runtime, dependencies } =
+        context;
+    const metadata = await dependencies.readLauncherMetadataFn(
+        paths.launcherMetadataPath
+    );
+
+    if (!metadata) {
+        printStatus(
+            dependencies,
+            {
+                state: 'not_found',
+                containerName: DEFAULT_CONTAINER_NAME,
+                configRoot,
+                volumeName: DEFAULT_VOLUME_NAME,
+                ownershipMatches: false,
+            },
+            null,
+            configRoot
+        );
+        return 0;
+    }
+
+    const status = await runtime.status({
+        configRoot,
+        configRootHash,
+        instance: metadata.instance,
+        launcherId: LAUNCHER_ID,
+        containerName: DEFAULT_CONTAINER_NAME,
+        volumeName: DEFAULT_VOLUME_NAME,
+    });
+
+    printStatus(dependencies, status, metadata, configRoot);
+    return 0;
+};
+
+const handleStopCommand = async (context: CommandContext): Promise<number> => {
+    const { configRoot, configRootHash, paths, runtime, dependencies } =
+        context;
+    const metadata = await dependencies.readLauncherMetadataFn(
+        paths.launcherMetadataPath
+    );
+
+    if (!metadata) {
+        writeLine(
+            dependencies,
+            formatMessage(
+                'info',
+                'No launcher metadata found; nothing to stop.'
+            )
+        );
+        return 0;
+    }
+
+    const stopResult = await runtime.stop({
+        configRoot,
+        configRootHash,
+        instance: metadata.instance,
+        launcherId: LAUNCHER_ID,
+        containerName: DEFAULT_CONTAINER_NAME,
+        volumeName: DEFAULT_VOLUME_NAME,
+    });
+
+    writeLine(dependencies, formatMessage('info', stopResult.message));
+    return 0;
+};
+
+const handleOpenCommand = async (context: CommandContext): Promise<number> => {
+    const { configRoot, configRootHash, paths, runtime, dependencies } =
+        context;
+    const metadata = await dependencies.readLauncherMetadataFn(
+        paths.launcherMetadataPath
+    );
+
+    if (!metadata?.lastKnown?.url) {
+        throw new LauncherError(
+            'environment',
+            formatSteps('No saved runtime URL is available.', [
+                'Run `footnote start` to initialize and start the runtime.',
+                'Run `footnote status` to inspect current runtime state.',
+            ])
+        );
+    }
+
+    const status = await runtime.status({
+        configRoot,
+        configRootHash,
+        instance: metadata.instance,
+        launcherId: LAUNCHER_ID,
+        containerName: DEFAULT_CONTAINER_NAME,
+        volumeName: DEFAULT_VOLUME_NAME,
+    });
+
+    if (status.state !== 'running' || !status.ownershipMatches) {
+        throw new LauncherError(
+            'environment',
+            formatSteps('Runtime is not currently live.', [
+                'Run `footnote start` to start the launcher-managed runtime.',
+                'Run `footnote logs` to inspect startup output.',
+            ])
+        );
+    }
+
+    const liveUrl = status.url ?? metadata.lastKnown.url;
+    await ensureLiveUrl(liveUrl);
+    await dependencies.openInBrowserFn(liveUrl);
+    writeLine(dependencies, formatMessage('success', `Opened ${liveUrl}`));
+    return 0;
+};
+
+const handleLogsCommand = async (
+    context: CommandContext,
+    follow: boolean
+): Promise<number> => {
+    const { configRoot, configRootHash, paths, runtime, dependencies } =
+        context;
+    const metadata = await dependencies.readLauncherMetadataFn(
+        paths.launcherMetadataPath
+    );
+
+    if (!metadata) {
+        throw new LauncherError(
+            'environment',
+            formatSteps('No launcher metadata found for logs.', [
+                'Run `footnote start` to create launcher-managed resources.',
+                'Run `footnote status` to inspect runtime state.',
+            ])
+        );
+    }
+
+    const lines = runtime.logs({
+        configRoot,
+        configRootHash,
+        instance: metadata.instance,
+        launcherId: LAUNCHER_ID,
+        containerName: DEFAULT_CONTAINER_NAME,
+        follow,
+    });
+
+    for await (const line of lines) {
+        writeLine(dependencies, line.text);
+    }
+
+    return 0;
+};
+
+const executeCommand = async (
+    command: LauncherCommand,
+    context: CommandContext
+): Promise<number> => {
+    switch (command) {
+        case 'start':
+            return handleStartCommand(context, {
+                headless: context.parsed.headless,
+                tagOverride: context.parsed.tag,
+            });
+        case 'setup':
+            return handleSetupCommand(context);
+        case 'update':
+            return handleUpdateCommand(context);
+        case 'status':
+            return handleStatusCommand(context);
+        case 'open':
+            return handleOpenCommand(context);
+        case 'logs':
+            return handleLogsCommand(context, context.parsed.follow);
+        case 'stop':
+            return handleStopCommand(context);
+        case 'help':
+            printHelp(context.dependencies);
+            return 0;
+        case 'info':
+            return 0;
+        default:
+            throw new LauncherError('usage', `Unsupported command: ${command}`);
+    }
+};
+
+const handleInfoCommand = async (context: CommandContext): Promise<number> => {
+    const { dependencies } = context;
+
+    if (!dependencies.isInteractiveTty()) {
+        await handleStatusCommand(context);
+        printReadOnlyInfoSnapshot(dependencies, context.configRoot);
+        return 0;
+    }
+
+    while (true) {
+        const action = await dependencies.promptInfoMenuAction();
+
+        if (action === 'exit') {
+            writeLine(
+                dependencies,
+                formatMessage('info', 'Exiting launcher menu.')
             );
-            if (latestFromLogs) {
-                activeMetadata = {
-                    ...activeMetadata,
-                    setup: {
-                        ...activeMetadata.setup,
-                        lastBootstrapEvent: {
-                            ...latestFromLogs,
-                            capturedAtIso: new Date().toISOString(),
-                        },
-                    },
-                };
-                await writeLauncherMetadata(
-                    paths.launcherMetadataPath,
-                    activeMetadata
-                );
-                if (isSetupBootstrapEventUsable(latestFromLogs)) {
-                    setupEvent = latestFromLogs;
-                }
-            }
+            return 0;
         }
 
-        if (!setupEvent) {
-            throw new LauncherError(
-                'environment',
-                formatSteps(
-                    'No usable setup bootstrap link is available from launcher-managed state or runtime logs.',
-                    [
-                        'Confirm setup is required (footnote.yaml missing).',
-                        'If the previous setup code expired, restart the runtime and run `footnote setup` again.',
-                        'Run `footnote logs --no-follow` to inspect setup startup events.',
-                    ]
-                )
-            );
+        if (action === 'help') {
+            printHelp(dependencies);
+            continue;
         }
-
-        const runtimeUrlForSetup =
-            statusBefore.state === 'running' &&
-            statusBefore.ownershipMatches &&
-            statusBefore.url
-                ? statusBefore.url
-                : activeMetadata.lastKnown?.url;
-
-        const setupUrl = resolveSetupUrlForLauncher({
-            setupEvent,
-            runtimeUrl: runtimeUrlForSetup,
-        });
 
         try {
-            await openInBrowser(setupUrl);
-            process.stdout.write(
-                `${formatMessage('success', `Opened setup link: ${setupUrl}`)}\n`
-            );
+            if (action === 'logs_no_follow') {
+                await handleLogsCommand(context, false);
+                continue;
+            }
+            await executeCommand(action, context);
         } catch (error: unknown) {
             const message =
-                error instanceof Error
-                    ? error.message
-                    : 'Unknown browser open error.';
-            process.stdout.write(
-                `${formatMessage('warn', `Could not open browser automatically: ${message}`)}\n`
-            );
-            process.stdout.write(
-                `${formatMessage('info', `Setup link: ${setupUrl}`)}\n`
-            );
+                error instanceof Error ? error.message : String(error);
+            writeLine(dependencies, formatMessage('error', message));
         }
+    }
+};
+
+/**
+ * Parses launcher CLI arguments and orchestrates command routing for runtime operations.
+ * This function decides command flow and exit semantics, while delegating runtime actions to DockerRuntime and shared launcher-core helpers.
+ * @param argv Raw CLI arguments after the executable name.
+ * @returns Promise<number> Exit code following launcher contract (0/1/2/3).
+ */
+export const runCli = async (
+    argv: readonly string[],
+    dependencyOverrides: Partial<CliDependencies> = {}
+): Promise<number> => {
+    const dependencies: CliDependencies = {
+        ...DEFAULT_CLI_DEPENDENCIES,
+        ...dependencyOverrides,
+    };
+
+    const parsed = dependencies.parseArgs(argv);
+
+    if (parsed.command === 'help') {
+        printHelp(dependencies);
         return 0;
     }
 
-    const metadata = await readLauncherMetadata(paths.launcherMetadataPath);
+    const configRoot = path.resolve(
+        parsed.configDir ??
+            dependencies.resolveDefaultConfigRootFn(
+                process.platform,
+                process.env
+            )
+    );
+    const paths = dependencies.resolveConfigPathsFn(configRoot);
+    const configRootHash = dependencies.computeConfigRootHashFn(configRoot);
 
-    if (parsed.command === 'status') {
-        if (!metadata) {
-            printStatus(
-                {
-                    state: 'not_found',
-                    containerName: DEFAULT_CONTAINER_NAME,
-                    configRoot,
-                    volumeName: DEFAULT_VOLUME_NAME,
-                    ownershipMatches: false,
-                },
-                null,
-                configRoot
-            );
-            return 0;
-        }
+    const context: CommandContext = {
+        parsed,
+        configRoot,
+        paths,
+        configRootHash,
+        runtime: dependencies.createRuntime(),
+        dependencies,
+    };
 
-        const status = await runtime.status({
-            configRoot,
-            configRootHash,
-            instance: metadata.instance,
-            launcherId: LAUNCHER_ID,
-            containerName: DEFAULT_CONTAINER_NAME,
-            volumeName: DEFAULT_VOLUME_NAME,
-        });
-
-        printStatus(status, metadata, configRoot);
-        return 0;
+    if (parsed.command === 'info') {
+        return handleInfoCommand(context);
     }
 
-    if (parsed.command === 'stop') {
-        if (!metadata) {
-            process.stdout.write(
-                `${formatMessage('info', 'No launcher metadata found; nothing to stop.')}\n`
-            );
-            return 0;
-        }
-
-        const stopResult = await runtime.stop({
-            configRoot,
-            configRootHash,
-            instance: metadata.instance,
-            launcherId: LAUNCHER_ID,
-            containerName: DEFAULT_CONTAINER_NAME,
-            volumeName: DEFAULT_VOLUME_NAME,
-        });
-
-        process.stdout.write(`${formatMessage('info', stopResult.message)}\n`);
-        return 0;
-    }
-
-    if (parsed.command === 'open') {
-        if (!metadata?.lastKnown?.url) {
-            throw new LauncherError(
-                'environment',
-                formatSteps('No saved runtime URL is available.', [
-                    'Run `footnote start` to initialize and start the runtime.',
-                    'Run `footnote status` to inspect current runtime state.',
-                ])
-            );
-        }
-
-        const status = await runtime.status({
-            configRoot,
-            configRootHash,
-            instance: metadata.instance,
-            launcherId: LAUNCHER_ID,
-            containerName: DEFAULT_CONTAINER_NAME,
-            volumeName: DEFAULT_VOLUME_NAME,
-        });
-
-        if (status.state !== 'running' || !status.ownershipMatches) {
-            throw new LauncherError(
-                'environment',
-                formatSteps('Runtime is not currently live.', [
-                    'Run `footnote start` to start the launcher-managed runtime.',
-                    'Run `footnote logs` to inspect startup output.',
-                ])
-            );
-        }
-
-        const liveUrl = status.url ?? metadata.lastKnown.url;
-        await ensureLiveUrl(liveUrl);
-        await openInBrowser(liveUrl);
-        process.stdout.write(
-            `${formatMessage('success', `Opened ${liveUrl}`)}\n`
-        );
-        return 0;
-    }
-
-    if (parsed.command === 'logs') {
-        if (!metadata) {
-            throw new LauncherError(
-                'environment',
-                formatSteps('No launcher metadata found for logs.', [
-                    'Run `footnote start` to create launcher-managed resources.',
-                    'Run `footnote status` to inspect runtime state.',
-                ])
-            );
-        }
-
-        const lines = runtime.logs({
-            configRoot,
-            configRootHash,
-            instance: metadata.instance,
-            launcherId: LAUNCHER_ID,
-            containerName: DEFAULT_CONTAINER_NAME,
-            follow: parsed.follow,
-        });
-
-        for await (const line of lines) {
-            process.stdout.write(`${line.text}\n`);
-        }
-
-        return 0;
-    }
-
-    throw new LauncherError('usage', `Unsupported command: ${parsed.command}`);
+    return executeCommand(parsed.command, context);
 };
 
 /**

--- a/packages/launcher-cli/src/cli.ts
+++ b/packages/launcher-cli/src/cli.ts
@@ -515,6 +515,20 @@ const handleSetupCommand = async (context: CommandContext): Promise<number> => {
     const setupRequiredNow = await dependencies.isSettingsFileMissingFn(
         paths.settingsFilePath
     );
+    const shouldShowBootstrap = setupRequiredNow;
+
+    if (!shouldShowBootstrap) {
+        throw new LauncherError(
+            'environment',
+            formatSteps(
+                `${path.basename(paths.settingsFilePath)} already exists; setup bootstrap is not required.`,
+                [
+                    'Run `footnote open` to open the current runtime URL.',
+                    'Run `footnote status` to inspect runtime state.',
+                ]
+            )
+        );
+    }
 
     const statusBefore = await runtime.status({
         configRoot,
@@ -574,11 +588,10 @@ const handleSetupCommand = async (context: CommandContext): Promise<number> => {
         }
     }
 
-    let setupEvent = readUsableSetupEventFromMetadata(
-        activeMetadata,
-        setupRequiredNow
-    );
-    if (!setupEvent) {
+    let setupEvent = shouldShowBootstrap
+        ? readUsableSetupEventFromMetadata(activeMetadata, shouldShowBootstrap)
+        : null;
+    if (!setupEvent && shouldShowBootstrap) {
         const latestFromLogs = await captureLatestSetupEventFromRuntimeLogs({
             runtime,
             configRoot,
@@ -941,7 +954,13 @@ const handleInfoCommand = async (context: CommandContext): Promise<number> => {
     const { dependencies } = context;
 
     if (!dependencies.isInteractiveTty()) {
-        await handleStatusCommand(context);
+        try {
+            await handleStatusCommand(context);
+        } catch (error: unknown) {
+            const message =
+                error instanceof Error ? error.message : String(error);
+            writeLine(dependencies, formatMessage('warn', message));
+        }
         printReadOnlyInfoSnapshot(dependencies, context.configRoot);
         return 0;
     }
@@ -982,7 +1001,7 @@ const handleInfoCommand = async (context: CommandContext): Promise<number> => {
  * @param argv Raw CLI arguments after the executable name.
  * @returns Promise<number> Exit code following launcher contract (0/1/2/3).
  */
-export const runCli = async (
+export const runCliWithDeps = async (
     argv: readonly string[],
     dependencyOverrides: Partial<CliDependencies> = {}
 ): Promise<number> => {
@@ -1023,6 +1042,9 @@ export const runCli = async (
 
     return executeCommand(parsed.command, context);
 };
+
+export const runCli = async (argv: readonly string[]): Promise<number> =>
+    runCliWithDeps(argv);
 
 /**
  * Executes the CLI orchestration and writes process exit code plus error output.


### PR DESCRIPTION
## Summary
- Add a new `footnote info` launcher flow that opens an interactive menu in TTY mode and prints a read-only snapshot in non-interactive mode.
- Change the no-argument launcher behavior from `start` to `info`, and add `update` as a first-class command.
- Extend launcher orchestration to support update restart flow, menu actions, and improved setup/status handling.
- Update README and CI docs to describe the new invocation model and recommend explicit commands for automation.
- Add and expand CLI tests for argument parsing, update behavior, setup handling, and info menu routing.

## Testing
- Added unit tests in `packages/launcher-cli/src/args.test.ts` covering default `info`, `info`, and `update` parsing.
- Added unit tests in `packages/launcher-cli/src/cli.test.ts` covering info snapshot output, update failure guidance, update restart flow, and menu selection routing.
- Not run: `pnpm lint:fix`
- Not run: `pnpm lint`
- Not run: `pnpm review`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Interactive launcher menu now opens when starting the app without specifying a command, replacing automatic startup behavior
  * Added support for explicit `update` command for automation workflows

* **Documentation**
  * Updated quick-start guide with clearer step-by-step instructions for launching the app
  * Enhanced documentation on launcher behavior and recommended commands for automated workflows

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/footnote-ai/footnote/pull/396?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->