### PR TITLE
Handle review parse and routing failures explicitly

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -33,7 +33,7 @@ The web package uses a layered stylesheet entrypoint at
   failures.
 - [Decisions](./decisions/): durable technical choices and why they were made.
 - [Proposals](./proposals/): unadopted or exploratory ideas.
-- [Status](./status/): branch-level implementation tracking documents.
+- [Status](./status.md): branch-level implementation tracking document.
 - [API](./api/README.md): OpenAPI source, operation mapping, and code-linking
   rules.
 - [AI](./ai/README.md): contributor workflow for AI-assisted changes.

--- a/docs/architecture/workflow.md
+++ b/docs/architecture/workflow.md
@@ -169,6 +169,12 @@ Assess may also emit TRACE alignment outputs:
 These assess outputs are used for lineage and metadata finalization. They stay
 inside workflow policy and limits.
 
+Review decision parsing uses explicit expected-failure results. If assess
+output is empty, not a JSON object, invalid JSON, or schema-invalid, the engine
+records a failed `assess` step and fails open to the latest successful draft.
+The failed step records the parse reason as serializable signals, not raw assess
+output.
+
 If the decision is `revise`, the engine may run planner re-entry and then a
 follow-up `generate` step for refinement.
 
@@ -211,6 +217,10 @@ Routing is fail-open where possible:
 - transient provider or upstream failures advance to the next chain entry
 - non-transient errors stop chain advancement for that step
 
+Routing-chain exhaustion is expected workflow data. Review and initial
+generation paths carry the exhausted reason code and attempts directly instead
+of converting those outcomes through exception-message control flow.
+
 Execution metadata and step signals record selected profile lineage, fallback
 attempts, and routing reason codes for trace inspection.
 
@@ -238,6 +248,17 @@ For `assess` steps, use `reviewDecision` and `reviewReason`. When
 `reviewDecision` is `revise`, `signals` may also include
 `revisionInstruction`. Assess signals may also include TRACE alignment and
 flattened final posture axes.
+
+Failed assess steps caused by invalid review parser output do not emit
+`reviewDecision`, `reviewReason`, or `revisionInstruction`. They may emit:
+
+- `reviewParseStatus`
+- `reviewParseFailureReason`
+- `reviewParseFailureMessage`
+- `reviewParseOutputLength`
+- `reviewParseIssueCount`
+- `reviewParseFirstIssuePath`
+- `reviewParseFirstIssueCode`
 
 Example assess signals:
 

--- a/docs/architecture/workflow.md
+++ b/docs/architecture/workflow.md
@@ -154,13 +154,13 @@ The `generate` step produces the current draft. The `assess` step returns
 `reviewDecision` and `reviewReason`.
 
 `reviewDecision` is either `finalize` or `revise`. When the decision is
-`revise`, `assess` may also emit `revisionInstruction`. `reviewReason` explains
+`revise`, `assess` may also return `revisionInstruction`. `reviewReason` explains
 why revision is needed. `revisionInstruction` gives concrete guidance for the
 follow-up refinement `generate` step.
 
-`revisionInstruction` is revise-only and is not emitted for `finalize`.
+`revisionInstruction` is revise-only and is not recorded for `finalize`.
 
-Assess may also emit TRACE alignment outputs:
+Assess may also return TRACE alignment outputs:
 
 - `traceAlignment`: `aligned` or `misaligned`
 - `traceAlignmentReason`: short reason when `traceAlignment` is `misaligned`
@@ -249,8 +249,8 @@ For `assess` steps, use `reviewDecision` and `reviewReason`. When
 `revisionInstruction`. Assess signals may also include TRACE alignment and
 flattened final posture axes.
 
-Failed assess steps caused by invalid review parser output do not emit
-`reviewDecision`, `reviewReason`, or `revisionInstruction`. They may emit:
+Failed assess steps caused by invalid review parser output do not include
+`reviewDecision`, `reviewReason`, or `revisionInstruction`. They may include:
 
 - `reviewParseStatus`
 - `reviewParseFailureReason`
@@ -301,7 +301,7 @@ When generation never occurred:
 
 - `steps` may be empty when termination happens before the first executable
   step
-- if any step executed before termination, emitted steps stay chronologically
+- if any step executed before termination, recorded steps stay chronologically
   ordered with valid parent references
 
 Profiles use the shared termination reason vocabulary rather than ad hoc
@@ -382,14 +382,14 @@ make a run look cleaner.
 
 Use this split when ownership is unclear:
 
-| Concern             | Engine core                                                                                    | Workflow profile                                                        | Adapters and callers                                       |
-| ------------------- | ---------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------- | ---------------------------------------------------------- |
-| Step legality       | handles the legality check before execution                                                    | declares intended flow and policy toggles                               | supplies policy and uses engine legality results           |
-| Limits              | handles hard-stop checks and stop-reason mapping                                               | declares default budgets within the shared limits model                 | passes config and surfaces the final result                |
-| Workflow state      | tracks step count, token totals, current step, and lineage progression                         | declares expected step shape                                            | treats engine-produced workflow state as the runtime state |
-| Step execution      | runs concrete steps today (`generate`, `assess`, refinement `generate`) and emits step records | defines step-specific behavior such as review parsing                   | builds requests and calls runtimes or providers            |
-| Termination reasons | assigns shared termination reasons                                                             | can request stop using shared reason handling                           | persists and returns engine-assigned reasons unchanged     |
-| Fail-open behavior  | handles degraded fail-open workflow behavior                                                   | can define recoverable profile behavior within shared fail-open meaning | keeps telemetry or persistence failures out of user blocks |
+| Concern             | Engine core                                                                                       | Workflow profile                                                        | Adapters and callers                                       |
+| ------------------- | ------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------- | ---------------------------------------------------------- |
+| Step legality       | handles the legality check before execution                                                       | declares intended flow and policy toggles                               | supplies policy and uses engine legality results           |
+| Limits              | handles hard-stop checks and stop-reason mapping                                                  | declares default budgets within the shared limits model                 | passes config and surfaces the final result                |
+| Workflow state      | tracks step count, token totals, current step, and lineage progression                            | declares expected step shape                                            | treats engine-produced workflow state as the runtime state |
+| Step execution      | runs concrete steps today (`generate`, `assess`, refinement `generate`) and records step outcomes | defines step-specific behavior such as review parsing                   | builds requests and calls runtimes or providers            |
+| Termination reasons | assigns shared termination reasons                                                                | can request stop using shared reason handling                           | persists and returns engine-assigned reasons unchanged     |
+| Fail-open behavior  | handles degraded fail-open workflow behavior                                                      | can define recoverable profile behavior within shared fail-open meaning | keeps telemetry or persistence failures out of user blocks |
 
 These rules stay stable as profiles expand:
 

--- a/docs/status.md
+++ b/docs/status.md
@@ -1,0 +1,87 @@
+# Trust Boundary Work Status
+
+This file tracks the planned branches for making trust-boundary code easier to
+inspect. Use explicit TypeScript shapes first. Use `neverthrow` for expected
+failures that callers need to handle with a concrete reason.
+
+### 1) review-routing
+
+Branch: `chore/trust-boundary-neverthrow-review-routing`  
+Status: `todo`
+
+Start here. This branch should clean up the review path where expected failures
+are still a little too implicit.
+
+The important cases are review decision parsing and routing-chain exhaustion.
+Right now, review parsing can collapse to `null`, and some routing failures move
+through `throw new Error(reasonCode)` before being mapped back into workflow
+metadata. That works, but it hides useful meaning from the type system and makes
+the reader chase string comparisons.
+
+Use `neverthrow` to return those outcomes directly. A parse failure should carry
+the parse reason. A routing-chain failure should carry its reason code as data,
+not as an exception message. The workflow must still fail open in the same
+situations it does today.
+
+Keep this branch small. It should touch review parsing, the review loop, initial
+generation routing, and only the profile wiring needed to support the new return
+types.
+
+### 2) context-step-outcomes
+
+Branch: `chore/trust-boundary-neverthrow-context-step-outcomes`  
+Status: `todo`
+
+This branch is about context steps: web search, weather, reverse image search,
+and similar tool-backed work.
+
+Make the outcome shape state the actual result: executed, failed, skipped, or
+needs user clarification. Do not leave these states as loose objects where
+unrelated fields can appear together by accident.
+
+Keep the current behavior. Tool failures should still be non-blocking. If a tool
+needs clarification, the workflow should still stop before generation and return
+that clarification to the caller. This change should make those states harder to
+misuse and easier to inspect.
+
+Keep public contracts serializable. Anything crossing package boundaries must
+remain plain data.
+
+### 3) metadata-normalization
+
+Branch: `chore/trust-boundary-metadata-domain-normalization`  
+Status: `todo`
+
+This branch should make response metadata easier to reason about.
+
+The metadata builder currently does several things at once: it classifies
+provenance, normalizes execution reason codes, derives TRACE fields, logs missing
+data, and fills defaults. That makes the function harder to test and harder to
+audit.
+
+Pull out pure helpers for the parts that are real domain decisions. For example:
+given this execution status and reason code, what generation reason should be
+recorded? Given this TRACE target and final value, should a finalization reason
+be stored?
+
+Do not change the meaning of provenance, TRACE, review labels, or cost fields in
+this branch. Keep the same behavior and move each decision into a smaller typed
+function.
+
+### 4) step-signal-typing
+
+Branch: `chore/trust-boundary-step-signal-typing`  
+Status: `todo`
+
+This branch should reduce the places where workflow step data is stored as a
+generic signal bag.
+
+Signals are useful because they keep workflow records flexible, but some of them
+have become important enough that they deserve names and types. Assess decisions,
+routing-chain details, clarification signals, and receipt-facing values are good
+places to look first.
+
+Do this gradually. This is not a redesign of every workflow record. Type the
+fields that readers and UI code already depend on, so future changes cannot
+drift silently.
+

--- a/docs/status.md
+++ b/docs/status.md
@@ -4,7 +4,7 @@ This file tracks the planned branches for making trust-boundary code easier to
 inspect. Use explicit TypeScript shapes first. Use `neverthrow` for expected
 failures that callers need to handle with a concrete reason.
 
-### 1) review-routing
+## 1) review-routing
 
 Branch: `chore/trust-boundary-neverthrow-review-routing`  
 Status: `done`
@@ -27,7 +27,7 @@ Keep this branch small. It should touch review parsing, the review loop, initial
 generation routing, and only the profile wiring needed to support the new return
 types.
 
-### 2) context-step-outcomes
+## 2) context-step-outcomes
 
 Branch: `chore/trust-boundary-neverthrow-context-step-outcomes`  
 Status: `todo`
