### PR TITLE
Normalize backend response metadata decisions

### DIFF
--- a/docs/status.md
+++ b/docs/status.md
@@ -56,7 +56,7 @@ unchanged.
 ## 3) metadata-normalization
 
 Branch: `chore/trust-boundary-metadata-domain-normalization`  
-Status: `todo`
+Status: `done`
 
 This branch should make response metadata easier to reason about.
 
@@ -74,6 +74,14 @@ Do not change the meaning of provenance, TRACE, review labels, or cost fields in
 this branch. Keep the same behavior and move each decision into a smaller typed
 function.
 
+Completed by extracting pure response-metadata decisions into a dedicated helper
+module. Provenance input shaping, TRACE target/final normalization,
+finalization-reason selection, retrieved chip derivation, and execution-event
+construction now have named typed helpers. The metadata builder still owns
+response ids, timestamps, structured logging, review-runtime summary wiring, and
+the final public metadata shape. Behavior stayed unchanged, with regression tests
+added for partial retrieved chip derivation and invalid TRACE axis normalization.
+
 ## 4) step-signal-typing
 
 Branch: `chore/trust-boundary-step-signal-typing`  
@@ -90,3 +98,34 @@ places to look first.
 Do this gradually. This is not a redesign of every workflow record. Type the
 fields that readers and UI code already depend on, so future changes cannot
 drift silently.
+
+## 5) runtime-boundary-service-reduction
+
+Branch: `chore/trust-boundary-runtime-boundary-service-reduction`  
+Status: `todo`
+
+This branch should reduce the stale `openaiService` naming and provider-specific
+surface now that normal text generation runs through the selected
+`GenerationRuntime` seam, currently VoltAgent.
+
+Do not move Footnote metadata authority into VoltAgent. VoltAgent should provide
+generation facts: text, model, usage, citations, retrieval facts, and optional
+tool execution facts. Backend remains the authority for provenance, TRACE,
+review, cost, trace storage, incident, and final response metadata semantics.
+
+Prefer renaming and boundary cleanup over behavior changes:
+
+- move response metadata assembly and decision helpers out of the
+  `openaiService` namespace into a provider-neutral metadata module
+- rename assistant/provider metadata input types so they no longer imply OpenAI
+  ownership
+- quarantine or remove the legacy direct `SimpleOpenAIService` adapter if it has
+  no production caller
+- deduplicate citation fallback normalization between the old OpenAI request
+  path and the VoltAgent runtime path
+- keep public contracts serializable and preserve existing response metadata
+  output
+
+This branch should not change the selected runtime behavior. It should make the
+module layout match the architecture: runtime adapters execute generation;
+backend-owned metadata builders interpret generation facts.

--- a/packages/backend/src/services/openaiService/metadata.ts
+++ b/packages/backend/src/services/openaiService/metadata.ts
@@ -8,25 +8,17 @@
  */
 
 import crypto from 'node:crypto';
-import type {
-    ExecutionEvent,
-    ExecutionReasonCode,
-    ExecutionStatus,
-    EvaluatorExecutionReasonCode,
-    GenerationExecutionReasonCode,
-    ResponseMetadata,
-    SafetyTier,
-    ToolInvocationReasonCode,
-    TraceAxisScore,
-} from '@footnote/contracts/policy';
+import type { ResponseMetadata, SafetyTier } from '@footnote/contracts/policy';
 import { deriveReviewRuntimeSummary } from '@footnote/contracts/policy';
 import { runtimeConfig } from '../../config.js';
 import { logger } from '../../utils/logger.js';
