### PR TITLE
Render web demo markdown

### DIFF
--- a/packages/web/src/components/AskMeAnything.tsx
+++ b/packages/web/src/components/AskMeAnything.tsx
@@ -8,6 +8,7 @@
 
 import { FormEvent, useEffect, useRef, useState } from 'react';
 import { Turnstile, type TurnstileInstance } from '@marsidev/react-turnstile';
+import MarkdownResponse from './MarkdownResponse';
 import ProvenanceFooter from './ProvenanceFooter';
 import type { ResponseMetadata } from '@footnote/contracts/policy';
 import { landingScenarios } from '../data/landingScenarios.js';
@@ -39,10 +40,8 @@ const AskMeAnything = (): JSX.Element => {
     const [question, setQuestion] = useState('');
     const [status, setStatus] = useState('');
     const [answer, setAnswer] = useState('');
-    const [displayedAnswer, setDisplayedAnswer] = useState('');
     const [metadata, setMetadata] = useState<ResponseMetadata | null>(null);
     const [isLoading, setIsLoading] = useState(false);
-    const [isTypingComplete, setIsTypingComplete] = useState(false);
     const [turnstileToken, setTurnstileToken] = useState<string | null>(null);
     const [turnstileError, setTurnstileError] = useState<string | null>(null);
     const [isTurnstileReady, setIsTurnstileReady] = useState(false);
@@ -91,8 +90,6 @@ const AskMeAnything = (): JSX.Element => {
         setIsLoading(false);
         setAnswer(currentScenario.response.message);
         setMetadata(currentScenario.response.metadata);
-        setIsTypingComplete(false);
-
         if (shouldAutoFocusAskInput('prompt-button')) {
             inputRef.current?.focus();
         }
@@ -346,44 +343,9 @@ const AskMeAnything = (): JSX.Element => {
         notifyEmbedLayoutChanged('question-input-resize');
     }, [question]);
 
-    // Animate the text reveal whenever the answer changes for a gentle typewriter feel.
-    useEffect(() => {
-        if (!answer) {
-            setDisplayedAnswer('');
-            setIsTypingComplete(false);
-            return;
-        }
-
-        setDisplayedAnswer('');
-        setIsTypingComplete(false);
-        const characters = Array.from(answer);
-
-        let index = 0;
-
-        const interval = window.setInterval(() => {
-            const char = characters[index];
-            setDisplayedAnswer((previous) => previous + char);
-            index += 1;
-
-            if (index >= characters.length) {
-                window.clearInterval(interval);
-                setIsTypingComplete(true);
-            }
-        }, 5);
-
-        return () => window.clearInterval(interval);
-    }, [answer]);
-
     useEffect(() => {
         notifyEmbedLayoutChanged('interaction-state-change');
-    }, [
-        displayedAnswer,
-        isLoading,
-        isTypingComplete,
-        metadata,
-        status,
-        turnstileError,
-    ]);
+    }, [answer, isLoading, metadata, status, turnstileError]);
 
     const onSubmit = async (event: FormEvent<HTMLFormElement>) => {
         event.preventDefault();
@@ -471,8 +433,6 @@ const AskMeAnything = (): JSX.Element => {
         setIsLoading(true);
         setAnswer('');
         setMetadata(null);
-        setIsTypingComplete(false);
-
         try {
             const payload = await api.chatQuestion(
                 {
@@ -611,7 +571,6 @@ const AskMeAnything = (): JSX.Element => {
             setStatus('');
             setAnswer(FALLBACK_REFLECTION);
             setMetadata(null);
-            setIsTypingComplete(false);
         } finally {
             clearTimeout(timeoutId); // Ensure timeout is cleared in all cases
             setIsLoading(false);
@@ -778,9 +737,9 @@ const AskMeAnything = (): JSX.Element => {
                 </div>
             )}
             {/* Only show output when there's actual content, not just when loading */}
-            {displayedAnswer && (
+            {answer && (
                 <div className="interaction-output" aria-live="polite">
-                    {displayedAnswer}
+                    <MarkdownResponse markdown={answer} />
                 </div>
             )}
             {/* Render Turnstile widget in Invisible mode - requires manual execute() calls for deterministic timing */}
@@ -832,9 +791,7 @@ const AskMeAnything = (): JSX.Element => {
                     </p>
                 </div>
             )}
-            {isTypingComplete && metadata && (
-                <ProvenanceFooter metadata={metadata} />
-            )}
+            {answer && metadata && <ProvenanceFooter metadata={metadata} />}
         </div>
     );
 };

--- a/packages/web/src/components/MarkdownResponse.tsx
+++ b/packages/web/src/components/MarkdownResponse.tsx
@@ -1,0 +1,22 @@
+/**
+ * @description: Renders agent response markdown for the web demo without allowing raw HTML.
+ * @footnote-scope: web
+ * @footnote-module: MarkdownResponse
+ * @footnote-risk: low - Formatting changes are scoped to response display.
+ * @footnote-ethics: medium - Response rendering affects how transparently users can inspect model output.
+ */
+
+import ReactMarkdown from 'react-markdown';
+import remarkGfm from 'remark-gfm';
+
+type MarkdownResponseProps = {
+    markdown: string;
+};
+
+const MarkdownResponse = ({ markdown }: MarkdownResponseProps): JSX.Element => (
+    <ReactMarkdown remarkPlugins={[remarkGfm]} skipHtml>
+        {markdown}
+    </ReactMarkdown>
+);
+
+export default MarkdownResponse;

--- a/packages/web/src/styles/interaction.css
+++ b/packages/web/src/styles/interaction.css
@@ -216,6 +216,87 @@
     );
 }
 
+.interaction-output > :first-child {
+    margin-top: 0;
+}
+
+.interaction-output > :last-child {
+    margin-bottom: 0;
+}
+
+.interaction-output p,
+.interaction-output ul,
+.interaction-output ol,
+.interaction-output blockquote,
+.interaction-output pre,
+.interaction-output table {
+    margin: 0.55rem 0;
+}
+
+.interaction-output ul,
+.interaction-output ol {
+    padding-left: 1.25rem;
+}
+
+.interaction-output li + li {
+    margin-top: 0.22rem;
+}
+
+.interaction-output strong {
+    color: var(--fn-text-primary);
+    font-weight: 700;
+}
+
+.interaction-output a {
+    color: var(--fn-brand-accent);
+    text-underline-offset: 0.18em;
+}
+
+.interaction-output blockquote {
+    border-left: 2px solid
+        color-mix(in srgb, var(--fn-brand-accent) 45%, transparent 55%);
+    padding-left: 0.75rem;
+    color: var(--fn-text-muted);
+}
+
+.interaction-output code {
+    border-radius: 4px;
+    padding: 0.08rem 0.24rem;
+    background: color-mix(
+        in srgb,
+        var(--fn-surface-bg) 75%,
+        var(--fn-brand-accent-soft) 25%
+    );
+    font-family: var(--fn-font-mono);
+    font-size: 0.9em;
+}
+
+.interaction-output pre {
+    overflow-x: auto;
+    border-radius: 6px;
+    padding: 0.7rem;
+    background: var(--fn-surface-bg);
+}
+
+.interaction-output pre code {
+    padding: 0;
+    background: transparent;
+}
+
+.interaction-output table {
+    width: 100%;
+    border-collapse: collapse;
+    font-size: 0.92rem;
+}
+
+.interaction-output th,
+.interaction-output td {
+    border: 1px solid var(--fn-border-default);
+    padding: 0.35rem 0.45rem;
+    text-align: left;
+    vertical-align: top;
+}
+
 .interaction-captcha {
     min-height: 0;
 }


### PR DESCRIPTION
- Render web demo agent output as markdown with the existing `react-markdown` and `remark-gfm` deps.
- Remove the temporary typewriter reveal so markdown renders cleanly.
- Add compact markdown styling for response output.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Responses now display with richer Markdown formatting, including lists, links, tables, quotes, and code blocks.
  * Added improved styling for response content to make long answers easier to read.

* **Bug Fixes**
  * Removed the typing-style answer reveal so responses appear more consistently and the provenance/footer information shows as soon as the response is available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->