@@ -47,7 +47,7 @@ misuse and easier to inspect.
 Keep public contracts serializable. Anything crossing package boundaries must
 remain plain data.
 
-### 3) metadata-normalization
+## 3) metadata-normalization
 
 Branch: `chore/trust-boundary-metadata-domain-normalization`  
 Status: `todo`
@@ -68,7 +68,7 @@ Do not change the meaning of provenance, TRACE, review labels, or cost fields in
 this branch. Keep the same behavior and move each decision into a smaller typed
 function.
 
-### 4) step-signal-typing
+## 4) step-signal-typing
 
 Branch: `chore/trust-boundary-step-signal-typing`  
 Status: `todo`

--- a/docs/status.md
+++ b/docs/status.md
@@ -7,21 +7,21 @@ failures that callers need to handle with a concrete reason.
 ### 1) review-routing
 
 Branch: `chore/trust-boundary-neverthrow-review-routing`  
-Status: `todo`
+Status: `done`
 
-Start here. This branch should clean up the review path where expected failures
-are still a little too implicit.
+This branch cleaned up the review path where expected failures were still a
+little too implicit.
 
 The important cases are review decision parsing and routing-chain exhaustion.
-Right now, review parsing can collapse to `null`, and some routing failures move
-through `throw new Error(reasonCode)` before being mapped back into workflow
-metadata. That works, but it hides useful meaning from the type system and makes
-the reader chase string comparisons.
+Before this branch, review parsing could collapse to `null`, and some routing
+failures moved through `throw new Error(reasonCode)` before being mapped back
+into workflow metadata. That worked, but it hid useful meaning from the type
+system and made the reader chase string comparisons.
 
-Use `neverthrow` to return those outcomes directly. A parse failure should carry
-the parse reason. A routing-chain failure should carry its reason code as data,
-not as an exception message. The workflow must still fail open in the same
-situations it does today.
+`neverthrow` now returns those outcomes directly. A parse failure carries the
+parse reason. A routing-chain failure carries its reason code as data, not as an
+exception message. The workflow still fails open in the same situations it did
+before.
 
 Keep this branch small. It should touch review parsing, the review loop, initial
 generation routing, and only the profile wiring needed to support the new return
@@ -84,4 +84,3 @@ places to look first.
 Do this gradually. This is not a redesign of every workflow record. Type the
 fields that readers and UI code already depend on, so future changes cannot
 drift silently.
-

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -17,6 +17,7 @@
         "express": "catalog:",
         "express-rate-limit": "catalog:",
         "js-yaml": "catalog:",
+        "neverthrow": "catalog:",
         "nodemailer": "catalog:",
         "winston": "catalog:",
         "winston-daily-rotate-file": "catalog:",

--- a/packages/backend/src/services/chatService.ts
+++ b/packages/backend/src/services/chatService.ts
@@ -33,6 +33,7 @@ import type {
     PostChatRequest,
     PostChatResponse,
 } from '@footnote/contracts/web';