+import { resolveTradeoffCount } from '../responseMetadataHeuristics.js';
 import {
-    classifyProvenanceWithSignals,
-    deriveRetrievedChips,
-    resolveTradeoffCount,
-} from '../responseMetadataHeuristics.js';
+    buildExecutionEvents,
+    resolveProvenanceDecision,
+    resolveRetrievedChipDecision,
+    resolveTracePostureDecision,
+} from './metadataDecisions.js';
 import type {
     AssistantResponseMetadata,
     ResponseMetadataRuntimeContext,
@@ -34,111 +26,6 @@ import type {
 
 // Owns: response metadata assembly and normalization of execution metadata fields.
 // Does not own: making provider calls or deciding chat policy.
-
-const TRACE_AXIS_KEYS = [
-    'tightness',
-    'rationale',
-    'attribution',
-    'caution',
-    'extent',
-] as const;
-
-/**
- * Runtime guard for TRACE axis chip values.
- */
-const isTraceAxisScore = (value: unknown): value is TraceAxisScore =>
-    typeof value === 'number' &&
-    Number.isInteger(value) &&
-    value >= 1 &&
-    value <= 5;
-
-/**
- * Keeps only valid TRACE planner axes so downstream metadata stays schema-safe.
- */
-const normalizePlannerTemperament = (
-    temperament: ResponseMetadataRuntimeContext['plannerTemperament']
-): ResponseMetadataRuntimeContext['plannerTemperament'] => {
-    if (!temperament) {
-        return undefined;
-    }
-
-    const normalized: NonNullable<
-        ResponseMetadataRuntimeContext['plannerTemperament']
-    > = {};
-    for (const axis of TRACE_AXIS_KEYS) {
-        const score = temperament[axis];
-        if (isTraceAxisScore(score)) {
-            normalized[axis] = score;
-        }
-    }
-
-    return Object.keys(normalized).length > 0 ? normalized : undefined;
-};
-
-const normalizeEvaluatorReasonCode = (
-    status: ExecutionStatus,
-    reasonCode: ExecutionReasonCode | undefined
-): EvaluatorExecutionReasonCode | undefined => {
-    if (status === 'executed' || status === 'skipped') {
-        return undefined;
-    }
-
-    if (reasonCode === 'evaluator_runtime_error') {
-        return reasonCode;
-    }
-
-    return undefined;
-};
-
-const normalizeGenerationReasonCode = (
-    status: ExecutionStatus,
-    reasonCode: ExecutionReasonCode | undefined
-): GenerationExecutionReasonCode | undefined => {
-    if (status === 'executed' || status === 'skipped') {
-        return undefined;
-    }
-
-    if (
-        reasonCode === 'generation_runtime_error' ||
-        reasonCode === 'routing_chain_exhausted' ||
-        reasonCode === 'routing_chain_non_transient_error'
-    ) {
-        return reasonCode;
-    }
-
-    return undefined;
-};
-
-const normalizeToolReasonCode = (
-    status: ExecutionStatus,
-    reasonCode: ToolInvocationReasonCode | undefined
-): ToolInvocationReasonCode | undefined => {
-    if (
-        reasonCode === 'tool_not_requested' ||
-        reasonCode === 'tool_not_used' ||
-        reasonCode === 'search_rerouted_to_fallback_profile' ||
-        reasonCode === 'search_reroute_not_permitted_by_selection_source' ||
-        reasonCode === 'search_reroute_no_tool_capable_fallback_available' ||
-        reasonCode === 'tool_unavailable' ||
-        reasonCode === 'tool_execution_error' ||
-        reasonCode === 'tool_timeout' ||
-        reasonCode === 'tool_http_error' ||
-        reasonCode === 'tool_network_error' ||
-        reasonCode === 'tool_invalid_response' ||
-        reasonCode === 'search_not_supported_by_selected_profile' ||
-        reasonCode === 'unspecified_tool_outcome'
-    ) {
-        return reasonCode;
-    }
-
-    if (status === 'executed') {
-        return undefined;
-    }
-
-    return status === 'failed'
-        ? 'tool_execution_error'
-        : 'unspecified_tool_outcome';
-};
 
 /**
  * Builds canonical ResponseMetadata for trace storage and UI rendering.
@@ -168,21 +55,11 @@ const buildResponseMetadata = (
         ? assistantMetadata.citations
         : [];
     const retrieval = runtimeContext.retrieval;
-    const classificationToolExecution = runtimeContext.executionContext?.tool;
-    const retrievalToolExecuted =
-        classificationToolExecution?.status === 'executed' &&
-        classificationToolExecution.toolName === 'web_search';
-    const provenanceClassification = classifyProvenanceWithSignals({
-        assistantProvenance: assistantMetadata.provenance,
-        citationCount: citations.length,
-        retrievalRequested: retrieval?.requested ?? false,
-        retrievalUsed: retrieval?.used ?? false,
-        retrievalToolExecuted,
-        workflowEvidence: runtimeContext.workflow !== undefined,
-        trustGraphEvidenceAvailable:
-            runtimeContext.trustGraphEvidenceAvailable ?? false,
-        trustGraphEvidenceUsed: runtimeContext.trustGraphEvidenceUsed ?? false,
-    });
+    const provenanceClassification = resolveProvenanceDecision(
+        assistantMetadata,
+        runtimeContext,
+        citations.length
+    );
     // TODO(provenance-structural-first): Reduce heuristic dependence here by
     // preferring explicit runtime retrieval/tool evidence signals wherever they
     // are available and contract-stable.
@@ -196,21 +73,8 @@ const buildResponseMetadata = (
     // workflow / review steps. If that model is added, keep canonical
     // lifecycle/history state and derive summary fields from it.
     // Current runtime stays summary-only and does not implement lifecycle.
-    const traceTarget =
-        normalizePlannerTemperament(runtimeContext.plannerTemperament) ?? {};
-    const traceFinal =
-        normalizePlannerTemperament(runtimeContext.finalTemperament) ??
-        traceTarget;
-    const traceChanged =
-        JSON.stringify(traceTarget) !== JSON.stringify(traceFinal);
-    const traceFinalReasonCode = traceChanged
-        ? (runtimeContext.temperamentFinalizationReasonCode ??
-          'runtime_posture_adjustment')
-        : undefined;
-    if (
-        traceChanged &&
-        runtimeContext.temperamentFinalizationReasonCode === undefined
-    ) {
+    const tracePosture = resolveTracePostureDecision(runtimeContext);
+    if (tracePosture.defaultedFinalReasonCode) {
         logger.warn(
             'TRACE target/final divergence reason code missing; defaulting to runtime_posture_adjustment.',
             {
@@ -218,33 +82,17 @@ const buildResponseMetadata = (
             }
         );
     }
-    const evidenceScore = isTraceAxisScore(assistantMetadata.evidenceScore)
-        ? assistantMetadata.evidenceScore
-        : undefined;
-    const freshnessScore = isTraceAxisScore(assistantMetadata.freshnessScore)
-        ? assistantMetadata.freshnessScore
-        : undefined;
     // TRACE chips remain posture-facing summaries even when deterministically
     // derived from retrieval-context signals.
-    const shouldDeriveRetrievedChips =
-        provenance === 'Retrieved' &&
-        (evidenceScore === undefined || freshnessScore === undefined);
-    const derivedRetrievedChips = shouldDeriveRetrievedChips
-        ? deriveRetrievedChips({
-              citationCount: citations.length,
-              intent: retrieval?.intent,
-              contextSize: retrieval?.contextSize,
-          })
-        : undefined;
-    const finalEvidenceScore =
-        evidenceScore ?? derivedRetrievedChips?.evidenceScore;
-    const finalFreshnessScore =
-        freshnessScore ?? derivedRetrievedChips?.freshnessScore;
+    const retrievedChipDecision = resolveRetrievedChipDecision({
+        provenance,
+        assistantEvidenceScore: assistantMetadata.evidenceScore,
+        assistantFreshnessScore: assistantMetadata.freshnessScore,
+        citationCount: citations.length,
+        retrieval,
+    });
 
-    if (
-        provenance === 'Retrieved' &&
-        (finalEvidenceScore === undefined || finalFreshnessScore === undefined)
-    ) {
+    if (retrievedChipDecision.missingRetrievedChips) {
         logger.error(
             'Retrieved response metadata is missing required evidence/freshness chips.',
             {
@@ -257,77 +105,8 @@ const buildResponseMetadata = (
 
     const safetyTier: SafetyTier = 'Low';
     const licenseContext = 'MIT + HL3';
-    const execution: ExecutionEvent[] = [];
+    const execution = buildExecutionEvents(runtimeContext.executionContext);
     const evaluatorExecution = runtimeContext.executionContext?.evaluator;
-    if (evaluatorExecution) {
-        // The evaluator already decided this. We are only copying that result
-        // into the response timeline.
-        const normalizedEvaluatorReasonCode = normalizeEvaluatorReasonCode(
-            evaluatorExecution.status,
-            evaluatorExecution.reasonCode
-        );
-        execution.push({
-            kind: 'evaluator',
-            status: evaluatorExecution.status,
-            ...(evaluatorExecution.outcome !== undefined && {
-                evaluator: evaluatorExecution.outcome,
-            }),
-            ...(normalizedEvaluatorReasonCode !== undefined && {
-                reasonCode: normalizedEvaluatorReasonCode,
-            }),
-            ...(evaluatorExecution.durationMs !== undefined && {
-                durationMs: evaluatorExecution.durationMs,
-            }),
-        });
-    }
-    const toolExecution = runtimeContext.executionContext?.tool;
-    if (toolExecution) {
-        // Keep the tool event compact. Readers usually need to know whether it
-        // ran and how it ended, not the full request payload.
-        const normalizedToolReasonCode = normalizeToolReasonCode(
-            toolExecution.status,
-            toolExecution.reasonCode
-        );
-        execution.push({
-            kind: 'tool',
-            status: toolExecution.status,
-            toolName: toolExecution.toolName,
-            ...(normalizedToolReasonCode !== undefined && {
-                reasonCode: normalizedToolReasonCode,
-            }),
-            ...(toolExecution.durationMs !== undefined && {
-                durationMs: toolExecution.durationMs,
-            }),
-        });
-    }
-    const generationExecution = runtimeContext.executionContext?.generation;
-    if (generationExecution) {
-        // The generation event is the real source of model information.
-        // `modelVersion` below only exists for older consumers.
-        const normalizedGenerationReasonCode = normalizeGenerationReasonCode(
-            generationExecution.status,
-            generationExecution.reasonCode
-        );
-        execution.push({
-            kind: 'generation',
-            status: generationExecution.status,
-            profileId: generationExecution.profileId,
-            ...(generationExecution.originalProfileId !== undefined && {
-                originalProfileId: generationExecution.originalProfileId,
-            }),
-            ...(generationExecution.effectiveProfileId !== undefined && {
-                effectiveProfileId: generationExecution.effectiveProfileId,
-            }),
-            provider: generationExecution.provider,
-            model: generationExecution.model,
-            ...(normalizedGenerationReasonCode !== undefined && {
-                reasonCode: normalizedGenerationReasonCode,
-            }),
-            ...(generationExecution.durationMs !== undefined && {
-                durationMs: generationExecution.durationMs,
-            }),
-        });
-    }
     // TODO(workflow-execution-metadata): Extend execution events with lineage
     // (id/parentId), timing (startedAt/finishedAt), and per-step usage/cost
     // once multi-step workflow execution is enabled.
@@ -371,16 +150,16 @@ const buildResponseMetadata = (
         ...(evaluatorExecution?.outcome !== undefined && {
             evaluator: evaluatorExecution.outcome,
         }),
-        trace_target: traceTarget,
-        trace_final: traceFinal,
-        ...(traceFinalReasonCode !== undefined && {
-            trace_final_reason_code: traceFinalReasonCode,
+        trace_target: tracePosture.traceTarget,
+        trace_final: tracePosture.traceFinal,
+        ...(tracePosture.traceFinalReasonCode !== undefined && {
+            trace_final_reason_code: tracePosture.traceFinalReasonCode,
         }),
-        ...(finalEvidenceScore !== undefined && {
-            evidenceScore: finalEvidenceScore,
+        ...(retrievedChipDecision.evidenceScore !== undefined && {
+            evidenceScore: retrievedChipDecision.evidenceScore,
         }),
-        ...(finalFreshnessScore !== undefined && {
-            freshnessScore: finalFreshnessScore,
+        ...(retrievedChipDecision.freshnessScore !== undefined && {
+            freshnessScore: retrievedChipDecision.freshnessScore,
         }),
     };
 };

--- a/packages/backend/src/services/openaiService/metadataDecisions.ts
+++ b/packages/backend/src/services/openaiService/metadataDecisions.ts
@@ -1,0 +1,313 @@
+/**
+ * @description: Pure domain decisions used by backend response metadata
+ * assembly.
+ * @footnote-scope: utility
+ * @footnote-module: OpenAIServiceMetadataDecisions
+ * @footnote-risk: high - Decision drift can misclassify provenance, TRACE chips, or execution records.
+ * @footnote-ethics: high - Metadata decisions shape user-visible transparency and governance records.
+ */
+
+import type {
+    ExecutionEvent,
+    ExecutionReasonCode,
+    ExecutionStatus,
+    EvaluatorExecutionReasonCode,
+    GenerationExecutionReasonCode,
+    PartialResponseTemperament,
+    Provenance,
+    ProvenanceAssessment,
+    ResponseMetadata,
+    ToolInvocationReasonCode,
+    TraceAxisScore,
+} from '@footnote/contracts/policy';
+import {
+    isTraceTemperamentEqual,
+    TRACE_TEMPERAMENT_AXIS_KEYS,
+} from '@footnote/contracts/policy';
+import {
+    classifyProvenanceWithSignals,
+    deriveRetrievedChips,
+} from '../responseMetadataHeuristics.js';
+import type {
+    AssistantResponseMetadata,
+    ResponseMetadataRuntimeContext,
+} from './types.js';
+
+type ExecutionContext = NonNullable<
+    ResponseMetadataRuntimeContext['executionContext']
+>;
+
+type ProvenanceDecision = {
+    provenance: Provenance;
+    assessment: ProvenanceAssessment;
+};
+
+type TracePostureDecision = {
+    traceTarget: PartialResponseTemperament;
+    traceFinal: PartialResponseTemperament;
+    traceChanged: boolean;
+    traceFinalReasonCode?: ResponseMetadata['trace_final_reason_code'];
+    defaultedFinalReasonCode: boolean;
+};
+
+type RetrievedChipDecision = {
+    evidenceScore?: TraceAxisScore;
+    freshnessScore?: TraceAxisScore;
+    missingRetrievedChips: boolean;
+};
+
+export const isTraceAxisScore = (value: unknown): value is TraceAxisScore =>
+    typeof value === 'number' &&
+    Number.isInteger(value) &&
+    value >= 1 &&
+    value <= 5;
+
+export const normalizeResponseTemperament = (
+    temperament: PartialResponseTemperament | undefined
+): PartialResponseTemperament | undefined => {
+    if (!temperament) {
+        return undefined;
+    }
+
+    const normalized: PartialResponseTemperament = {};
+    for (const axis of TRACE_TEMPERAMENT_AXIS_KEYS) {
+        const score = temperament[axis];
+        if (isTraceAxisScore(score)) {
+            normalized[axis] = score;
+        }
+    }
+
+    return Object.keys(normalized).length > 0 ? normalized : undefined;
+};
+
+export const normalizeEvaluatorReasonCode = (
+    status: ExecutionStatus,
+    reasonCode: ExecutionReasonCode | undefined
+): EvaluatorExecutionReasonCode | undefined => {
+    if (status === 'executed' || status === 'skipped') {
+        return undefined;
+    }
+
+    if (reasonCode === 'evaluator_runtime_error') {
+        return reasonCode;
+    }
+
+    return undefined;
+};
+
+export const normalizeGenerationReasonCode = (
+    status: ExecutionStatus,
+    reasonCode: ExecutionReasonCode | undefined
+): GenerationExecutionReasonCode | undefined => {
+    if (status === 'executed' || status === 'skipped') {
+        return undefined;
+    }
+
+    if (
+        reasonCode === 'generation_runtime_error' ||
+        reasonCode === 'routing_chain_exhausted' ||
+        reasonCode === 'routing_chain_non_transient_error'
+    ) {
+        return reasonCode;
+    }
+
+    return undefined;
+};
+
+export const normalizeToolReasonCode = (
+    status: ExecutionStatus,
+    reasonCode: ToolInvocationReasonCode | undefined
+): ToolInvocationReasonCode | undefined => {
+    if (
+        reasonCode === 'tool_not_requested' ||
+        reasonCode === 'tool_not_used' ||
+        reasonCode === 'search_rerouted_to_fallback_profile' ||
+        reasonCode === 'search_reroute_not_permitted_by_selection_source' ||
+        reasonCode === 'search_reroute_no_tool_capable_fallback_available' ||
+        reasonCode === 'tool_unavailable' ||
+        reasonCode === 'tool_execution_error' ||
+        reasonCode === 'tool_timeout' ||
+        reasonCode === 'tool_http_error' ||
+        reasonCode === 'tool_network_error' ||
+        reasonCode === 'tool_invalid_response' ||
+        reasonCode === 'search_not_supported_by_selected_profile' ||
+        reasonCode === 'unspecified_tool_outcome'
+    ) {
+        return reasonCode;
+    }
+
+    if (status === 'executed') {
+        return undefined;
+    }
+
+    return status === 'failed'
+        ? 'tool_execution_error'
+        : 'unspecified_tool_outcome';
+};
+
+export const resolveProvenanceDecision = (
+    assistantMetadata: AssistantResponseMetadata,
+    runtimeContext: ResponseMetadataRuntimeContext,
+    citationCount: number
+): ProvenanceDecision => {
+    const retrieval = runtimeContext.retrieval;
+    const classificationToolExecution = runtimeContext.executionContext?.tool;
+    const retrievalToolExecuted =
+        classificationToolExecution?.status === 'executed' &&
+        classificationToolExecution.toolName === 'web_search';
+
+    return classifyProvenanceWithSignals({
+        assistantProvenance: assistantMetadata.provenance,
+        citationCount,
+        retrievalRequested: retrieval?.requested ?? false,
+        retrievalUsed: retrieval?.used ?? false,
+        retrievalToolExecuted,
+        workflowEvidence: runtimeContext.workflow !== undefined,
+        trustGraphEvidenceAvailable:
+            runtimeContext.trustGraphEvidenceAvailable ?? false,
+        trustGraphEvidenceUsed: runtimeContext.trustGraphEvidenceUsed ?? false,
+    });
+};
+
+export const resolveTracePostureDecision = (
+    runtimeContext: ResponseMetadataRuntimeContext
+): TracePostureDecision => {
+    const traceTarget =
+        normalizeResponseTemperament(runtimeContext.plannerTemperament) ?? {};
+    const traceFinal =
+        normalizeResponseTemperament(runtimeContext.finalTemperament) ??
+        traceTarget;
+    const traceChanged = !isTraceTemperamentEqual(traceTarget, traceFinal);
+    const traceFinalReasonCode = traceChanged
+        ? (runtimeContext.temperamentFinalizationReasonCode ??
+          'runtime_posture_adjustment')
+        : undefined;
+
+    return {
+        traceTarget,
+        traceFinal,
+        traceChanged,
+        ...(traceFinalReasonCode !== undefined && {
+            traceFinalReasonCode,
+        }),
+        defaultedFinalReasonCode:
+            traceChanged &&
+            runtimeContext.temperamentFinalizationReasonCode === undefined,
+    };
+};
+
+export const resolveRetrievedChipDecision = (input: {
+    provenance: Provenance;
+    assistantEvidenceScore: unknown;
+    assistantFreshnessScore: unknown;
+    citationCount: number;
+    retrieval: ResponseMetadataRuntimeContext['retrieval'];
+}): RetrievedChipDecision => {
+    const evidenceScore = isTraceAxisScore(input.assistantEvidenceScore)
+        ? input.assistantEvidenceScore
+        : undefined;
+    const freshnessScore = isTraceAxisScore(input.assistantFreshnessScore)
+        ? input.assistantFreshnessScore
+        : undefined;
+    const shouldDeriveRetrievedChips =
+        input.provenance === 'Retrieved' &&
+        (evidenceScore === undefined || freshnessScore === undefined);
+    const derivedRetrievedChips = shouldDeriveRetrievedChips
+        ? deriveRetrievedChips({
+              citationCount: input.citationCount,
+              intent: input.retrieval?.intent,
+              contextSize: input.retrieval?.contextSize,
+          })
+        : undefined;
+    const finalEvidenceScore =
+        evidenceScore ?? derivedRetrievedChips?.evidenceScore;
+    const finalFreshnessScore =
+        freshnessScore ?? derivedRetrievedChips?.freshnessScore;
+
+    return {
+        ...(finalEvidenceScore !== undefined && {
+            evidenceScore: finalEvidenceScore,
+        }),
+        ...(finalFreshnessScore !== undefined && {
+            freshnessScore: finalFreshnessScore,
+        }),
+        missingRetrievedChips:
+            input.provenance === 'Retrieved' &&
+            (finalEvidenceScore === undefined ||
+                finalFreshnessScore === undefined),
+    };
+};
+
+export const buildExecutionEvents = (
+    executionContext: ExecutionContext | undefined
+): ExecutionEvent[] => {
+    const execution: ExecutionEvent[] = [];
+    const evaluatorExecution = executionContext?.evaluator;
+    if (evaluatorExecution) {
+        const normalizedEvaluatorReasonCode = normalizeEvaluatorReasonCode(
+            evaluatorExecution.status,
+            evaluatorExecution.reasonCode
+        );
+        execution.push({
+            kind: 'evaluator',
+            status: evaluatorExecution.status,
+            ...(evaluatorExecution.outcome !== undefined && {
+                evaluator: evaluatorExecution.outcome,
+            }),
+            ...(normalizedEvaluatorReasonCode !== undefined && {
+                reasonCode: normalizedEvaluatorReasonCode,
+            }),
+            ...(evaluatorExecution.durationMs !== undefined && {
+                durationMs: evaluatorExecution.durationMs,
+            }),
+        });
+    }
+
+    const toolExecution = executionContext?.tool;
+    if (toolExecution) {
+        const normalizedToolReasonCode = normalizeToolReasonCode(
+            toolExecution.status,
+            toolExecution.reasonCode
+        );
+        execution.push({
+            kind: 'tool',
+            status: toolExecution.status,
+            toolName: toolExecution.toolName,
+            ...(normalizedToolReasonCode !== undefined && {
+                reasonCode: normalizedToolReasonCode,
+            }),
+            ...(toolExecution.durationMs !== undefined && {
+                durationMs: toolExecution.durationMs,
+            }),
+        });
+    }
+
+    const generationExecution = executionContext?.generation;
+    if (generationExecution) {
+        const normalizedGenerationReasonCode = normalizeGenerationReasonCode(
+            generationExecution.status,
+            generationExecution.reasonCode
+        );
+        execution.push({
+            kind: 'generation',
+            status: generationExecution.status,
+            profileId: generationExecution.profileId,
+            ...(generationExecution.originalProfileId !== undefined && {
+                originalProfileId: generationExecution.originalProfileId,
+            }),
+            ...(generationExecution.effectiveProfileId !== undefined && {
+                effectiveProfileId: generationExecution.effectiveProfileId,
+            }),
+            provider: generationExecution.provider,
+            model: generationExecution.model,
+            ...(normalizedGenerationReasonCode !== undefined && {
+                reasonCode: normalizedGenerationReasonCode,
+            }),
+            ...(generationExecution.durationMs !== undefined && {
+                durationMs: generationExecution.durationMs,
+            }),
+        });
+    }
+
+    return execution;
+};

--- a/packages/backend/test/openaiService.metadata.test.ts
+++ b/packages/backend/test/openaiService.metadata.test.ts
@@ -7,7 +7,10 @@
  */
 import test from 'node:test';
 import assert from 'node:assert/strict';
-import type { ToolInvocationReasonCode } from '@footnote/contracts/policy';
+import type {
+    ToolInvocationReasonCode,
+    TraceAxisScore,
+} from '@footnote/contracts/policy';
 
 import {
     type AssistantResponseMetadata,
@@ -148,6 +151,26 @@ test('buildResponseMetadata preserves explicit chip values when present', () => 
     assert.equal(metadata.freshnessScore, 2);
 });
 
+test('buildResponseMetadata preserves explicit evidence while deriving missing freshness chip', () => {
+    const metadata = buildResponseMetadata(
+        baseAssistantMetadata({
+            evidenceScore: 5,
+            freshnessScore: undefined,
+        }),
+        baseRuntimeContext({
+            retrieval: {
+                requested: true,
+                used: true,
+                intent: 'current_facts',
+                contextSize: 'low',
+            },
+        })
+    );
+
+    assert.equal(metadata.evidenceScore, 5);
+    assert.equal(metadata.freshnessScore, 4);
+});
+
 test('buildResponseMetadata does not add chips for non-retrieved responses', () => {
     const metadata = buildResponseMetadata(
         baseAssistantMetadata({ provenance: 'Speculative', citations: [] }),
@@ -273,6 +296,29 @@ test('buildResponseMetadata emits canonical trace_target and trace_final fields'
     assert.deepEqual(metadata.trace_final, {
         tightness: 4,
         rationale: 3,
+    });
+    assert.equal(metadata.trace_final_reason_code, undefined);
+});
+
+test('buildResponseMetadata drops invalid TRACE axes before comparing target and final posture', () => {
+    const metadata = buildResponseMetadata(
+        baseAssistantMetadata(),
+        baseRuntimeContext({
+            plannerTemperament: {
+                tightness: 2,
+                rationale: 8 as unknown as TraceAxisScore,
+            },
+            finalTemperament: {
+                tightness: 2,
+            },
+        })
+    );
+
+    assert.deepEqual(metadata.trace_target, {
+        tightness: 2,
+    });
+    assert.deepEqual(metadata.trace_final, {
+        tightness: 2,
     });
     assert.equal(metadata.trace_final_reason_code, undefined);
 });


### PR DESCRIPTION
- Extracted response metadata decision logic into a dedicated backend module for provenance, TRACE posture, retrieved chips, and execution events.
- Normalized TRACE temperament handling so invalid axes are dropped before comparison and posture divergence is computed with a shared equality check.
- Kept retrieved chip derivation and execution reason-code normalization centralized, with tests covering explicit chips, partial chip derivation, and invalid TRACE axes.