+import type { Result } from 'neverthrow';
 import type {
     AssistantResponseMetadata,
     AssistantUsage,
@@ -83,16 +84,29 @@ import { runtimeConfig } from '../config.js';
 import { buildToolClarificationResponse } from './tools/toolClarificationResponse.js';
 import { buildWeatherToolFailureResponse } from './tools/weatherToolFailureResponse.js';
 import { resolveStepRoutingChain } from './stepRoutingChains.js';
-import { executeStepRoutingChain } from './stepRoutingExecutor.js';
+import {
+    executeStepRoutingChain,
+    type RoutingChainAttemptLog,
+} from './stepRoutingExecutor.js';
 import type { ConversationContextEnvelope } from './conversationContextService.js';
 import { sanitizeReviewModuleIds } from './reviewModules.js';
 import {
     fromAssessSignalsToFinalTemperament,
     hasDifferentTemperament,
 } from './traceAlignmentSignals.js';
+import {
+    toRoutingChainResult,
+    type RoutingChainFailure,
+} from './routingChainResult.js';
 
 const SURFACED_NO_GENERATION_MESSAGE =
     'I could not generate a response for this request.';
+
+type GenerateWithChainSuccess = {
+    generationResult: GenerationResult;
+    selectedProfile: ModelProfile;
+    attempts: RoutingChainAttemptLog[];
+};
 
 /**
  * Returns context-step results in canonical order for downstream consumers.
@@ -1025,24 +1039,9 @@ export const createChatService = ({
             );
             const runGenerateWithChain = async (
                 request: GenerationRequest
-            ): Promise<{
-                generationResult: GenerationResult;
-                selectedProfile: ModelProfile;
-                attempts: Array<{
-                    index: number;
-                    step: string;
-                    profileId: string;
-                    provider?: string;
-                    model?: string;
-                    status: string;
-                    reasonCode?: string;
-                    errorMessage?: string;
-                    chooseOneUsed: boolean;
-                    chooseOneCandidates?: string[];
-                    chooseOneSelectedIndex?: number;
-                    seedKeyType?: 'session_id' | 'correlation_id';
-                }>;
-            }> => {
+            ): Promise<
+                Result<GenerateWithChainSuccess, RoutingChainFailure>
+            > => {
                 const chainResult = await executeStepRoutingChain({
                     step: 'generate',
                     candidates: generateProfileCandidates,
@@ -1056,14 +1055,12 @@ export const createChatService = ({
                             capabilities: profile.capabilities,
                         }),
                 });
-                if (chainResult.status !== 'executed') {
-                    throw new Error(chainResult.reasonCode);
-                }
-                return {
-                    generationResult: chainResult.value,
-                    selectedProfile: chainResult.selected.profile,
-                    attempts: chainResult.attempts,
-                };
+                const routingResult = toRoutingChainResult(chainResult);
+                return routingResult.map((executedResult) => ({
+                    generationResult: executedResult.value,
+                    selectedProfile: executedResult.selected.profile,
+                    attempts: executedResult.attempts,
+                }));
             };
 
             return {
@@ -1364,14 +1361,41 @@ export const createChatService = ({
                                     await runGenerateWithChain(
                                         effectiveGenerationRequest
                                     );
-                                generationResult =
-                                    chainGenerationResult.generationResult;
-                                routedGenerationSelectedProfile =
-                                    chainGenerationResult.selectedProfile;
-                                recordUsageForStep(
-                                    generationResult,
-                                    effectiveGenerationRequest.model
-                                );
+                                if (chainGenerationResult.isErr()) {
+                                    logger.warn(
+                                        'Fallback generation after internal no-generation exhausted routing chain; preserving no-generation lineage.',
+                                        {
+                                            workflowName:
+                                                workflowProfile.workflowName,
+                                            reasonCode:
+                                                chainGenerationResult.error
+                                                    .reasonCode,
+                                            terminationReason:
+                                                workflowResult.workflowLineage
+                                                    .terminationReason,
+                                            routingChainAttemptCount:
+                                                chainGenerationResult.error
+                                                    .attempts.length,
+                                        }
+                                    );
+                                    generationResult = {
+                                        text: SURFACED_NO_GENERATION_MESSAGE,
+                                        model: effectiveGenerationRequest.model,
+                                        provenance: 'Inferred',
+                                        citations: [],
+                                    };
+                                } else {
+                                    generationResult =
+                                        chainGenerationResult.value
+                                            .generationResult;
+                                    routedGenerationSelectedProfile =
+                                        chainGenerationResult.value
+                                            .selectedProfile;
+                                    recordUsageForStep(
+                                        generationResult,
+                                        effectiveGenerationRequest.model
+                                    );
+                                }
                             } catch (error) {
                                 logger.warn(
                                     'Fallback generation after internal no-generation failed; preserving no-generation lineage.',
@@ -1439,13 +1463,31 @@ export const createChatService = ({
                 const chainGenerationResult = await runGenerateWithChain(
                     effectiveGenerationRequest
                 );
-                generationResult = chainGenerationResult.generationResult;
-                routedGenerationSelectedProfile =
-                    chainGenerationResult.selectedProfile;
-                recordUsageForStep(
-                    generationResult,
-                    effectiveGenerationRequest.model
-                );
+                if (chainGenerationResult.isErr()) {
+                    logger.warn(
+                        'Initial generation routing chain failed; surfacing no-generation response.',
+                        {
+                            reasonCode: chainGenerationResult.error.reasonCode,
+                            routingChainAttemptCount:
+                                chainGenerationResult.error.attempts.length,
+                        }
+                    );
+                    generationResult = {
+                        text: SURFACED_NO_GENERATION_MESSAGE,
+                        model: effectiveGenerationRequest.model,
+                        provenance: 'Inferred',
+                        citations: [],
+                    };
+                } else {
+                    generationResult =
+                        chainGenerationResult.value.generationResult;
+                    routedGenerationSelectedProfile =
+                        chainGenerationResult.value.selectedProfile;
+                    recordUsageForStep(
+                        generationResult,
+                        effectiveGenerationRequest.model
+                    );
+                }
             }
 
             return {

--- a/packages/backend/src/services/chatService.ts
+++ b/packages/backend/src/services/chatService.ts
@@ -1388,6 +1388,7 @@ export const createChatService = ({
                                     generationResult =
                                         chainGenerationResult.value
                                             .generationResult;
+                                    fallbackAfterInternalNoGeneration = true;
                                     routedGenerationSelectedProfile =
                                         chainGenerationResult.value
                                             .selectedProfile;
@@ -1420,7 +1421,6 @@ export const createChatService = ({
                                     citations: [],
                                 };
                             }
-                            fallbackAfterInternalNoGeneration = true;
                             break;
                         }
                         if (

--- a/packages/backend/src/services/routingChainResult.ts
+++ b/packages/backend/src/services/routingChainResult.ts
@@ -28,6 +28,12 @@ export type ExecutedRoutingChainResult<TSuccess> = Extract<
     { status: 'executed' }
 >;
 
+/**
+ * Maps a broad ExecutionReasonCode into the collapsed RoutingChainFailureReasonCode set: non-transient failures keep their code, and all other exhausted-chain reasons collapse to routing_chain_exhausted.
+ *
+ * @param reasonCode Execution reason emitted by the routing-chain executor.
+ * @returns RoutingChainFailureReasonCode used by fail-open routing callers.
+ */
 export const toRoutingChainFailureReasonCode = (
     reasonCode: ExecutionReasonCode
 ): RoutingChainFailureReasonCode =>
@@ -35,6 +41,12 @@ export const toRoutingChainFailureReasonCode = (
         ? 'routing_chain_non_transient_error'
         : 'routing_chain_exhausted';
 
+/**
+ * Converts a RoutingChainExecutionResult into ok(chainResult) for executed chains or err(RoutingChainFailure) with collapsed reasonCode and attempts for non-executed chains.
+ *
+ * @param chainResult Routing-chain executor result to convert.
+ * @returns Result containing the executed chain or a RoutingChainFailure.
+ */
 export const toRoutingChainResult = <TSuccess>(
     chainResult: RoutingChainExecutionResult<TSuccess>
 ): Result<ExecutedRoutingChainResult<TSuccess>, RoutingChainFailure> =>

--- a/packages/backend/src/services/routingChainResult.ts
+++ b/packages/backend/src/services/routingChainResult.ts
@@ -1,0 +1,48 @@
+/**
+ * @description: Converts workflow routing-chain execution outcomes into typed
+ * expected-failure Results.
+ * @footnote-scope: utility
+ * @footnote-module: RoutingChainResult
+ * @footnote-risk: medium - Incorrect failure mapping can hide routing exhaustion causes.
+ * @footnote-ethics: medium - Routing failure clarity supports auditable fail-open behavior.
+ */
+import type { ExecutionReasonCode } from '@footnote/contracts/policy';
+import { err, ok, type Result } from 'neverthrow';
+import type {
+    RoutingChainAttemptLog,
+    RoutingChainExecutionResult,
+} from './stepRoutingExecutor.js';
+
+export type RoutingChainFailureReasonCode = Extract<
+    ExecutionReasonCode,
+    'routing_chain_exhausted' | 'routing_chain_non_transient_error'
+>;
+
+export type RoutingChainFailure = {
+    reasonCode: RoutingChainFailureReasonCode;
+    attempts: RoutingChainAttemptLog[];
+};
+
+export type ExecutedRoutingChainResult<TSuccess> = Extract<
+    RoutingChainExecutionResult<TSuccess>,
+    { status: 'executed' }
+>;
+
+export const toRoutingChainFailureReasonCode = (
+    reasonCode: ExecutionReasonCode
+): RoutingChainFailureReasonCode =>
+    reasonCode === 'routing_chain_non_transient_error'
+        ? 'routing_chain_non_transient_error'
+        : 'routing_chain_exhausted';
+
+export const toRoutingChainResult = <TSuccess>(
+    chainResult: RoutingChainExecutionResult<TSuccess>
+): Result<ExecutedRoutingChainResult<TSuccess>, RoutingChainFailure> =>
+    chainResult.status === 'executed'
+        ? ok(chainResult)
+        : err({
+              reasonCode: toRoutingChainFailureReasonCode(
+                  chainResult.reasonCode
+              ),
+              attempts: chainResult.attempts,
+          });

--- a/packages/backend/src/services/workflowEngine.ts
+++ b/packages/backend/src/services/workflowEngine.ts
@@ -41,8 +41,8 @@ import {
 import {
     DEFAULT_REVIEW_DECISION_PROMPT,
     DEFAULT_REVISION_PROMPT_PREFIX,
-    parseReviewDecisionOutput,
-    type ReviewDecision,
+    parseReviewDecisionOutputResult,
+    type ReviewDecisionParseResult,
 } from './workflowEngine/reviewDecision.js';
 import { isWorkflowTransitionAllowed } from './workflowEngine/transitions.js';
 import {
@@ -70,6 +70,7 @@ import {
 } from './stepRoutingExecutor.js';
 import type { ResolvedStepRoutingCandidate } from './stepRoutingChains.js';
 import { buildRoutingChainSignals } from './workflowEngine/routingSignals.js';
+import { toRoutingChainResult } from './routingChainResult.js';
 
 /**
  * Canonical Execution Contract workflow-policy surface.
@@ -92,18 +93,19 @@ export {
     DEFAULT_REVIEW_DECISION_PROMPT,
     DEFAULT_REVISION_PROMPT_PREFIX,
     parseReviewDecisionOutput,
+    parseReviewDecisionOutputResult,
 } from './workflowEngine/reviewDecision.js';
 
 export type BoundedReviewProfileStrategy = {
     reviewDecisionPrompt: string;
     revisionPromptPrefix: string;
-    parseReviewDecision: (text: string) => ReviewDecision | null;
+    parseReviewDecision: (text: string) => ReviewDecisionParseResult;
 };
 
 export const BOUNDED_REVIEW_PROFILE_STRATEGY: BoundedReviewProfileStrategy = {
     reviewDecisionPrompt: DEFAULT_REVIEW_DECISION_PROMPT,
     revisionPromptPrefix: DEFAULT_REVISION_PROMPT_PREFIX,
-    parseReviewDecision: parseReviewDecisionOutput,
+    parseReviewDecision: parseReviewDecisionOutputResult,
 };
 
 export type ReviewWorkflowRuntimeConfig = {
@@ -137,7 +139,7 @@ export type RunBoundedReviewWorkflowInput = {
     reviewDecisionPrompt?: string;
     revisionPromptPrefix?: string;
     reviewModuleIds?: ReviewModuleId[];
-    parseReviewDecision?: (text: string) => ReviewDecision | null;
+    parseReviewDecision?: (text: string) => ReviewDecisionParseResult;
     captureUsage: (
         result: GenerationResult,
         requestedModel: string | undefined
@@ -221,6 +223,7 @@ type LimitStopEvaluation = {
     workflowStatus: WorkflowRecord['status'];
     exhaustedLimitKey?: WorkflowLimitKey;
 };
+
 export { isWorkflowTransitionAllowed } from './workflowEngine/transitions.js';
 export {
     applyStepExecutionToState,
@@ -918,77 +921,125 @@ export const runBoundedReviewWorkflow = async ({
                                 capabilities: profile.capabilities,
                             }),
                     });
-                    if (chainResult.status !== 'executed') {
-                        throw new Error(chainResult.reasonCode);
-                    }
-                    initialRoutingChainAttempts = chainResult.attempts;
-                    initialRoutedProfile = {
-                        profileId: chainResult.selected.profile.id,
-                        provider: chainResult.selected.profile.provider,
-                        model: chainResult.selected.profile.providerModel,
-                    };
-                    draftResult = chainResult.value;
-                } else {
-                    draftResult = await generationRuntime.generate(
-                        generationRequestForAttempt
-                    );
-                }
-                const initialDraftFinishedAt = Date.now();
-                const initialDraftUsage = captureUsage(
-                    draftResult,
-                    effectiveGenerationRequest.model
-                );
-                const initialDraftStepId = captureStep({
-                    stepKind: 'generate',
-                    status: 'executed',
-                    summary: 'Generated initial draft response.',
-                    startedAtMs: initialDraftStartedAt,
-                    finishedAtMs: initialDraftFinishedAt,
-                    model: initialDraftUsage.model,
-                    usage: draftResult.usage,
-                    estimatedCost: initialDraftUsage.estimatedCost,
-                    parentStepId: plannerRootStepId,
-                    attempt: 1,
-                    ...(initialRoutingChainAttempts !== undefined && {
-                        signals: {
-                            ...buildRoutingChainSignals({
-                                attempts: initialRoutingChainAttempts,
-                                selectedProfileId:
-                                    initialRoutedProfile?.profileId,
-                                selectedProvider:
-                                    initialRoutedProfile?.provider,
-                                selectedModel: initialRoutedProfile?.model,
+                    const routingResult = toRoutingChainResult(chainResult);
+                    if (routingResult.isErr()) {
+                        const routingFailure = routingResult.error;
+                        const initialDraftFinishedAt = Date.now();
+                        logger.error(
+                            'Initial workflow generation routing failed; returning classified no-generation outcome.',
+                            {
+                                stepKind: 'generate',
+                                reasonCode: routingFailure.reasonCode,
+                                startedAtMs: initialDraftStartedAt,
+                                finishedAtMs: initialDraftFinishedAt,
+                                workflowName: workflowState.workflowName,
+                                workflowId: workflowState.workflowId,
+                                routingChainAttemptCount:
+                                    routingFailure.attempts.length,
+                            }
+                        );
+                        captureStep({
+                            stepKind: 'generate',
+                            status: 'failed',
+                            summary:
+                                'Initial generation routing failed; workflow returned classified no-generation outcome.',
+                            reasonCode: routingFailure.reasonCode,
+                            startedAtMs: initialDraftStartedAt,
+                            finishedAtMs: initialDraftFinishedAt,
+                            parentStepId: plannerRootStepId,
+                            attempt: 1,
+                            signals: buildRoutingChainSignals({
+                                attempts: routingFailure.attempts,
+                                selectedProfileId: null,
                                 signalKeys: {
                                     profileId: 'routedProfileId',
                                     provider: 'routedProvider',
                                     model: 'routedModel',
                                 },
                             }),
-                        },
-                    }),
-                });
-                draftParentStepId = initialDraftStepId;
-                workflowState = applyStepExecutionToState(
-                    workflowState,
-                    'generate',
-                    initialDraftUsage.totalTokens,
-                    0,
-                    0
-                );
+                        });
+                        workflowState = applyStepExecutionToState(
+                            workflowState,
+                            'generate',
+                            0,
+                            0,
+                            0
+                        );
+                        terminationReason = 'executor_error_fail_open';
+                        workflowStatus = 'degraded';
+                        shouldStop = true;
+                    } else {
+                        initialRoutingChainAttempts =
+                            routingResult.value.attempts;
+                        initialRoutedProfile = {
+                            profileId: routingResult.value.selected.profile.id,
+                            provider:
+                                routingResult.value.selected.profile.provider,
+                            model: routingResult.value.selected.profile
+                                .providerModel,
+                        };
+                        draftResult = routingResult.value.value;
+                    }
+                } else {
+                    draftResult = await generationRuntime.generate(
+                        generationRequestForAttempt
+                    );
+                }
+                if (!shouldStop && draftResult !== null) {
+                    const initialDraftFinishedAt = Date.now();
+                    const initialDraftUsage = captureUsage(
+                        draftResult,
+                        effectiveGenerationRequest.model
+                    );
+                    const initialDraftStepId = captureStep({
+                        stepKind: 'generate',
+                        status: 'executed',
+                        summary: 'Generated initial draft response.',
+                        startedAtMs: initialDraftStartedAt,
+                        finishedAtMs: initialDraftFinishedAt,
+                        model: initialDraftUsage.model,
+                        usage: draftResult.usage,
+                        estimatedCost: initialDraftUsage.estimatedCost,
+                        parentStepId: plannerRootStepId,
+                        attempt: 1,
+                        ...(initialRoutingChainAttempts !== undefined && {
+                            signals: {
+                                ...buildRoutingChainSignals({
+                                    attempts: initialRoutingChainAttempts,
+                                    selectedProfileId:
+                                        initialRoutedProfile?.profileId,
+                                    selectedProvider:
+                                        initialRoutedProfile?.provider,
+                                    selectedModel: initialRoutedProfile?.model,
+                                    signalKeys: {
+                                        profileId: 'routedProfileId',
+                                        provider: 'routedProvider',
+                                        model: 'routedModel',
+                                    },
+                                }),
+                            },
+                        }),
+                    });
+                    draftParentStepId = initialDraftStepId;
+                    workflowState = applyStepExecutionToState(
+                        workflowState,
+                        'generate',
+                        initialDraftUsage.totalTokens,
+                        0,
+                        0
+                    );
+                } else if (!shouldStop) {
+                    throw new Error(
+                        'Initial generation completed without a draft result.'
+                    );
+                }
             } catch (error) {
                 const initialDraftFinishedAt = Date.now();
-                const errorMessage =
-                    error instanceof Error ? error.message : String(error);
-                const reasonCode: ExecutionReasonCode =
-                    errorMessage === 'routing_chain_exhausted' ||
-                    errorMessage === 'routing_chain_non_transient_error'
-                        ? (errorMessage as ExecutionReasonCode)
-                        : 'generation_runtime_error';
                 logger.error(
                     'Initial workflow generation failed; returning classified no-generation outcome.',
                     {
                         stepKind: 'generate',
-                        reasonCode,
+                        reasonCode: 'generation_runtime_error',
                         startedAtMs: initialDraftStartedAt,
                         finishedAtMs: initialDraftFinishedAt,
                         workflowName: workflowState.workflowName,
@@ -1004,7 +1055,7 @@ export const runBoundedReviewWorkflow = async ({
                     status: 'failed',
                     summary:
                         'Initial generation failed; workflow returned classified no-generation outcome.',
-                    reasonCode,
+                    reasonCode: 'generation_runtime_error',
                     startedAtMs: initialDraftStartedAt,
                     finishedAtMs: initialDraftFinishedAt,
                     parentStepId: plannerRootStepId,

--- a/packages/backend/src/services/workflowEngine/reviewDecision.ts
+++ b/packages/backend/src/services/workflowEngine/reviewDecision.ts
@@ -104,7 +104,9 @@ const PartialResponseTemperamentSchema = z
 const ReviewDecisionSchema = z
     .object({
         reviewDecision: z.enum(['finalize', 'revise']),
-        reviewReason: z.string().min(1),
+        reviewReason: z.string().refine((value) => value.trim().length > 0, {
+            message: 'reviewReason must be non-empty after trimming.',
+        }),
         revisionInstruction: z.string().optional(),
         traceAlignment: z.enum(['aligned', 'misaligned']).optional(),
         traceAlignmentReason: z.string().optional(),

--- a/packages/backend/src/services/workflowEngine/reviewDecision.ts
+++ b/packages/backend/src/services/workflowEngine/reviewDecision.ts
@@ -10,6 +10,7 @@ import type {
     PartialResponseTemperament,
     TraceAxisScore,
 } from '@footnote/contracts/policy';
+import { err, ok, type Result } from 'neverthrow';
 import { z } from 'zod';
 import { sanitizeReviewModuleIds } from '../reviewModules.js';
 
@@ -28,6 +29,26 @@ export type ReviewDecision = {
     };
     routingHints?: string[];
 };
+
+export type ReviewDecisionParseFailureReason =
+    | 'empty_output'
+    | 'non_json_object'
+    | 'invalid_json'
+    | 'schema_invalid';
+
+export type ReviewDecisionParseFailure = {
+    reason: ReviewDecisionParseFailureReason;
+    message: string;
+    outputLength: number;
+    issueCount?: number;
+    firstIssuePath?: string;
+    firstIssueCode?: string;
+};
+
+export type ReviewDecisionParseResult = Result<
+    ReviewDecision,
+    ReviewDecisionParseFailure
+>;
 
 export const DEFAULT_REVIEW_DECISION_PROMPT = `Return plain JSON only.
 Schema:
@@ -143,63 +164,109 @@ const ReviewDecisionSchema = z
         }
     });
 
-export const parseReviewDecisionOutput = (
+const normalizeReviewDecision = (
+    parsedDecision: z.infer<typeof ReviewDecisionSchema>
+): ReviewDecision => {
+    const normalizedRevisionInstruction =
+        parsedDecision.revisionInstruction?.trim();
+    const moduleHints = parsedDecision.moduleHints
+        ? sanitizeReviewModuleIds(parsedDecision.moduleHints)
+        : undefined;
+    const normalizedConcerns: NonNullable<ReviewDecision['concerns']> = {
+        ...(parsedDecision.concerns?.length !== undefined && {
+            length: parsedDecision.concerns.length,
+        }),
+        ...(parsedDecision.concerns?.style !== undefined && {
+            style: parsedDecision.concerns.style,
+        }),
+        ...(parsedDecision.concerns?.evidence !== undefined && {
+            evidence: parsedDecision.concerns.evidence,
+        }),
+    };
+
+    return {
+        reviewDecision: parsedDecision.reviewDecision,
+        reviewReason: parsedDecision.reviewReason.trim(),
+        ...(normalizedRevisionInstruction !== undefined && {
+            revisionInstruction: normalizedRevisionInstruction,
+        }),
+        ...(parsedDecision.traceAlignment !== undefined && {
+            traceAlignment: parsedDecision.traceAlignment,
+        }),
+        ...(parsedDecision.traceAlignmentReason !== undefined && {
+            traceAlignmentReason: parsedDecision.traceAlignmentReason.trim(),
+        }),
+        ...(parsedDecision.finalTemperament !== undefined && {
+            finalTemperament: parsedDecision.finalTemperament,
+        }),
+        ...(moduleHints !== undefined && { moduleHints }),
+        ...(Object.keys(normalizedConcerns).length > 0 && {
+            concerns: normalizedConcerns,
+        }),
+        ...(parsedDecision.routingHints !== undefined && {
+            routingHints: parsedDecision.routingHints,
+        }),
+    };
+};
+
+export const parseReviewDecisionOutputResult = (
     text: string
-): ReviewDecision | null => {
+): ReviewDecisionParseResult => {
     const trimmed = text.trim();
+    if (trimmed.length === 0) {
+        return err({
+            reason: 'empty_output',
+            message: 'Review decision output was empty.',
+            outputLength: text.length,
+        });
+    }
+
     if (!trimmed.startsWith('{') || !trimmed.endsWith('}')) {
-        return null;
+        return err({
+            reason: 'non_json_object',
+            message: 'Review decision output must be a JSON object.',
+            outputLength: text.length,
+        });
     }
 
     try {
         const parsedPayload = JSON.parse(trimmed) as unknown;
         const parsedDecision = ReviewDecisionSchema.safeParse(parsedPayload);
         if (!parsedDecision.success) {
-            return null;
+            const firstIssue = parsedDecision.error.issues.at(0);
+            const firstIssuePath = firstIssue?.path
+                .map((pathSegment) => String(pathSegment))
+                .join('.');
+            return err({
+                reason: 'schema_invalid',
+                message:
+                    firstIssue?.message ??
+                    'Review decision output did not match the required schema.',
+                outputLength: text.length,
+                issueCount: parsedDecision.error.issues.length,
+                ...(firstIssuePath !== undefined &&
+                    firstIssuePath.length > 0 && {
+                        firstIssuePath,
+                    }),
+                ...(firstIssue?.code !== undefined && {
+                    firstIssueCode: firstIssue.code,
+                }),
+            });
         }
 
-        const normalizedRevisionInstruction =
-            parsedDecision.data.revisionInstruction?.trim();
-        const moduleHints = parsedDecision.data.moduleHints
-            ? sanitizeReviewModuleIds(parsedDecision.data.moduleHints)
-            : undefined;
-        const normalizedConcerns: NonNullable<ReviewDecision['concerns']> = {
-            ...(parsedDecision.data.concerns?.length !== undefined && {
-                length: parsedDecision.data.concerns.length,
-            }),
-            ...(parsedDecision.data.concerns?.style !== undefined && {
-                style: parsedDecision.data.concerns.style,
-            }),
-            ...(parsedDecision.data.concerns?.evidence !== undefined && {
-                evidence: parsedDecision.data.concerns.evidence,
-            }),
-        };
-
-        return {
-            reviewDecision: parsedDecision.data.reviewDecision,
-            reviewReason: parsedDecision.data.reviewReason.trim(),
-            ...(normalizedRevisionInstruction !== undefined && {
-                revisionInstruction: normalizedRevisionInstruction,
-            }),
-            ...(parsedDecision.data.traceAlignment !== undefined && {
-                traceAlignment: parsedDecision.data.traceAlignment,
-            }),
-            ...(parsedDecision.data.traceAlignmentReason !== undefined && {
-                traceAlignmentReason:
-                    parsedDecision.data.traceAlignmentReason.trim(),
-            }),
-            ...(parsedDecision.data.finalTemperament !== undefined && {
-                finalTemperament: parsedDecision.data.finalTemperament,
-            }),
-            ...(moduleHints !== undefined && { moduleHints }),
-            ...(Object.keys(normalizedConcerns).length > 0 && {
-                concerns: normalizedConcerns,
-            }),
-            ...(parsedDecision.data.routingHints !== undefined && {
-                routingHints: parsedDecision.data.routingHints,
-            }),
-        };
+        return ok(normalizeReviewDecision(parsedDecision.data));
     } catch {
-        return null;
+        return err({
+            reason: 'invalid_json',
+            message: 'Review decision output was not valid JSON.',
+            outputLength: text.length,
+        });
     }
+};
+
+export const parseReviewDecisionOutput = (
+    text: string
+): ReviewDecision | null => {
+    const result = parseReviewDecisionOutputResult(text);
+    return result.isOk() ? result.value : null;
 };

--- a/packages/backend/src/services/workflowEngine/reviewLoopExecutor.ts
+++ b/packages/backend/src/services/workflowEngine/reviewLoopExecutor.ts
@@ -29,13 +29,18 @@ import type {
     PlannerStepRequest,
 } from '../plannerWorkflowSeams.js';
 import type { ConversationContextEnvelope } from '../conversationContextService.js';
-import type { ReviewDecision } from './reviewDecision.js';
+import type {
+    ReviewDecision,
+    ReviewDecisionParseFailure,
+    ReviewDecisionParseResult,
+} from './reviewDecision.js';
 import { isWorkflowTransitionAllowed } from './transitions.js';
 import { applyStepExecutionToState, type WorkflowState } from './state.js';
 import type { WorkflowRunPolicy } from '../workflowEngine.js';
 import { buildAssessSignals } from './reviewLoopSignals.js';
 import { executeStepRoutingChain } from '../stepRoutingExecutor.js';
 import type { ResolvedStepRoutingCandidate } from '../stepRoutingChains.js';
+import { toRoutingChainResult } from '../routingChainResult.js';
 import {
     decideRevisionRoutingHintLane,
     extractRoutingHintsFromAssess,
@@ -80,6 +85,24 @@ type LimitStopEvaluation = {
         | 'maxDurationMs';
 };
 
+const buildReviewParseFailureSignals = (
+    failure: ReviewDecisionParseFailure
+): Record<string, string | number | boolean | null> => ({
+    reviewParseStatus: 'failed',
+    reviewParseFailureReason: failure.reason,
+    reviewParseFailureMessage: failure.message,
+    reviewParseOutputLength: failure.outputLength,
+    ...(failure.issueCount !== undefined && {
+        reviewParseIssueCount: failure.issueCount,
+    }),
+    ...(failure.firstIssuePath !== undefined && {
+        reviewParseFirstIssuePath: failure.firstIssuePath,
+    }),
+    ...(failure.firstIssueCode !== undefined && {
+        reviewParseFirstIssueCode: failure.firstIssueCode,
+    }),
+});
+
 /**
  * Executes the assess/revise loop and returns the updated workflow state bag.
  * The loop remains fail-open: generation/review/planner runtime failures are
@@ -117,7 +140,7 @@ export const executeReviewLoop = async (ctx: {
             totalCostUsd: number;
         };
     };
-    effectiveParseReviewDecision: (text: string) => ReviewDecision | null;
+    effectiveParseReviewDecision: (text: string) => ReviewDecisionParseResult;
     captureStep: CaptureStep;
     draftParentStepId?: string;
     terminationReason: WorkflowTerminationReason;
@@ -261,17 +284,49 @@ export const executeReviewLoop = async (ctx: {
                               }),
                       })
                     : undefined;
-            if (assessChainResult?.status === 'exhausted') {
-                throw new Error(assessChainResult.reasonCode);
+            const assessRoutingResult =
+                assessChainResult !== undefined
+                    ? toRoutingChainResult(assessChainResult)
+                    : undefined;
+            if (assessRoutingResult?.isErr()) {
+                const routingFailure = assessRoutingResult.error;
+                const reviewFinishedAt = Date.now();
+                ctx.captureStep({
+                    stepKind: 'assess',
+                    status: 'failed',
+                    summary:
+                        'Assessment routing chain failed; fail-open returned latest successful draft.',
+                    reasonCode: routingFailure.reasonCode,
+                    startedAtMs: reviewStartedAt,
+                    finishedAtMs: reviewFinishedAt,
+                    parentStepId: draftParentStepId,
+                    attempt: iteration,
+                    signals: {
+                        ...toLatestRoutingHintSignals(),
+                        ...buildRoutingChainSignals({
+                            attempts: routingFailure.attempts,
+                            selectedProfileId: null,
+                        }),
+                    },
+                });
+                workflowState = applyStepExecutionToState(
+                    workflowState,
+                    'assess',
+                    0,
+                    0,
+                    1
+                );
+                terminationReason = 'executor_error_fail_open';
+                workflowStatus = 'degraded';
+                shouldStop = true;
+                return { status: 'stopped' };
             }
-            const reviewResult =
-                assessChainResult?.status === 'executed'
-                    ? assessChainResult.value
-                    : await ctx.generationRuntime.generate(assessRequest);
-            const assessUsageModel =
-                assessChainResult?.status === 'executed'
-                    ? assessChainResult.selected.profile.providerModel
-                    : effectiveGenerationRequest.model;
+            const reviewResult = assessRoutingResult?.isOk()
+                ? assessRoutingResult.value.value
+                : await ctx.generationRuntime.generate(assessRequest);
+            const assessUsageModel = assessRoutingResult?.isOk()
+                ? assessRoutingResult.value.selected.profile.providerModel
+                : effectiveGenerationRequest.model;
             const reviewFinishedAt = Date.now();
             const reviewUsage = ctx.captureUsage(
                 reviewResult,
@@ -284,10 +339,11 @@ export const executeReviewLoop = async (ctx: {
                 0,
                 1
             );
-            const decision = ctx.effectiveParseReviewDecision(
+            const parseResult = ctx.effectiveParseReviewDecision(
                 reviewResult.text
             );
-            if (!decision) {
+            if (parseResult.isErr()) {
+                const failure = parseResult.error;
                 ctx.captureStep({
                     stepKind: 'assess',
                     status: 'failed',
@@ -301,12 +357,17 @@ export const executeReviewLoop = async (ctx: {
                     estimatedCost: reviewUsage.estimatedCost,
                     parentStepId: draftParentStepId,
                     attempt: iteration,
+                    signals: {
+                        ...buildReviewParseFailureSignals(failure),
+                        ...toLatestRoutingHintSignals(),
+                    },
                 });
                 terminationReason = 'executor_error_fail_open';
                 workflowStatus = 'degraded';
                 shouldStop = true;
                 return { status: 'stopped' };
             }
+            const decision = parseResult.value;
             const assessSignals = buildAssessSignals(decision);
             const assessRoutingHints = extractRoutingHintsFromAssess({
                 assessRawText: reviewResult.text,
@@ -336,11 +397,12 @@ export const executeReviewLoop = async (ctx: {
                     ...assessSignals,
                     ...toLatestRoutingHintSignals(),
                     ...buildRoutingChainSignals({
-                        attempts: assessChainResult?.attempts,
-                        selectedProfileId:
-                            assessChainResult?.status === 'executed'
-                                ? assessChainResult.selected.profile.id
-                                : null,
+                        attempts: assessRoutingResult?.isOk()
+                            ? assessRoutingResult.value.attempts
+                            : undefined,
+                        selectedProfileId: assessRoutingResult?.isOk()
+                            ? assessRoutingResult.value.selected.profile.id
+                            : null,
                     }),
                 },
             });
@@ -350,21 +412,14 @@ export const executeReviewLoop = async (ctx: {
                 decision,
                 reviewStepId,
             };
-        } catch (error) {
+        } catch {
             const reviewFinishedAt = Date.now();
-            const errorMessage =
-                error instanceof Error ? error.message : String(error);
-            const reasonCode: ExecutionReasonCode =
-                errorMessage === 'routing_chain_exhausted' ||
-                errorMessage === 'routing_chain_non_transient_error'
-                    ? (errorMessage as ExecutionReasonCode)
-                    : 'generation_runtime_error';
             ctx.captureStep({
                 stepKind: 'assess',
                 status: 'failed',
                 summary:
                     'Assessment step failed; fail-open returned latest successful draft.',
-                reasonCode,
+                reasonCode: 'generation_runtime_error',
                 startedAtMs: reviewStartedAt,
                 finishedAtMs: reviewFinishedAt,
                 parentStepId: draftParentStepId,
@@ -553,17 +608,49 @@ export const executeReviewLoop = async (ctx: {
                               }),
                       })
                     : undefined;
-            if (revisionChainResult?.status === 'exhausted') {
-                throw new Error(revisionChainResult.reasonCode);
+            const revisionRoutingResult =
+                revisionChainResult !== undefined
+                    ? toRoutingChainResult(revisionChainResult)
+                    : undefined;
+            if (revisionRoutingResult?.isErr()) {
+                const routingFailure = revisionRoutingResult.error;
+                const revisionFinishedAt = Date.now();
+                ctx.captureStep({
+                    stepKind: 'generate',
+                    status: 'failed',
+                    summary:
+                        'Refinement routing chain failed; fail-open returned latest successful draft.',
+                    reasonCode: routingFailure.reasonCode,
+                    startedAtMs: revisionStartedAt,
+                    finishedAtMs: revisionFinishedAt,
+                    parentStepId: input.reviewStepId,
+                    attempt: input.iteration,
+                    signals: {
+                        ...toLatestRoutingHintSignals(),
+                        ...buildRoutingChainSignals({
+                            attempts: routingFailure.attempts,
+                            selectedProfileId: null,
+                        }),
+                    },
+                });
+                workflowState = applyStepExecutionToState(
+                    workflowState,
+                    'generate',
+                    0,
+                    0,
+                    0
+                );
+                terminationReason = 'executor_error_fail_open';
+                workflowStatus = 'degraded';
+                shouldStop = true;
+                return;
             }
-            const revisionResult =
-                revisionChainResult?.status === 'executed'
-                    ? revisionChainResult.value
-                    : await ctx.generationRuntime.generate(revisionRequest);
-            const revisionUsageModel =
-                revisionChainResult?.status === 'executed'
-                    ? revisionChainResult.selected.profile.providerModel
-                    : effectiveGenerationRequest.model;
+            const revisionResult = revisionRoutingResult?.isOk()
+                ? revisionRoutingResult.value.value
+                : await ctx.generationRuntime.generate(revisionRequest);
+            const revisionUsageModel = revisionRoutingResult?.isOk()
+                ? revisionRoutingResult.value.selected.profile.providerModel
+                : effectiveGenerationRequest.model;
             const revisionFinishedAt = Date.now();
             const revisionUsage = ctx.captureUsage(
                 revisionResult,
@@ -594,11 +681,12 @@ export const executeReviewLoop = async (ctx: {
                     }),
                     ...toLatestRoutingHintSignals(),
                     ...buildRoutingChainSignals({
-                        attempts: revisionChainResult?.attempts,
-                        selectedProfileId:
-                            revisionChainResult?.status === 'executed'
-                                ? revisionChainResult.selected.profile.id
-                                : null,
+                        attempts: revisionRoutingResult?.isOk()
+                            ? revisionRoutingResult.value.attempts
+                            : undefined,
+                        selectedProfileId: revisionRoutingResult?.isOk()
+                            ? revisionRoutingResult.value.selected.profile.id
+                            : null,
                     }),
                 },
             });
@@ -611,21 +699,14 @@ export const executeReviewLoop = async (ctx: {
             );
             draftResult = revisionResult;
             draftParentStepId = revisionStepId;
-        } catch (error) {
+        } catch {
             const revisionFinishedAt = Date.now();
-            const errorMessage =
-                error instanceof Error ? error.message : String(error);
-            const reasonCode: ExecutionReasonCode =
-                errorMessage === 'routing_chain_exhausted' ||
-                errorMessage === 'routing_chain_non_transient_error'
-                    ? (errorMessage as ExecutionReasonCode)
-                    : 'generation_runtime_error';
             ctx.captureStep({
                 stepKind: 'generate',
                 status: 'failed',
                 summary:
                     'Refinement generation failed; fail-open returned latest successful draft.',
-                reasonCode,
+                reasonCode: 'generation_runtime_error',
                 startedAtMs: revisionStartedAt,
                 finishedAtMs: revisionFinishedAt,
                 parentStepId: input.reviewStepId,

--- a/packages/backend/src/services/workflowProfileContract.ts
+++ b/packages/backend/src/services/workflowProfileContract.ts
@@ -15,7 +15,7 @@ import type {
     WorkflowTerminationReason,
     WorkflowStepKind,
 } from '@footnote/contracts/policy';
-import type { ReviewDecision } from './workflowEngine/reviewDecision.js';
+import type { ReviewDecisionParseResult } from './workflowEngine/reviewDecision.js';
 
 /**
  * Stable workflow profile identifier.
@@ -289,7 +289,7 @@ type WorkflowProfileRuntimeHooks = {
             reasonCode: WorkflowNoGenerationReasonCode
         ) => WorkflowNoGenerationReasonCode;
     };
-    parseReviewDecision?: (text: string) => ReviewDecision | null;
+    parseReviewDecision?: (text: string) => ReviewDecisionParseResult;
 };
 
 export type WorkflowProfileRuntime = WorkflowProfileContract &

--- a/packages/backend/src/services/workflowProfileRegistry.ts
+++ b/packages/backend/src/services/workflowProfileRegistry.ts
@@ -11,7 +11,7 @@
 import {
     DEFAULT_REVIEW_DECISION_PROMPT,
     DEFAULT_REVISION_PROMPT_PREFIX,
-    parseReviewDecisionOutput,
+    parseReviewDecisionOutputResult,
 } from './workflowEngine.js';
 import type {
     ExecutionContract,
@@ -82,7 +82,7 @@ const REVIEWED_WORKFLOW_PROFILE: WorkflowProfileRuntime = {
         canEmitGeneration: () => true,
         classifyNoGeneration: (reasonCode) => reasonCode,
     },
-    parseReviewDecision: parseReviewDecisionOutput,
+    parseReviewDecision: parseReviewDecisionOutputResult,
 };
 
 // Extension checklist (workflow profiles):

--- a/packages/backend/test/chatService.test.ts
+++ b/packages/backend/test/chatService.test.ts
@@ -2244,6 +2244,12 @@ test('runChatMessages preserves no-generation lineage when fallback routing chai
         traceMetadata?.workflow?.terminationReason,
         'budget_exhausted_steps'
     );
+    const fallbackExecution = response.metadata.execution?.find(
+        (event) =>
+            event.kind === 'generation' &&
+            event.profileId === 'workflow_internal_fallback'
+    );
+    assert.equal(fallbackExecution, undefined);
 });
 
 test('runChatMessages keeps no-generation surfaced when execution policy disables fallback generation', async () => {

--- a/packages/backend/test/chatService.test.ts
+++ b/packages/backend/test/chatService.test.ts
@@ -2181,6 +2181,71 @@ test('runChatMessages handles internal no-generation reasons with fallback gener
     }
 });
 
+test('runChatMessages preserves no-generation lineage when fallback routing chain exhausts', async () => {
+    let generationCalls = 0;
+    const usageRecords: BackendLLMCostRecord[] = [];
+    let traceMetadata: ResponseMetadata | undefined;
+    const generationRuntime: GenerationRuntime = {
+        kind: 'test-runtime',
+        async generate() {
+            generationCalls += 1;
+            throw new Error('401 unauthorized');
+        },
+    };
+
+    const chatService = createChatService({
+        generationRuntime,
+        storeTrace: async (metadata) => {
+            traceMetadata = metadata;
+        },
+        buildResponseMetadata,
+        defaultModel: 'gpt-5-mini',
+        recordUsage: (record) => {
+            usageRecords.push(record);
+        },
+        chatWorkflowConfig: {
+            modeId: 'grounded',
+            reviewLoopEnabled: true,
+            maxIterations: 1,
+            maxDurationMs: 15000,
+        },
+        runReviewWorkflow: async () =>
+            ({
+                outcome: 'no_generation',
+                workflowLineage: {
+                    workflowId: 'wf_internal_routing_exhausted',
+                    workflowName: 'message_reviewed',
+                    status: 'degraded',
+                    terminationReason: 'budget_exhausted_steps',
+                    stepCount: 0,
+                    maxSteps: 3,
+                    maxDurationMs: 15000,
+                    steps: [],
+                },
+            }) satisfies RunBoundedReviewWorkflowResult,
+    });
+
+    const response = await chatService.runChatMessages({
+        messages: [{ role: 'user', content: 'Summarize this.' }],
+        conversationSnapshot: 'Summarize this.',
+    });
+
+    assert.equal(generationCalls, 1);
+    assert.equal(usageRecords.length, 0);
+    assert.equal(
+        response.message,
+        'I could not generate a response for this request.'
+    );
+    assert.equal(
+        response.metadata.workflow?.terminationReason,
+        'budget_exhausted_steps'
+    );
+    assert.equal(
+        traceMetadata?.workflow?.terminationReason,
+        'budget_exhausted_steps'
+    );
+});
+
 test('runChatMessages keeps no-generation surfaced when execution policy disables fallback generation', async () => {
     let generationCalls = 0;
     let traceMetadata: ResponseMetadata | undefined;
@@ -2271,6 +2336,50 @@ test('runChatMessages keeps no-generation surfaced when execution policy disable
             event.profileId === 'workflow_internal_fallback'
     );
     assert.equal(fallbackExecution, undefined);
+});
+
+test('runChatMessages surfaces no-generation when direct generation routing chain exhausts', async () => {
+    let generationCalls = 0;
+    const usageRecords: BackendLLMCostRecord[] = [];
+    let traceMetadata: ResponseMetadata | undefined;
+    const generationRuntime: GenerationRuntime = {
+        kind: 'test-runtime',
+        async generate() {
+            generationCalls += 1;
+            throw new Error('401 unauthorized');
+        },
+    };
+
+    const chatService = createChatService({
+        generationRuntime,
+        storeTrace: async (metadata) => {
+            traceMetadata = metadata;
+        },
+        buildResponseMetadata,
+        defaultModel: 'gpt-5-mini',
+        recordUsage: (record) => {
+            usageRecords.push(record);
+        },
+        chatWorkflowConfig: {
+            modeId: 'grounded',
+            reviewLoopEnabled: false,
+            maxIterations: 1,
+            maxDurationMs: 15000,
+        },
+    });
+
+    const response = await chatService.runChatMessages({
+        messages: [{ role: 'user', content: 'Summarize this.' }],
+        conversationSnapshot: 'Summarize this.',
+    });
+
+    assert.equal(generationCalls, 1);
+    assert.equal(usageRecords.length, 0);
+    assert.equal(
+        response.message,
+        'I could not generate a response for this request.'
+    );
+    assert.equal(traceMetadata?.workflow, undefined);
 });
 
 test('runChatMessages keeps workflow execution policy gated by the execution contract response mode', async () => {

--- a/packages/backend/test/workflowEngine/review-decision.test.ts
+++ b/packages/backend/test/workflowEngine/review-decision.test.ts
@@ -94,6 +94,22 @@ test('parseReviewDecisionOutputResult reports missing revise instruction', () =>
     }
 });
 
+test('parseReviewDecisionOutputResult rejects whitespace review reasons', () => {
+    const result = parseReviewDecisionOutputResult(
+        '{"reviewDecision":"finalize","reviewReason":"   "}'
+    );
+
+    assert.equal(result.isErr(), true);
+    if (result.isErr()) {
+        assert.equal(result.error.reason, 'schema_invalid');
+        assert.equal(result.error.firstIssuePath, 'reviewReason');
+        assert.equal(
+            result.error.message,
+            'reviewReason must be non-empty after trimming.'
+        );
+    }
+});
+
 test('parseReviewDecisionOutputResult reports incomplete trace misalignment fields', () => {
     const result = parseReviewDecisionOutputResult(
         '{"reviewDecision":"finalize","reviewReason":"Ready.","traceAlignment":"misaligned"}'

--- a/packages/backend/test/workflowEngine/review-decision.test.ts
+++ b/packages/backend/test/workflowEngine/review-decision.test.ts
@@ -1,0 +1,113 @@
+/**
+ * @description: Verifies reviewed workflow assess output parsing preserves
+ * expected failure reasons.
+ * @footnote-scope: test
+ * @footnote-module: WorkflowEngineReviewDecisionTests
+ * @footnote-risk: low - Parser regressions can hide assess fail-open causes.
+ * @footnote-ethics: high - Review parse clarity supports auditable workflow decisions.
+ */
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+    parseReviewDecisionOutput,
+    parseReviewDecisionOutputResult,
+} from '../../src/services/workflowEngine/reviewDecision.js';
+
+test('parseReviewDecisionOutputResult parses finalize decisions', () => {
+    const result = parseReviewDecisionOutputResult(
+        '{"reviewDecision":"finalize","reviewReason":"Ready."}'
+    );
+
+    assert.equal(result.isOk(), true);
+    if (result.isOk()) {
+        assert.deepEqual(result.value, {
+            reviewDecision: 'finalize',
+            reviewReason: 'Ready.',
+        });
+    }
+});
+
+test('parseReviewDecisionOutputResult parses revise decisions and trims instruction', () => {
+    const result = parseReviewDecisionOutputResult(
+        '{"reviewDecision":"revise","reviewReason":"Needs polish.","revisionInstruction":"  Tighten wording.  "}'
+    );
+
+    assert.equal(result.isOk(), true);
+    if (result.isOk()) {
+        assert.equal(result.value.reviewDecision, 'revise');
+        assert.equal(result.value.revisionInstruction, 'Tighten wording.');
+    }
+});
+
+test('parseReviewDecisionOutputResult reports empty output', () => {
+    const result = parseReviewDecisionOutputResult('   ');
+
+    assert.equal(result.isErr(), true);
+    if (result.isErr()) {
+        assert.equal(result.error.reason, 'empty_output');
+        assert.equal(result.error.message, 'Review decision output was empty.');
+        assert.equal(result.error.outputLength, 3);
+    }
+});
+
+test('parseReviewDecisionOutputResult reports non-object output', () => {
+    const result = parseReviewDecisionOutputResult(
+        '```json\n{"reviewDecision":"finalize"}\n```'
+    );
+
+    assert.equal(result.isErr(), true);
+    if (result.isErr()) {
+        assert.equal(result.error.reason, 'non_json_object');
+        assert.equal(
+            result.error.message,
+            'Review decision output must be a JSON object.'
+        );
+    }
+});
+
+test('parseReviewDecisionOutputResult reports invalid JSON', () => {
+    const result = parseReviewDecisionOutputResult(
+        '{"reviewDecision":"finalize",}'
+    );
+
+    assert.equal(result.isErr(), true);
+    if (result.isErr()) {
+        assert.equal(result.error.reason, 'invalid_json');
+        assert.equal(
+            result.error.message,
+            'Review decision output was not valid JSON.'
+        );
+    }
+});
+
+test('parseReviewDecisionOutputResult reports missing revise instruction', () => {
+    const result = parseReviewDecisionOutputResult(
+        '{"reviewDecision":"revise","reviewReason":"Needs polish."}'
+    );
+
+    assert.equal(result.isErr(), true);
+    if (result.isErr()) {
+        assert.equal(result.error.reason, 'schema_invalid');
+        assert.equal(result.error.firstIssuePath, 'revisionInstruction');
+        assert.ok((result.error.issueCount ?? 0) > 0);
+    }
+});
+
+test('parseReviewDecisionOutputResult reports incomplete trace misalignment fields', () => {
+    const result = parseReviewDecisionOutputResult(
+        '{"reviewDecision":"finalize","reviewReason":"Ready.","traceAlignment":"misaligned"}'
+    );
+
+    assert.equal(result.isErr(), true);
+    if (result.isErr()) {
+        assert.equal(result.error.reason, 'schema_invalid');
+        assert.ok((result.error.issueCount ?? 0) > 0);
+    }
+});
+
+test('parseReviewDecisionOutput keeps nullable compatibility wrapper', () => {
+    const result = parseReviewDecisionOutput('not json');
+
+    assert.equal(result, null);
+});

--- a/packages/backend/test/workflowEngine/review-loop.test.ts
+++ b/packages/backend/test/workflowEngine/review-loop.test.ts
@@ -9,7 +9,24 @@ import test from 'node:test';
 import assert from 'node:assert/strict';
 import type { GenerationRuntime } from '@footnote/agent-runtime';
 import type { ModelProfile } from '@footnote/contracts';
+import { ok } from 'neverthrow';
 import { runBoundedReviewWorkflowForTest } from './helpers.js';
+
+const makeWorkflowTestProfile = (input: {
+    id: string;
+    provider: 'openai' | 'ollama';
+    providerModel: string;
+    enabled?: boolean;
+    canUseSearch?: boolean;
+}): ModelProfile => ({
+    id: input.id,
+    description: input.id,
+    provider: input.provider,
+    providerModel: input.providerModel,
+    enabled: input.enabled ?? true,
+    tierBindings: [],
+    capabilities: { canUseSearch: input.canUseSearch ?? true },
+});
 
 test('runBoundedReviewWorkflow enforces legality before initial generate execution', async () => {
     let generationCalls = 0;
@@ -55,10 +72,11 @@ test('runBoundedReviewWorkflow enforces legality before initial generate executi
         },
         reviewDecisionPrompt: 'json',
         revisionPromptPrefix: 'revise',
-        parseReviewDecision: () => ({
-            reviewDecision: 'finalize',
-            reviewReason: 'done',
-        }),
+        parseReviewDecision: () =>
+            ok({
+                reviewDecision: 'finalize',
+                reviewReason: 'done',
+            }),
         captureUsage: () => {
             usageCaptures += 1;
             return {
@@ -288,11 +306,12 @@ test('runBoundedReviewWorkflow records explicit limit stop attribution for exhau
                 totalCostUsd: 0,
             },
         }),
-        parseReviewDecision: () => ({
-            reviewDecision: 'revise',
-            reviewReason: 'One revision pass is required.',
-            revisionInstruction: 'Tighten wording and remove redundancy.',
-        }),
+        parseReviewDecision: () =>
+            ok({
+                reviewDecision: 'revise',
+                reviewReason: 'One revision pass is required.',
+                revisionInstruction: 'Tighten wording and remove redundancy.',
+            }),
     });
 
     assert.equal(result.outcome, 'generated');
@@ -376,6 +395,97 @@ test('runBoundedReviewWorkflow classifies initial generate runtime failure as no
     assert.equal(
         result.workflowLineage.steps[0].reasonCode,
         'generation_runtime_error'
+    );
+});
+
+test('runBoundedReviewWorkflow records initial generation routing exhaustion without exception-message control flow', async () => {
+    let generationCalls = 0;
+    const ineligibleProfile = makeWorkflowTestProfile({
+        id: 'openai-text-medium',
+        provider: 'openai',
+        providerModel: 'gpt-5.4-mini',
+        enabled: false,
+    });
+    const generationRuntime: GenerationRuntime = {
+        kind: 'test-runtime',
+        async generate() {
+            generationCalls += 1;
+            return {
+                text: 'should not run',
+                model: 'gpt-5-mini',
+                usage: {
+                    promptTokens: 10,
+                    completionTokens: 5,
+                    totalTokens: 15,
+                },
+                provenance: 'Inferred',
+                citations: [],
+            };
+        },
+    };
+
+    const result = await runBoundedReviewWorkflowForTest({
+        generationRuntime,
+        generationRequest: {
+            model: 'gpt-5-mini',
+            messages: [{ role: 'user', content: 'hi' }],
+        },
+        messagesWithHints: [{ role: 'user', content: 'hi' }],
+        generationStartedAtMs: Date.now(),
+        workflowConfig: {
+            workflowName: 'message_reviewed',
+            maxIterations: 2,
+            maxDurationMs: 15000,
+        },
+        workflowPolicy: {
+            enablePlanning: false,
+            enableToolUse: false,
+            enableReplanning: false,
+            enableGeneration: true,
+            enableAssessment: true,
+            enableRevision: true,
+        },
+        captureUsage: () => ({
+            model: 'gpt-5-mini',
+            promptTokens: 0,
+            completionTokens: 0,
+            totalTokens: 0,
+            estimatedCost: {
+                inputCostUsd: 0,
+                outputCostUsd: 0,
+                totalCostUsd: 0,
+            },
+        }),
+        stepRoutingChainSet: {
+            enabledProfilesById: new Map([
+                [ineligibleProfile.id, ineligibleProfile],
+            ]),
+            generateCandidates: [
+                { profileId: ineligibleProfile.id, chooseOneUsed: false },
+            ],
+            assessCandidates: [],
+        },
+    });
+
+    assert.equal(generationCalls, 0);
+    assert.equal(result.outcome, 'no_generation');
+    assert.equal(
+        result.workflowLineage.terminationReason,
+        'executor_error_fail_open'
+    );
+    const failedGenerateStep = result.workflowLineage.steps.find(
+        (step) =>
+            step.stepKind === 'generate' && step.outcome.status === 'failed'
+    );
+    assert.ok(failedGenerateStep);
+    assert.equal(failedGenerateStep.reasonCode, 'routing_chain_exhausted');
+    assert.equal(
+        failedGenerateStep.outcome.signals?.routingChainAttemptCount,
+        1
+    );
+    assert.match(
+        String(failedGenerateStep.outcome.signals?.routingChainAttemptsJson),
+        /skipped_ineligible/
     );
 });
 
@@ -785,6 +895,20 @@ test('runBoundedReviewWorkflow fail-opens when assess revise omits required revi
         ),
         false
     );
+    const failedAssessStep = result.workflowLineage.steps.find(
+        (step) => step.stepKind === 'assess' && step.outcome.status === 'failed'
+    );
+    assert.ok(failedAssessStep);
+    assert.equal(failedAssessStep.reasonCode, 'generation_runtime_error');
+    assert.equal(failedAssessStep.outcome.signals?.reviewParseStatus, 'failed');
+    assert.equal(
+        failedAssessStep.outcome.signals?.reviewParseFailureReason,
+        'schema_invalid'
+    );
+    assert.equal(
+        failedAssessStep.outcome.signals?.reviewParseFirstIssuePath,
+        'revisionInstruction'
+    );
 });
 
 test('runBoundedReviewWorkflow persists assess TRACE alignment signals when provided', async () => {
@@ -867,6 +991,302 @@ test('runBoundedReviewWorkflow persists assess TRACE alignment signals when prov
         'Need tighter caution tone.'
     );
     assert.equal(assessStep.outcome.signals?.finalTemperamentCaution, 4);
+});
+
+test('runBoundedReviewWorkflow records invalid JSON assess parse failure signals', async () => {
+    let generationCalls = 0;
+    const generationRuntime: GenerationRuntime = {
+        kind: 'test-runtime',
+        async generate() {
+            generationCalls += 1;
+            if (generationCalls === 1) {
+                return {
+                    text: 'initial draft',
+                    model: 'gpt-5-mini',
+                    usage: {
+                        promptTokens: 10,
+                        completionTokens: 10,
+                        totalTokens: 20,
+                    },
+                    provenance: 'Inferred',
+                    citations: [],
+                };
+            }
+            return {
+                text: '{"reviewDecision":"finalize",}',
+                model: 'gpt-5-mini',
+                usage: {
+                    promptTokens: 5,
+                    completionTokens: 5,
+                    totalTokens: 10,
+                },
+                provenance: 'Inferred',
+                citations: [],
+            };
+        },
+    };
+
+    const result = await runBoundedReviewWorkflowForTest({
+        generationRuntime,
+        generationRequest: {
+            model: 'gpt-5-mini',
+            messages: [{ role: 'user', content: 'Draft answer' }],
+        },
+        messagesWithHints: [{ role: 'user', content: 'Draft answer' }],
+        generationStartedAtMs: Date.now(),
+        workflowConfig: {
+            workflowName: 'message_reviewed',
+            maxIterations: 2,
+            maxDurationMs: 15000,
+        },
+        workflowPolicy: {
+            enablePlanning: false,
+            enableToolUse: false,
+            enableReplanning: false,
+            enableGeneration: true,
+            enableAssessment: true,
+            enableRevision: true,
+        },
+        captureUsage: (generationResult) => ({
+            model: generationResult.model ?? 'gpt-5-mini',
+            promptTokens: generationResult.usage?.promptTokens ?? 0,
+            completionTokens: generationResult.usage?.completionTokens ?? 0,
+            totalTokens: generationResult.usage?.totalTokens ?? 0,
+            estimatedCost: {
+                inputCostUsd: 0,
+                outputCostUsd: 0,
+                totalCostUsd: 0,
+            },
+        }),
+    });
+
+    assert.equal(result.outcome, 'generated');
+    assert.equal(result.generationResult.text, 'initial draft');
+    assert.equal(result.workflowLineage.status, 'degraded');
+    assert.equal(
+        result.workflowLineage.terminationReason,
+        'executor_error_fail_open'
+    );
+    const failedAssessStep = result.workflowLineage.steps.find(
+        (step) => step.stepKind === 'assess' && step.outcome.status === 'failed'
+    );
+    assert.ok(failedAssessStep);
+    assert.equal(
+        failedAssessStep.outcome.signals?.reviewParseFailureReason,
+        'invalid_json'
+    );
+});
+
+test('runBoundedReviewWorkflow records assess routing-chain exhaustion as data', async () => {
+    let generationCalls = 0;
+    const generateProfile = makeWorkflowTestProfile({
+        id: 'openai-text-medium',
+        provider: 'openai',
+        providerModel: 'gpt-5.4-mini',
+    });
+    const assessProfile = makeWorkflowTestProfile({
+        id: 'openai-json-optimized',
+        provider: 'openai',
+        providerModel: 'gpt-5.4-nano',
+    });
+    const generationRuntime: GenerationRuntime = {
+        kind: 'test-runtime',
+        async generate(input) {
+            generationCalls += 1;
+            if (input.model === assessProfile.providerModel) {
+                throw new Error('401 unauthorized');
+            }
+            return {
+                text: 'initial draft',
+                model: input.model,
+                usage: {
+                    promptTokens: 10,
+                    completionTokens: 10,
+                    totalTokens: 20,
+                },
+                provenance: 'Inferred',
+                citations: [],
+            };
+        },
+    };
+
+    const result = await runBoundedReviewWorkflowForTest({
+        generationRuntime,
+        generationRequest: {
+            model: 'gpt-5-mini',
+            messages: [{ role: 'user', content: 'Draft answer' }],
+        },
+        messagesWithHints: [{ role: 'user', content: 'Draft answer' }],
+        generationStartedAtMs: Date.now(),
+        workflowConfig: {
+            workflowName: 'message_reviewed',
+            maxIterations: 2,
+            maxDurationMs: 15000,
+        },
+        workflowPolicy: {
+            enablePlanning: false,
+            enableToolUse: false,
+            enableReplanning: false,
+            enableGeneration: true,
+            enableAssessment: true,
+            enableRevision: true,
+        },
+        captureUsage: (generationResult) => ({
+            model: generationResult.model ?? 'gpt-5-mini',
+            promptTokens: generationResult.usage?.promptTokens ?? 0,
+            completionTokens: generationResult.usage?.completionTokens ?? 0,
+            totalTokens: generationResult.usage?.totalTokens ?? 0,
+            estimatedCost: {
+                inputCostUsd: 0,
+                outputCostUsd: 0,
+                totalCostUsd: 0,
+            },
+        }),
+        stepRoutingChainSet: {
+            enabledProfilesById: new Map([
+                [generateProfile.id, generateProfile],
+                [assessProfile.id, assessProfile],
+            ]),
+            generateCandidates: [
+                { profileId: generateProfile.id, chooseOneUsed: false },
+            ],
+            assessCandidates: [
+                { profileId: assessProfile.id, chooseOneUsed: false },
+            ],
+        },
+    });
+
+    assert.equal(result.outcome, 'generated');
+    assert.equal(result.generationResult.text, 'initial draft');
+    assert.equal(generationCalls, 2);
+    const failedAssessStep = result.workflowLineage.steps.find(
+        (step) => step.stepKind === 'assess' && step.outcome.status === 'failed'
+    );
+    assert.ok(failedAssessStep);
+    assert.equal(
+        failedAssessStep.reasonCode,
+        'routing_chain_non_transient_error'
+    );
+    assert.equal(failedAssessStep.outcome.signals?.routingChainAttemptCount, 1);
+    assert.match(
+        String(failedAssessStep.outcome.signals?.routingChainAttemptsJson),
+        /failed_non_transient_stopped/
+    );
+});
+
+test('runBoundedReviewWorkflow records revision routing-chain exhaustion as data', async () => {
+    let generationCalls = 0;
+    const generateProfile = makeWorkflowTestProfile({
+        id: 'openai-text-medium',
+        provider: 'openai',
+        providerModel: 'gpt-5.4-mini',
+    });
+    const assessProfile = makeWorkflowTestProfile({
+        id: 'openai-json-optimized',
+        provider: 'openai',
+        providerModel: 'gpt-5.4-nano',
+    });
+    const generationRuntime: GenerationRuntime = {
+        kind: 'test-runtime',
+        async generate(input) {
+            generationCalls += 1;
+            if (generationCalls === 1) {
+                return {
+                    text: 'initial draft',
+                    model: input.model,
+                    usage: {
+                        promptTokens: 10,
+                        completionTokens: 10,
+                        totalTokens: 20,
+                    },
+                    provenance: 'Inferred',
+                    citations: [],
+                };
+            }
+            if (input.model === assessProfile.providerModel) {
+                return {
+                    text: '{"reviewDecision":"revise","reviewReason":"Need precision.","revisionInstruction":"Tighten the logic.","routingHints":["logic.precision_up"]}',
+                    model: input.model,
+                    usage: {
+                        promptTokens: 5,
+                        completionTokens: 5,
+                        totalTokens: 10,
+                    },
+                    provenance: 'Inferred',
+                    citations: [],
+                };
+            }
+            throw new Error('401 unauthorized');
+        },
+    };
+
+    const result = await runBoundedReviewWorkflowForTest({
+        generationRuntime,
+        generationRequest: {
+            model: 'gpt-5-mini',
+            messages: [{ role: 'user', content: 'Draft answer' }],
+        },
+        messagesWithHints: [{ role: 'user', content: 'Draft answer' }],
+        generationStartedAtMs: Date.now(),
+        workflowConfig: {
+            workflowName: 'message_reviewed',
+            maxIterations: 2,
+            maxDurationMs: 15000,
+        },
+        workflowPolicy: {
+            enablePlanning: false,
+            enableToolUse: false,
+            enableReplanning: false,
+            enableGeneration: true,
+            enableAssessment: true,
+            enableRevision: true,
+        },
+        captureUsage: (generationResult) => ({
+            model: generationResult.model ?? 'gpt-5-mini',
+            promptTokens: generationResult.usage?.promptTokens ?? 0,
+            completionTokens: generationResult.usage?.completionTokens ?? 0,
+            totalTokens: generationResult.usage?.totalTokens ?? 0,
+            estimatedCost: {
+                inputCostUsd: 0,
+                outputCostUsd: 0,
+                totalCostUsd: 0,
+            },
+        }),
+        stepRoutingChainSet: {
+            enabledProfilesById: new Map([
+                [generateProfile.id, generateProfile],
+                [assessProfile.id, assessProfile],
+            ]),
+            generateCandidates: [
+                { profileId: generateProfile.id, chooseOneUsed: false },
+            ],
+            assessCandidates: [
+                { profileId: assessProfile.id, chooseOneUsed: false },
+            ],
+        },
+    });
+
+    assert.equal(result.outcome, 'generated');
+    assert.equal(result.generationResult.text, 'initial draft');
+    const failedRevisionStep = result.workflowLineage.steps.find(
+        (step) =>
+            step.stepKind === 'generate' &&
+            step.outcome.status === 'failed' &&
+            step.attempt === 1
+    );
+    assert.ok(failedRevisionStep);
+    assert.equal(
+        failedRevisionStep.reasonCode,
+        'routing_chain_non_transient_error'
+    );
+    assert.equal(
+        failedRevisionStep.outcome.signals?.routingHintApplied,
+        'openai_first_logic'
+    );
+    assert.equal(
+        failedRevisionStep.outcome.signals?.routingChainAttemptCount,
+        1
+    );
 });
 
 test('runBoundedReviewWorkflow can use independent generate and assess model chains', async () => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -130,6 +130,9 @@ catalogs:
         mime-types:
             specifier: ^3.0.2
             version: 3.0.2
+        neverthrow:
+            specifier: ^8.2.0
+            version: 8.2.0
         node-fetch:
             specifier: ^3.3.2
             version: 3.3.2
@@ -348,6 +351,9 @@ importers:
             js-yaml:
                 specifier: 'catalog:'
                 version: 4.1.1
+            neverthrow:
+                specifier: 'catalog:'
+                version: 8.2.0
             nodemailer:
                 specifier: 'catalog:'
                 version: 8.0.7
@@ -2489,6 +2495,14 @@ packages:
             {
                 integrity: sha512-qujRfC8sFVInYSPPMLQByRh7zhwkGFS4+tyMQ83srV1qrxL4g8E2tyxVVyxd0+8QeBM1mIk9KbWxkegRr76XzA==,
             }
+
+    '@rollup/rollup-linux-x64-gnu@4.61.0':
+        resolution:
+            {
+                integrity: sha512-0uMOcf3eZ5K+K4cYHkdxShFMPlPXCOdfDFEFn9dNYAEEd2cVvmOfH7zFgRVoDgmtQ1m9k5q7qfrHzyMAubKYUA==,
+            }
+        cpu: [x64]
+        os: [linux]
 
     '@sap-ai-sdk/ai-api@2.10.0':
         resolution:
@@ -6008,6 +6022,13 @@ packages:
                 integrity: sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==,
             }
 
+    neverthrow@8.2.0:
+        resolution:
+            {
+                integrity: sha512-kOCT/1MCPAxY5iUV3wytNFUMUolzuwd/VF/1KCx7kf6CutrOsTie+84zTGTpgQycjvfLdBBdvBvFLqFD2c0wkQ==,
+            }
+        engines: { node: '>=18' }
+
     node-abi@3.85.0:
         resolution:
             {
@@ -8853,6 +8874,9 @@ snapshots:
 
     '@rolldown/pluginutils@1.0.0-rc.7': {}
 
+    '@rollup/rollup-linux-x64-gnu@4.61.0':
+        optional: true
+
     '@sap-ai-sdk/ai-api@2.10.0':
         dependencies:
             '@sap-ai-sdk/core': 2.10.0
@@ -11192,6 +11216,10 @@ snapshots:
     negotiator@1.0.0: {}
 
     neo-async@2.6.2: {}
+
+    neverthrow@8.2.0:
+        optionalDependencies:
+            '@rollup/rollup-linux-x64-gnu': 4.61.0
 
     node-abi@3.85.0:
         dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -61,6 +61,7 @@ catalog:
     js-yaml: ^4.1.1
     jsonwebtoken: ^9.0.3
     mime-types: ^3.0.2
+    neverthrow: ^8.2.0
     node-fetch: ^3.3.2
     nodemailer: ^8.0.7
     only: ^0.0.2


### PR DESCRIPTION
- Make review decision parsing return typed expected-failure results instead of collapsing to `null`.
- Treat routing-chain exhaustion and non-transient routing errors as classified data, then fail open with clearer workflow signals.
- Update the workflow engine and chat service to preserve no-generation lineage when routing fails.
- Add tests for review parsing, review-loop fail-open behavior, and chat-service routing fallback handling.
- Update architecture and status docs to describe the new failure handling model.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved resilience when generation routing chains exhaust; system now provides fallback messages instead of errors.
  * Enhanced review decision parsing with explicit failure handling for invalid or empty outputs.
  * Workflow execution gracefully degrades on routing or parsing failures instead of terminating abruptly.

* **Chores**
  * Added error handling library for improved result typing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->